### PR TITLE
Fix incorrect dapr oauth2 middleware config

### DIFF
--- a/howto/authorization-with-oauth/README.md
+++ b/howto/authorization-with-oauth/README.md
@@ -71,7 +71,8 @@ metadata:
 spec:
   httpPipeline:
     handlers:
-    - name: middleware.http.oauth2
+    - name: oauth2
+      type: middleware.http.oauth2
 ```
 
 ## Apply the configuration


### PR DESCRIPTION
# Description
Added a type property to the `pipeline.handlers` in the sample dapr config as expected by the runtime.

## Issue reference

Please reference the issue this PR will close: #296

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
