### PR TITLE
fix regression by merge mistake

### DIFF
--- a/concepts/README.md
+++ b/concepts/README.md
@@ -28,13 +28,6 @@ This directory contains various Dapr concepts. The goal of these documents is to
 
   Application state is anything an application wants to perserve beyound a single session. Dapr allows pluggable state stores behind a key/value-based state API.
 
-* [Terminology](./terminology/terminology.md)
-* [Bindings](./bindings/Readme.md)
-* [Pub-sub](./publish-subscribe-messaging/Readme.md)
-* [Secrets](./components/secrets.md)
-* [State](./state-management/state-management.md)
-* [Tracing](./tracing-logging/tracing-logging.md)
-
 ## Actors
 
 * [Overview](./actor/actor_overview.md)


### PR DESCRIPTION
This is to fix #94 , which is a regression by merge mistake. We don't have a dedicated terminology page. Instead, the abstracts of the terms are baked into this doc.