### PR TITLE
Fix broken install KEDA link

### DIFF
--- a/howto/autoscale-with-keda/README.md
+++ b/howto/autoscale-with-keda/README.md
@@ -7,7 +7,7 @@ For apps that use these bindings, it is easy to configure a KEDA autoscaler.
 
 ## Install KEDA
 
-To install KEDA, follow [these instructions](https://github.com/dapr/docs/tree/master/concepts/bindings#supported-bindings-and-specs) on the KEDA Github page.
+To install KEDA, follow the [Deploying KEDA](https://keda.sh/deploy/) instructions on the KEDA website.
 
 ## Create KEDA enabled Dapr binding
 


### PR DESCRIPTION
# Description

Fix broken install KEDA link, points now to https://keda.sh/deploy/

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
