### PR TITLE
Add the note for Docker Desktop for windows

### DIFF
--- a/getting-started/environment-setup.md
+++ b/getting-started/environment-setup.md
@@ -13,6 +13,8 @@ Dapr can be run in either Standalone or Kubernetes modes. Running Dapr runtime i
 
 * Install [Docker](https://docs.docker.com/install/)
 
+> For Windows user, ensure that `Docker Desktop For Windows` uses Linux containers.
+
 ## Installing Dapr CLI
 
 ### Using script to install the latest release


### PR DESCRIPTION
# Description

Docker Desktop for Windows supports both Linux and Windows containers modes. When running Dapr via CLI as a standalone mode, dapr cli starts the container to run placement service. container image is built for linux container. therefore, Windows user needs to ensure that they are using Linux containers mode. This PR added the note to environment-setup document.

## Issue reference

#162

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
