### PR TITLE
removes programmability, no cron output bind in .9

### DIFF
--- a/reference/specs/bindings/cron.md
+++ b/reference/specs/bindings/cron.md
@@ -39,7 +39,3 @@ For ease of use, the Dapr cron binding also supports few shortcuts:
 
 * `@every 15s` where `s` is seconds, `m` minutes, and `h` hours
 * `@daily` or `@hourly` which runs at that period from the time the binding is initialized  
-
-## Programmability 
-
-The Dapr cron binding also supports `Invoke` method with `Delete` operation as an output binding which can be used to cancel existing schedule programmatically. For more about sending events see the [Output Bindings docs](https://github.com/dapr/docs/tree/master/howto/send-events-with-output-bindings).


### PR DESCRIPTION
Remove programmability using output binding. That PR landed in master but has not been included in v0.9 dapr main so users have no access to it.

The dapr/dapr corresponding issue is [here](https://github.com/dapr/dapr/issues/1804)