### PR TITLE
Add SqlServer as another actor state store

### DIFF
--- a/concepts/actor/actors_features.md
+++ b/concepts/actor/actors_features.md
@@ -12,6 +12,7 @@ To use actors, your state store must support multi-item transactions.  This mean
 
 - Redis
 - MongoDB
+- SQL Server
 
 ### Save the Actor State
 


### PR DESCRIPTION
# Description

As SQL Server also supports the TransactionalStore interface it can also be used as an actor state store.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
