### PR TITLE
Update bindings.redis spec to have enableTLS option

### DIFF
--- a/reference/specs/bindings/redis.md
+++ b/reference/specs/bindings/redis.md
@@ -12,9 +12,12 @@ spec:
     value: <address>:6379
   - name: redisPassword
     value: **************
+  - name: enableTLS
+    value: <bool>
 ```
 
 - `redisHost` is the Redis host address.
 - `redisPassword` is the Redis password.
+- `enableTLS` - If the Redis instance supports TLS with public certificates it can be configured to enable or disable TLS.
 
 > **Note:** In production never place passwords or secrets within Dapr components. For information on securely storing and retrieving secrets refer to [Setup Secret Store](../../../howto/setup-secret-store)


### PR DESCRIPTION
# Description

Now that we support TLS with redis binding component, updated the spec to show this option.

## Issue reference

Please reference the issue this PR will close: #510 
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
