### PR TITLE
Wrap value in doublequotes for ttlInSeconds value.

### DIFF
--- a/reference/specs/bindings/storagequeues.md
+++ b/reference/specs/bindings/storagequeues.md
@@ -15,7 +15,7 @@ spec:
   - name: queue
     value: "myqueue"
   - name: ttlInSeconds
-    value: 60
+    value: "60"
 ```
 
 - `storageAccount` is the Azure Storage account name.


### PR DESCRIPTION
# Description

ttlInSeconds parameter needs to be doublequoted or you get a very, very arcane error message complaining about an error from the ReadString method requires \" or n which took me quite a long time to figure out.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #529 

https://github.com/dapr/docs/issues/529

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

[X] Extended the documentation
