### PR TITLE
Link to instructions for adding helm stable repo

### DIFF
--- a/howto/configure-redis/README.md
+++ b/howto/configure-redis/README.md
@@ -19,7 +19,7 @@ We can use [Helm](https://helm.sh/) to quickly create a Redis instance in our Ku
 helm install redis stable/redis
 ```
 
-> This chart comes from the `stable` repository, which is no longer included by default as of Helm v3. You may need to add the stable repo if this is your first time using Helm - documented [here](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository)
+> This chart comes from the `stable` repository, which is no longer included by default as of Helm v3. You may need to add the stable repo if this is your first time using Helm - documented [here](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository).
 
 > Note that you need a Redis version greater than 5, which is what Dapr' pub/sub functionality requires. If you're intending on using Redis as just a state store (and not for pub/sub), also a lower version can be used.
 

--- a/howto/configure-redis/README.md
+++ b/howto/configure-redis/README.md
@@ -19,6 +19,8 @@ We can use [Helm](https://helm.sh/) to quickly create a Redis instance in our Ku
 helm install redis stable/redis
 ```
 
+> This chart comes from the `stable` repository, which is no longer included by default as of Helm v3. You may need to add the stable repo if this is your first time using Helm - documented [here](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository)
+
 > Note that you need a Redis version greater than 5, which is what Dapr' pub/sub functionality requires. If you're intending on using Redis as just a state store (and not for pub/sub), also a lower version can be used.
 
 2. Run `kubectl get pods` to see the Redis containers now running in your cluster.


### PR DESCRIPTION
This isn't included by default anymore in v3.

# Description

Added a link to the helm docs for adding the stable repo (which the instructions use)

## Issue reference

This is a docs update, I can create an issue first if y'all really want :0

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

~~* [ ] Code compiles correctly~~ N/A
~~* [ ] Created/updated tests~~ N/A
* [x] Extended the documentation
