### PR TITLE
Add quotes to the connectionString

### DIFF
--- a/reference/specs/bindings/servicebusqueues.md
+++ b/reference/specs/bindings/servicebusqueues.md
@@ -9,7 +9,7 @@ spec:
   type: bindings.azure.servicebusqueues
   metadata:
   - name: connectionString
-    value: sb://************
+    value: "sb://************"
   - name: queueName
     value: queue1
 ```


### PR DESCRIPTION
Adding quotes to the connectionString for Service Bus to work

# Description

Add quotes to the connectionString for Service Bus

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
