### PR TITLE
PubSub config changed to pubsub.yaml

### DIFF
--- a/howto/setup-pub-sub-message-broker/setup-azure-servicebus.md
+++ b/howto/setup-pub-sub-message-broker/setup-azure-servicebus.md
@@ -47,4 +47,4 @@ kubectl apply -f azuresb.yaml
 ### Running locally
 
 The Dapr CLI will automatically create a directory named `components` in your current working directory with a Redis component.
-To use Azure Service Bus, replace the contents of `messagebus.yaml` file with the contents of `azuresb.yaml` above (Don't change the filename).
+To use Azure Service Bus, replace the contents of `pubsub.yaml` (or `messagebus.yaml` for Dapr < 0.6.0) file with the contents of `azuresb.yaml` above (Don't change the filename).

--- a/howto/setup-pub-sub-message-broker/setup-gcp.md
+++ b/howto/setup-pub-sub-message-broker/setup-gcp.md
@@ -69,4 +69,4 @@ kubectl apply -f messagebus.yaml
 
 ### Running locally
 
-The Dapr CLI will automatically create a directory named `components` in your current working directory. To use Cloud Pubsub, replace the contents of `messagebus.yaml` file with the contents of yaml above.
+The Dapr CLI will automatically create a directory named `components` in your current working directory. To use Cloud Pubsub, replace the contents of `pubsub.yaml` (or `messagebus.yaml` for Dapr < 0.6.0) file with the contents of yaml above.

--- a/howto/setup-pub-sub-message-broker/setup-hazelcast.md
+++ b/howto/setup-pub-sub-message-broker/setup-hazelcast.md
@@ -48,4 +48,4 @@ kubectl apply -f hazelcast.yaml
 ### Running locally
 
 The Dapr CLI will automatically create a directory named `components` in your current working directory with a Redis component.
-To use Hazelcast, replace the redis.yaml file with the hazelcast.yaml above.
+To use Hazelcast, replace the `pubsub.yaml` (or `messagebus.yaml` for Dapr < 0.6.0) file with the hazelcast.yaml above.

--- a/howto/setup-pub-sub-message-broker/setup-nats.md
+++ b/howto/setup-pub-sub-message-broker/setup-nats.md
@@ -58,4 +58,4 @@ kubectl apply -f nats.yaml
 ### Running locally
 
 The Dapr CLI will automatically create a directory named `components` in your current working directory with a Redis component.
-To use NATS, replace the contents of `messagebus.yaml` file with the contents of `nats.yaml` above (Don't change the filename).
+To use NATS, replace the contents of `pubsub.yaml` (or `messagebus.yaml` for Dapr < 0.6.0) file with the contents of `nats.yaml` above (Don't change the filename).

--- a/howto/setup-pub-sub-message-broker/setup-rabbitmq.md
+++ b/howto/setup-pub-sub-message-broker/setup-rabbitmq.md
@@ -72,4 +72,4 @@ kubectl apply -f rabbitmq.yaml
 ### Running locally
 
 The Dapr CLI will automatically create a directory named `components` in your current working directory with a Redis component.
-To use RabbitMQ, replace the contents of `messagebus.yaml` file with the contents of `rabbitmq.yaml` above (Don't change the filename).
+To use RabbitMQ, replace the contents of `pubsub.yaml` (or `messagebus.yaml` for Dapr < 0.6.0) file with the contents of `rabbitmq.yaml` above (Don't change the filename).


### PR DESCRIPTION
# Description

Updated CLI docs to reflect the configuration file being renamed from `messagebus.yaml` to `pubsub.yaml`

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #505 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
