### PR TITLE
add OPTIONS requests for input bindings

### DIFF
--- a/concepts/bindings/README.md
+++ b/concepts/bindings/README.md
@@ -45,6 +45,8 @@ In order to receive events from an input binding:
 1. Define the component YAML that describes the type of binding and its metadata (connection info, etc.)
 2. Listen on an HTTP endpoint for the incoming event, or use the gRPC proto library to get incoming events
 
+> On startup Dapr sends a ```OPTIONS``` request for all defined input bindings to the application and expects a different status code as ```NOT FOUND (404)``` if this application wants to subscribe to the binding.
+
 Read the [How To](../../howto) section to get started with input bindings.
 
 ## Output Bindings

--- a/reference/api/bindings.md
+++ b/reference/api/bindings.md
@@ -21,7 +21,9 @@ spec:
 
 The ```metadata.name``` is the name of the binding. A developer who wants to trigger her app using an input binding can listen on a ```POST``` http endpoint with the route name being the same as ```metadata.name```.
 
-the ```metadata``` section is an open key/value metadata pair that allows a binding to define connection properties, as well as custom properties unique to the implementation.
+On startup Dapr sends a ```OPTIONS``` request to the ```metadata.name``` endpoint and expects a different status code as ```NOT FOUND (404)``` if this application wants to subscribe to the binding.
+
+The ```metadata``` section is an open key/value metadata pair that allows a binding to define connection properties, as well as custom properties unique to the implementation.
 
 For example, here's how a Python application subscribes for events from ```Kafka``` using an Dapr API compliant platform:
 


### PR DESCRIPTION
# Description

Add explanation how Dapr uses a OPTIONS request for determining which application wants to subscribe to a specific input binding.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: dapr/dapr#778

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
