### PR TITLE
Include instructions to enable or disable TLS

### DIFF
--- a/howto/setup-pub-sub-message-broker/setup-redis.md
+++ b/howto/setup-pub-sub-message-broker/setup-redis.md
@@ -44,7 +44,7 @@ We can use [Helm](https://helm.sh/) to quickly create a Redis instance in our Ku
 
 To setup Redis, you need to create a component for `pubsub.redis`.
 
-The following yaml files demonstrates how to define each. **Note:** yaml files below illustrate secret management in plain text. In a production-grade application, follow [secret management](../../concepts/secrets/README.md) instructions to securely manage your secrets.
+The following yaml files demonstrates how to define each. If the Redis instance supports TLS with public certificates it can be configured to enable or disable TLS in the yaml. **Note:** yaml files below illustrate secret management in plain text. In a production-grade application, follow [secret management](../../concepts/secrets/README.md) instructions to securely manage your secrets.
 
 ### Configuring Redis Streams for Pub/Sub
 
@@ -62,6 +62,8 @@ spec:
     value: <HOST>
   - name: redisPassword
     value: <PASSWORD>
+  - name: enableTLS
+    value: <bool>
 ```
 
 ## Apply the configuration

--- a/howto/setup-state-store/setup-redis.md
+++ b/howto/setup-state-store/setup-redis.md
@@ -51,7 +51,7 @@ We can use [Helm](https://helm.sh/) to quickly create a Redis instance in our Ku
 
 To setup Redis, you need to create a component for `state.redis`. 
 <br>
-The following yaml files demonstrates how to define each. **Note:** yaml files below illustrate secret management in plain text. In a production-grade application, follow [secret management](../../concepts/secrets/README.md) instructions to securely manage your secrets.
+The following yaml files demonstrates how to define each. If the Redis instance supports TLS with public certificates it can be configured to enable or disable TLS in the yaml. **Note:** yaml files below illustrate secret management in plain text. In a production-grade application, follow [secret management](../../concepts/secrets/README.md) instructions to securely manage your secrets.
 
 ### Configuring Redis for State Persistence and Retrieval
 
@@ -69,6 +69,8 @@ spec:
     value: <HOST>
   - name: redisPassword
     value: <PASSWORD>
+  - name: enableTLS
+    value: <bool>
 ```
 
 ## Apply the configuration


### PR DESCRIPTION
# Description

Updated Setup Redis doc to have instructions of how to enable or disable TLS for state.redis and pubsub.redis components

## Issue reference

Please reference the issue this PR will close: [490](https://github.com/dapr/docs/issues/490)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
