### PR TITLE
consumerGroup must be the same in both manifests and fixed ScaledObject

### DIFF
--- a/howto/autoscale-with-keda/README.md
+++ b/howto/autoscale-with-keda/README.md
@@ -70,8 +70,8 @@ spec:
       direction: in
       name: event
       topic: myTopic
-      brokers:  my-kafka:9092
-      consumerGroup: group2
+      bootstrapServers:  my-kafka:9092
+      consumerGroup: group1
       dataType: binary
       lagThreshold: '5'
 ```


### PR DESCRIPTION
# Description

Fixed doc:

- In order for the integration with _KEDA_ to work, the consumer group must be the same as the one defined in the component.
- Also the brokers field is no longer valid and the correct parameter is _bootstrapServers_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
