### PR TITLE
deployment in stead of run for 1.15+ compatibility

### DIFF
--- a/howto/diagnose-with-tracing/zipkin.md
+++ b/howto/diagnose-with-tracing/zipkin.md
@@ -66,13 +66,13 @@ The following steps shows you how to configure Dapr to send distributed tracing 
 First, deploy Zipkin:
 
 ```bash
-kubectl run zipkin --image openzipkin/zipkin --port 9411
+kubectl create deployment zipkin --image openzipkin/zipkin
 ```
 
 Create a Kubernetes service for the Zipkin pod:
 
 ```bash
-kubectl expose deploy zipkin --type ClusterIP --port 9411
+kubectl expose deployment zipkin --type ClusterIP --port 9411
 ```
 
 Next, create the following YAML files locally:


### PR DESCRIPTION
Addresses #572 

Current instructions for deploying Zipkin do not create service which makes the following command fail because there is no service, as starting with 1.15 k8s no longer creates service under the `run` command.

Changing the `run` to `create deployment`

```shell
kubectl create deployment zipkin --image openzipkin/zipkin
```

Which creates will allow the following command to create a service and expose its port.

```shell
kubectl expose deployment zipkin --type ClusterIP --port 9411
```

