### PR TITLE
Update binding api docs - Invalid JSON

### DIFF
--- a/reference/api/bindings.md
+++ b/reference/api/bindings.md
@@ -84,9 +84,9 @@ The bindings endpoint receives the following JSON payload:
 ```json
 {
   "data": "",
-  "metadata": [
+  "metadata": {
     "": ""
-  ]
+  }
 }
 ```
 
@@ -107,8 +107,8 @@ curl -X POST http://localhost:3500/v1.0/bindings/myKafka \
         "data": {
           "message": "Hi"
         },
-        "metadata": [
+        "metadata": {
           "key": "redis-key-1"
-        ]
+        }
       }'
 ```


### PR DESCRIPTION
The binding docs api defined metadata payload is invalid json.

# Description

The docs suggest using an invalid json payload.

![image](https://user-images.githubusercontent.com/16475649/75975767-698d3f00-5ed9-11ea-9d75-657d551eaba1.png)


To work with the bindings WriteRequest we should use an object not an array:

```go
type WriteRequest struct {
	Data     []byte            `json:"data"`
	Metadata map[string]string `json:"metadata"`
}

```

Should be:

```json
{
  "data": "",
  "metadata": {
    "": ""
  }
}
```