### PR TITLE
Fix broken link to KEDA deployment

### DIFF
--- a/howto/autoscale-with-keda/README.md
+++ b/howto/autoscale-with-keda/README.md
@@ -7,7 +7,7 @@ For apps that use these bindings, it is easy to configure a KEDA autoscaler.
 
 ## Install KEDA
 
-To install KEDA, follow the [Deploying KEDA](https://keda.sh/docs/deploy/) instructions on the KEDA website.
+To install KEDA, follow the [Deploying KEDA](https://keda.sh/docs/latest/deploy/) instructions on the KEDA website.
 
 ## Create KEDA enabled Dapr binding
 


### PR DESCRIPTION
## Description

Fix broken link to KEDA deployment in [Autoscaling a Dapr app with KEDA](https://github.com/dapr/docs/tree/master/howto/autoscale-with-keda)

## Issue reference

Closes #710
