### PR TITLE
Providing dotnet sdk actor doc reference from docs repo

### DIFF
--- a/tutorials/actors/create-.net-actor-application.md
+++ b/tutorials/actors/create-.net-actor-application.md
@@ -1,3 +1,2 @@
-# documentation 
-
-Content for this file to be added
+## Getting started with Actors
+[Reference](https://github.com/dapr/dotnet-sdk/blob/master/docs/get-started-dapr-actor.md)


### PR DESCRIPTION
This change will help reference to discover the gettting started with actors documentation.