### PR TITLE
Use checkmarks to show bindings support

### DIFF
--- a/concepts/bindings/README.md
+++ b/concepts/bindings/README.md
@@ -10,7 +10,7 @@ Bindings allow for on-demand, event-driven compute scenarios, and dapr bindings 
 * Switch between bindings at runtime time
 * Enable portable applications where environment-specific bindings are set-up and no code changes are required
 
-Bindings are developed independently of Dapr runtime. You can view and contribute to the bindings [here](https://github.com/dapr/components-contrib/tree/master/bindings). 
+Bindings are developed independently of Dapr runtime. You can view and contribute to the bindings [here](https://github.com/dapr/components-contrib/tree/master/bindings).
 
 ## Supported Bindings and Specs
 
@@ -18,22 +18,22 @@ Every binding has its own unique set of properties. Click the name link to see t
 
 | Name  | Input Binding | Output Binding | Status
 | ------------- | -------------- | -------------  | ------------- |
-| [Kafka](./specs/kafka.md) | V | V | Experimental |
-| [RabbitMQ](./specs/rabbitmq.md) | V  | V | Experimental |
-| [AWS SQS](./specs/sqs.md) | V | V | Experimental |
-| [AWS SNS](./specs/sns.md) |  | V | Experimental |
-| [Azure EventHubs](./specs/eventhubs.md) | V | V | Experimental |
-| [Azure CosmosDB](./specs/cosmosdb.md) | | V | Experimental |
-| [GCP Storage Bucket](./specs/gcpbucket.md)  | | V | Experimental |
-| [HTTP](./specs/http.md) |  | V | Experimental |
-| [MQTT](./specs/mqtt.md) | V | V | Experimental |
-| [Redis](./specs/redis.md) |  | V | Experimental |
-| [AWS DynamoDB](./specs/dynamodb.md) | | V | Experimental |
-| [AWS S3](./specs/s3.md) | | V | Experimental |
-| [Azure Blob Storage](./specs/blobstorage.md) | | V | Experimental |
-| [Azure Service Bus Queues](./specs/servicebusqueues.md) | V | V | Experimental |
-| [GCP Cloud Pub/Sub](./specs/gcppubsub.md) | V | V | Experimental |
-| [Kubernetes Events](./specs/kubernetes.md) | V |  | Experimental |
+| [Kafka](./specs/kafka.md) | ✅ | ✅ | Experimental |
+| [RabbitMQ](./specs/rabbitmq.md) | ✅  | ✅ | Experimental |
+| [AWS SQS](./specs/sqs.md) | ✅ | ✅ | Experimental |
+| [AWS SNS](./specs/sns.md) |  | ✅ | Experimental |
+| [Azure EventHubs](./specs/eventhubs.md) | ✅ | ✅ | Experimental |
+| [Azure CosmosDB](./specs/cosmosdb.md) | | ✅ | Experimental |
+| [GCP Storage Bucket](./specs/gcpbucket.md)  | | ✅ | Experimental |
+| [HTTP](./specs/http.md) |  | ✅ | Experimental |
+| [MQTT](./specs/mqtt.md) | ✅ | ✅ | Experimental |
+| [Redis](./specs/redis.md) |  | ✅ | Experimental |
+| [AWS DynamoDB](./specs/dynamodb.md) | | ✅ | Experimental |
+| [AWS S3](./specs/s3.md) | | ✅ | Experimental |
+| [Azure Blob Storage](./specs/blobstorage.md) | | ✅ | Experimental |
+| [Azure Service Bus Queues](./specs/servicebusqueues.md) | ✅ | ✅ | Experimental |
+| [GCP Cloud Pub/Sub](./specs/gcppubsub.md) | ✅ | ✅ | Experimental |
+| [Kubernetes Events](./specs/kubernetes.md) | ✅ |  | Experimental |
 
 ## Input Bindings
 


### PR DESCRIPTION
# Description

It took me a while to understand what `V` stands for in supported bindings table. I thought using checkmarks makes more sense

Feel free to ignore PR for any other reason
