### PR TITLE
Fixed CURL example JSON data.

### DIFF
--- a/howto/send-events-with-output-bindings/README.md
+++ b/howto/send-events-with-output-bindings/README.md
@@ -37,7 +37,7 @@ All that's left now is to invoke the bindings endpoint on a running Dapr instanc
 We can do so using HTTP:
 
 ```
-curl -X POST -H  http://localhost:3500/v1.0/bindings/myEvent -d '{ data: { "message": "Hi!" } }'
+curl -X POST -H  http://localhost:3500/v1.0/bindings/myEvent -d '{ "data": { "message": "Hi!" } }'
 ```
 
 As seen above, we invoked the `/binding` endpoint with the name of the binding to invoke, in our case its `myEvent`.<br>


### PR DESCRIPTION
# Description

The JSON data in the curl example was not properly formatted so was generating an error when it was copied/pasted.

## Issue reference

No issue to reference as I found it on my own.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [_] Code compiles correctly
* [_] Created/updated tests
* [X] Extended the documentation
