### PR TITLE
updated blobstorage docs

### DIFF
--- a/reference/specs/bindings/blobstorage.md
+++ b/reference/specs/bindings/blobstorage.md
@@ -30,9 +30,7 @@ By default the Azure Blob Storage output binding will auto generate a UUID as bl
 Applications publishing to an Azure Blob Storage output binding should send a message with the following contract:
 ```json
 {
-    "data": {
-        "message": "Hi"
-    },
+    "data": "file content",
     "metadata": {
         "blobName"           : "filename.txt",
         "ContentType"        : "text/plain",


### PR DESCRIPTION
Setting file content in data.message creates an empty file.
Updated docs: file content should go into "data", and not "data.message".

