### PR TITLE
Remove broadcast in pub/sub

### DIFF
--- a/reference/api/pubsub.md
+++ b/reference/api/pubsub.md
@@ -1,4 +1,4 @@
-# Pub Sub and Broadcast
+# Pub Sub
 
 ## Publish a message to a given topic
 
@@ -31,81 +31,6 @@ curl -X POST http://localhost:3500/v1.0/publish/deathStarStatus \
  -d '{
        "status": "completed"
      }'
-```
-
-## Broadcast a message to a list of recipients
-
-This endpoint lets you publish a payload to a named list recipients  who are listening on a given ```topic```.
-The list of recipients may include the unique identifiers of other apps (used by Dapr for messaging) and also Dapr bindings.
-
-### HTTP Request
-
-```http
-POST http://localhost:<daprPort>/v1.0/publish/<topic>
-```
-
-### HTTP Response codes
-
-Code | Description
----- | -----------
-200  | Message delivered
-500  | Delivery failed
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-daprPort | the Dapr port
-topic | the name of the topic
-
-> Example of publishing a message to another Dapr app:
-
-```shell
-curl -X POST http://localhost:3500/v1.0/publish \
-  -H "Content-Type: application/json" \
-  -d '{
-        "topic": "DeathStarStatus",
-        "data": {
-          "status": "completed"
-        },
-        "to": [
-          "otherApp"
-        ]
-      }'
-```
-
-> Example of publishing a message to an Dapr binding:
-
-```shell
-curl -X POST http://localhost:3500/v1.0/publish \
-  -H "Content-Type: application/json" \
-  -d '{
-        "topic": "DeathStarStatus",
-        "data": {
-          "status": "completed"
-        },
-        "to": [
-          "azure-queues"
-        ]
-      }'
-```
-
-> Example of publishing a message to multiple consumers in parallel:
-
-```shell
-curl -X POST http://localhost:3500/v1.0/publish \
-  -H "Content-Type: application/json" \
-  -d '{
-        "eventName": "DeathStarStatus",
-        "data": {
-          "status": "completed"
-        },
-        "to": [
-          "otherApp",
-          "azure-queues"
-        ],
-        "concurrency": "parallel"
-      }'
 ```
 
 ## Handling topic subscriptions


### PR DESCRIPTION
This PR removes an API endpoint that does not exist anymore in Dapr.
Closes https://github.com/dapr/docs/issues/375.

The actual API endpoints that are used in Dapr samples/how-to/code for pub/sub are correct.