### PR TITLE
Cosmos - data must be in json

### DIFF
--- a/howto/setup-state-store/setup-azure-cosmosdb.md
+++ b/howto/setup-state-store/setup-azure-cosmosdb.md
@@ -105,9 +105,11 @@ To run locally, create a YAML file described above and provide the path to the `
 
 ## Data format
 
-To use the cosmos state store, your data must be sent to Dapr in json format.  Having it just json *serializable* but not json will not work.
+To use the cosmos state store, your data must be sent to Dapr in json-serialized.  Having it just json *serializable* will not work.
 
 If you are using the Dapr SDKs (e.g. https://github.com/dapr/dotnet-sdk) the SDK will serialize your data to json.
+
+For examples see the curl operations in the [Partition keys](#partition-keys) section.
 
 ## Partition keys
 

--- a/howto/setup-state-store/setup-azure-cosmosdb.md
+++ b/howto/setup-state-store/setup-azure-cosmosdb.md
@@ -103,6 +103,12 @@ kubectl apply -f cosmos.yaml
 
 To run locally, create a YAML file described above and provide the path to the `dapr run` command with the flag `--components-path`.  See [this](https://github.com/dapr/cli#use-non-default-components-path) or run `dapr run --help` for more information on the path.
 
+## Data format
+
+To use the cosmos state store, your data must be sent to Dapr in json format.  Having it just json *serializable* but not json will not work.
+
+If you are using the Dapr SDKs (e.g. https://github.com/dapr/dotnet-sdk) the SDK will serialize your data to json.
+
 ## Partition keys
 
 


### PR DESCRIPTION
This clarifies data sent to cosmos must be in json, just just json serializable.