### PR TITLE
updated to reflect helm 3 syntax

### DIFF
--- a/howto/setup-state-store/setup-redis.md
+++ b/howto/setup-state-store/setup-redis.md
@@ -8,7 +8,7 @@ Dapr can use any Redis instance - containerized, running on your local dev machi
 
 We can use [Helm](https://helm.sh/) to quickly create a Redis instance in our Kubernetes cluster. This approach requires [Installing Helm](https://github.com/helm/helm#install).
 
-1. Install Redis into your cluster: `helm install stable/redis --name redis --set image.tag=5.0.5-debian-9-r104`. Note that we're explicitly setting an image tag to get a version greater than 5, which is what Dapr' pub/sub functionality requires. If you're intending on using Redis as just a state store (and not for pub/sub), you do not have to set the image version.
+1. Install Redis into your cluster: `helm install redis stable/redis`. Note that we're explicitly setting an image tag to get a version greater than 5, which is what Dapr' pub/sub functionality requires. If you're intending on using Redis as just a state store (and not for pub/sub), you do not have to set the image version.
 2. Run `kubectl get pods` to see the Redis containers now running in your cluster.
 3. Add `redis-master:6379` as the `redisHost` in your [redis.yaml](#configuration) file. For example:
     ```yaml


### PR DESCRIPTION
- Removed name flag 
- Removed Redis version (now that default version is >5 and therefore supports Redis Streams)
