### PR TITLE
Remove "Deliver events to subscribers"

### DIFF
--- a/reference/api/pubsub.md
+++ b/reference/api/pubsub.md
@@ -58,29 +58,3 @@ Example:
 ```json
 "["TopicA","TopicB"]"
 ```
-
-## Delivering events to subscribers
-
-In order to deliver events to a subscribed application, a `POST` call should be made to user code with the name of the topic as the URL path.
-
-The following example illustrates this point, considering a subscription for topic `TopicA`:
-
-### HTTP Request
-
-```http
-POST http://localhost:<appPort>/TopicA
-```
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-appPort | the application port
-
-### HTTP Response body
-
-A JSON encoded payload.
-
-## Message Envelope
-
-Dapr Pub/Sub adheres to version 0.3 of Cloud Events.


### PR DESCRIPTION
This is no longer valid. The dapr APIs don't support this route.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
