### PR TITLE
Fix link to pub/sub API spec

### DIFF
--- a/concepts/publish-subscribe-messaging/README.md
+++ b/concepts/publish-subscribe-messaging/README.md
@@ -9,7 +9,7 @@ These implementations are pluggable, and developed outside of the Dapr runtime i
 
 ## Publish/Subscribe API
 
-The API for Publish/Subscribe can be found in the [spec repo](../../reference/api/pubsub.md).
+The API for Publish/Subscribe can be found in the [spec repo](../../reference/api/pubsub_api.md).
 
 ## Behavior and guarantees
 


### PR DESCRIPTION
# Description

Fixed a broken link in the pub/sub documentation

## Issue reference

Didn't think this was worth opening an issue. Happy to do so if the maintainer's insist.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] ~~Code compiles correctly~~ (n/a)
* [x] ~~Created/updated tests~~ (n/a)
* [x] Extended the documentation
