### PR TITLE
Added endpoint details for event triggers.

### DIFF
--- a/howto/send-events-with-output-bindings/README.md
+++ b/howto/send-events-with-output-bindings/README.md
@@ -37,7 +37,7 @@ All that's left now is to invoke the bindings endpoint on a running Dapr instanc
 We can do so using HTTP:
 
 ```
-curl -X POST -H  http://localhost:3500/v1.0/bindings/myEvent -d '{ data: { "message": "Hi!" } }'
+curl -X POST -H  http://localhost:3500/v1.0/bindings/myEvent -d '{ "data": { "message": "Hi!" } }'
 ```
 
 As seen above, we invoked the `/binding` endpoint with the name of the binding to invoke, in our case its `myEvent`.<br>

--- a/howto/trigger-app-with-input-binding/README.md
+++ b/howto/trigger-app-with-input-binding/README.md
@@ -81,3 +81,13 @@ res.status(500).send()
 
 ### Event delivery Guarantees
 Event delivery guarantees are controlled by the binding implementation. Depending on the binding implementation, the event delivery can be exactly once or at least once.
+
+## 3. Triggering the Event 
+
+Now you can trigger the event from within your code using the DAPR bindings endpoint, which is structured like this:
+
+```
+POST http://localhost:[DAPR-port-number]/v1.0/bindings/[event-name]
+```
+
+The [bindings example](https://github.com/dapr/samples/tree/master/5.bindings) demonstrates this process.


### PR DESCRIPTION
# Description

Added a section to the inbound bindings documentation that describes how to trigger an event.

While referencing the example briefly in the head of the inbound bindings documentation, the doc was not explicit about how to actually trigger an event. 

## Issue reference

Issue #85 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [N/A] Code compiles correctly
* [N/A] Created/updated tests
* [X] Extended the documentation
