### PR TITLE
dapr init only supports default namespace

### DIFF
--- a/getting-started/environment-setup.md
+++ b/getting-started/environment-setup.md
@@ -116,6 +116,9 @@ When setting up Kubernetes you can do this either via the Dapr CLI or Helm
 
 You can install Dapr to Kubernetes cluster using CLI.
 
+> Please note, that using the CLI does not support non-default namespaces.  
+> If you need a non-default namespace, Helm has to be used (see below).
+
 #### Install Dapr to Kubernetes
 
 ```bash


### PR DESCRIPTION
# Description

dapr init does not support non-default K8s namespaces 

## Issue reference

dapr/dapr#657

## Checklist

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [x ] Extended the documentation
