### PR TITLE
Add kubernetes configuration how-to

### DIFF
--- a/getting-started/environment-setup.md
+++ b/getting-started/environment-setup.md
@@ -207,7 +207,7 @@ dapr-sentry-9435776c7f-8f7yd             1/1       Running   0          40s
 
 #### Sidecar annotations
 
-To see all the supported annotations for the Dapr sidecar on Kubernetes, visit [this](../howto/configure-annotations/README.md) how to guide.
+To see all the supported annotations for the Dapr sidecar on Kubernetes, visit [this](../howto/configure-k8s/README.md) how to guide.
 
 #### Uninstall Dapr on Kubernetes
 

--- a/getting-started/environment-setup.md
+++ b/getting-started/environment-setup.md
@@ -205,6 +205,10 @@ dapr-sidecar-injector-8555576b6f-29cqm   1/1       Running   0          40s
 dapr-sentry-9435776c7f-8f7yd             1/1       Running   0          40s
 ```
 
+#### Sidecar annotations
+
+To see all the supported annotations for the Dapr sidecar on Kubernetes, visit [this](../howto/configure-annotations/README.md) how to guide.
+
 #### Uninstall Dapr on Kubernetes
 
 Helm 3

--- a/howto/README.md
+++ b/howto/README.md
@@ -11,9 +11,8 @@ Here you'll find a list of How To guides that walk you through accomplishing spe
 - [Observerability](#observerability)
 - [Security](#security)
 - [Components](#components)
-- [Kubernetes Configuration](#kubernetes-configuration)
+- [Hosting Platforms](#hosting-platforms)
 - [Developer tooling](#developer-tooling)
-- [Infrastructure integration](#Infrastructure-integration)
 
 ## Service invocation
 
@@ -77,9 +76,11 @@ For Actors How Tos see the SDK documentation
 
 * [Limit components for one or more applications using scopes](./components-scopes)
 
-## Kubernetes Configuration
+## Hosting Platforms
+### Kubernetes Configuration
 
 * [Sidecar configuration on Kubernetes](./configure-k8s)
+* [Autoscale on Kubernetes using KEDA and Dapr bindings](./autoscale-with-keda)
 
 ## Developer tooling
 ### Using Visual Studio Code
@@ -96,7 +97,3 @@ For Actors How Tos see the SDK documentation
 ### SDKs
 
 * [Serialization in Dapr's SDKs](./serialize)
-
-## Infrastructure integration
-
-* [Autoscale on Kubernetes using KEDA and Dapr bindings](./autoscale-with-keda)

--- a/howto/README.md
+++ b/howto/README.md
@@ -11,6 +11,7 @@ Here you'll find a list of How To guides that walk you through accomplishing spe
 - [Observerability](#observerability)
 - [Security](#security)
 - [Components](#components)
+- [Kubernetes Configuration](#kubernetes-configuration)
 - [Developer tooling](#developer-tooling)
 - [Infrastructure integration](#Infrastructure-integration)
 
@@ -31,7 +32,6 @@ Here you'll find a list of How To guides that walk you through accomplishing spe
 * [Create a stateful, replicated service with different consistency/concurrency levels](./stateful-replicated-service)
 * [Control your app's throttling using rate limiting features](./control-concurrency)
 * [Configuring Redis for state management ](./configure-redis)
-
 
 ## Pub/Sub
 
@@ -76,6 +76,10 @@ For Actors How Tos see the SDK documentation
 ## Components
 
 * [Limit components for one or more applications using scopes](./components-scopes)
+
+## Kubernetes Configuration
+
+* [Sidecar configuration on Kubernetes](./configure-k8s)
 
 ## Developer tooling
 ### Using Visual Studio Code

--- a/howto/configure-k8s/README.md
+++ b/howto/configure-k8s/README.md
@@ -1,0 +1,23 @@
+# Configuring the Dapr sidecar on Kubernetes
+
+On Kubernetes, Dapr uses a sidecar injector pod that automatically injects the Dapr sidecar container to a Pod that has the correct annotations.
+The sidecar injector is an implementation of a Kubernetes [Admission Conroller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). 
+
+The following table shows all the supported Pod Spec annotations supported by Dapr.
+
+| Annotation          | Description 
+| ----------------------------------- | -------------- |
+| `dapr.io/enabled`   | Setting this paramater to `true` will have Dapr auto-inject the sidecar container to the Pod
+| `dapr.io/port`   | This parameter tells Dapr which port your application is listening on
+| `dapr.io/id`   | The unique ID of the application. Used for service discovery, state encapsulation and the pub/sub consumer ID
+| `dapr.io/log-level`   | Sets the log level for the Dapr sidecar. Allowed values are `debug`, `info`, `warn`, `error`. Default is `info`
+| `dapr.io/config`   | Tells Dapr which Configuration CRD to use
+| `dapr.io/log-as-json`   | Setting this parameter to `true` will output logs in JSON format. Default is text
+| `dapr.io/profiling`   | Setting this paramater to `true` will start the Dapr profiling server on port `7777`
+| `dapr.io/protocol`   | Tells Dapr which protocol your application is using. Valid options are `http` and `grpc`. Default is `http`
+| `dapr.io/max-concurrency`   | Limit the concurrency of your application. A valid value is any number larger than `0`
+| `dapr.io/metrics-port`   | Sets the port for the sidecar metrics server. Default is `9090`
+| `dapr.io/sidecar-cpu-limit`   | Maximum amount of CPU that the Dapr sidecar can use
+| `dapr.io/sidecar-memory-limit`   | Maximum amount of Memory that the Dapr sidecar can use
+| `dapr.io/sidecar-cpu-request`   | Amount of CPU that the Dapr sidecar requests
+| `dapr.io/sidecar-memory-request`   | Amount of Memory that the Dapr sidecar requests

--- a/howto/configure-k8s/README.md
+++ b/howto/configure-k8s/README.md
@@ -1,23 +1,23 @@
 # Configuring the Dapr sidecar on Kubernetes
 
-On Kubernetes, Dapr uses a sidecar injector pod that automatically injects the Dapr sidecar container to a Pod that has the correct annotations.
-The sidecar injector is an implementation of a Kubernetes [Admission Conroller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). 
+On Kubernetes, Dapr uses a sidecar injector pod that automatically injects the Dapr sidecar container into a pod that has the correct annotations.
+The sidecar injector is an implementation of a Kubernetes [Admission Controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). 
 
-The following table shows all the supported Pod Spec annotations supported by Dapr.
+The following table shows all the supported pod Spec annotations supported by Dapr.
 
 | Annotation          | Description 
 | ----------------------------------- | -------------- |
-| `dapr.io/enabled`   | Setting this paramater to `true` will have Dapr auto-inject the sidecar container to the Pod
+| `dapr.io/enabled`   | Setting this paramater to `true` injects the Dapr sidecar into the pod
 | `dapr.io/port`   | This parameter tells Dapr which port your application is listening on
 | `dapr.io/id`   | The unique ID of the application. Used for service discovery, state encapsulation and the pub/sub consumer ID
 | `dapr.io/log-level`   | Sets the log level for the Dapr sidecar. Allowed values are `debug`, `info`, `warn`, `error`. Default is `info`
 | `dapr.io/config`   | Tells Dapr which Configuration CRD to use
-| `dapr.io/log-as-json`   | Setting this parameter to `true` will output logs in JSON format. Default is text
-| `dapr.io/profiling`   | Setting this paramater to `true` will start the Dapr profiling server on port `7777`
+| `dapr.io/log-as-json`   | Setting this parameter to `true` outputs logs in JSON format. Default is `false`
+| `dapr.io/profiling`   | Setting this paramater to `true` starts the Dapr profiling server on port `7777`. Default is `false`
 | `dapr.io/protocol`   | Tells Dapr which protocol your application is using. Valid options are `http` and `grpc`. Default is `http`
 | `dapr.io/max-concurrency`   | Limit the concurrency of your application. A valid value is any number larger than `0`
 | `dapr.io/metrics-port`   | Sets the port for the sidecar metrics server. Default is `9090`
-| `dapr.io/sidecar-cpu-limit`   | Maximum amount of CPU that the Dapr sidecar can use
-| `dapr.io/sidecar-memory-limit`   | Maximum amount of Memory that the Dapr sidecar can use
-| `dapr.io/sidecar-cpu-request`   | Amount of CPU that the Dapr sidecar requests
-| `dapr.io/sidecar-memory-request`   | Amount of Memory that the Dapr sidecar requests
+| `dapr.io/sidecar-cpu-limit`   | Maximum amount of CPU that the Dapr sidecar can use. See valid values [here](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/). By default this is not set
+| `dapr.io/sidecar-memory-limit`   | Maximum amount of Memory that the Dapr sidecar can use. See valid values [here](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/). By default this is not set
+| `dapr.io/sidecar-cpu-request`   | Amount of CPU that the Dapr sidecar requests. See valid values [here](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/). By default this is not set
+| `dapr.io/sidecar-memory-request`   | Amount of Memory that the Dapr sidecar requests .See valid values [here](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/). By default this is not set


### PR DESCRIPTION
Today, users have no place they can look to see the supported sidecar configuration on Kubernetes.
The list of supported Dapr annotations are scattered in different places, and some of them are not even documented anywhere.

This PR adds a clear How To guide for configuring the Sidecar on Kubernetes with all the available annotations, their description and default values.

Closes #521 