### PR TITLE
Fix broken link to pubsub section

### DIFF
--- a/howto/README.md
+++ b/howto/README.md
@@ -5,7 +5,7 @@ Here you'll find a list of How To guides that walk you through accomplishing spe
 ## Contents
 - [Service invocation](#service-invocation)
 - [State Management](#state-management)
-- [Pub/Sub](#Pub/Sub)
+- [Pub/Sub](#pubsub)
 - [Bindings and Triggers](#bindings-and-triggers)
 - [Actors](#actors)
 - [Observerability](#observerability)


### PR DESCRIPTION
# Description

Fixed broken link to pubsub section [here](https://github.com/dapr/docs/tree/v0.6.0/howto#contents)

## Issue reference

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
