### PR TITLE
Updated error on password placement in setup-redis.md

### DIFF
--- a/howto/setup-pub-sub-message-broker/setup-redis.md
+++ b/howto/setup-pub-sub-message-broker/setup-redis.md
@@ -28,7 +28,7 @@ We can use [Helm](https://helm.sh/) to quickly create a Redis instance in our Ku
 
     Add this password as the `redisPassword` value in your redis.yaml file. For example:
     ```yaml
-        - name: redisHost
+        - name: redisPassword
           value: "lhDOkwTlp0"
     ```
 


### PR DESCRIPTION
# Description

Corrected typo in documentation stating password should be placed in redisHost when it should be placed in redisPassword


