### PR TITLE
Adding missing Kafka link in reference section

### DIFF
--- a/howto/setup-pub-sub-message-broker/README.md
+++ b/howto/setup-pub-sub-message-broker/README.md
@@ -53,4 +53,4 @@ kubectl apply -f pubsub.yaml
 - [Setup SNS/SQS](./setup-snssqs.md)
 - [Setup MQTT](./setup-mqtt.md)
 - [Setup Apache Pulsar](./setup-pulsar.md)
-- [Setup Kafaka](./setup-kafka.md)
+- [Setup Kafka](./setup-kafka.md)


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

If you are a new contributor, please see the [this contribution guidance](https://github.com/dapr/docs/blob/master/contributing/README.md) which helps keep the Dapr documentation readable, consistent and useful for Dapr users.

If you are contributing a new authored "How To" article, [this template](https://github.com/dapr/docs/blob/master/contributing/howto-template.md) was created to assist you.

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Main README for pub/sub setup is missing a link to Kafka HowTo


