### PR TITLE
changed bindings metadata name with lowercase

### DIFF
--- a/howto/send-events-with-output-bindings/README.md
+++ b/howto/send-events-with-output-bindings/README.md
@@ -21,7 +21,7 @@ Create the following YAML file, named binding.yaml, and save this to a `componen
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: myEvent
+  name: myevent
   namespace: default
 spec:
   type: bindings.kafka
@@ -32,7 +32,7 @@ spec:
     value: topic1
 ```
 
-Here, we create a new binding component with the name of `myEvent`.
+Here, we create a new binding component with the name of `myevent`.
 
 Inside the `metadata` section, we configure Kafka related properties such as the topic to publish the message to and the broker.
 
@@ -43,10 +43,10 @@ All that's left now is to invoke the bindings endpoint on a running Dapr instanc
 We can do so using HTTP:
 
 ```bash
-curl -X POST -H  http://localhost:3500/v1.0/bindings/myEvent -d '{ "data": { "message": "Hi!" }, "operation": "create" }'
+curl -X POST -H  http://localhost:3500/v1.0/bindings/myevent -d '{ "data": { "message": "Hi!" }, "operation": "create" }'
 ```
 
-As seen above, we invoked the `/binding` endpoint with the name of the binding to invoke, in our case its `myEvent`.
+As seen above, we invoked the `/binding` endpoint with the name of the binding to invoke, in our case its `myevent`.
 The payload goes inside the mandatory `data` field, and can be any JSON serializable value.
 
 You'll also notice that there's an `operation` field that tells the binding what we need it to do.

--- a/howto/trigger-app-with-input-binding/README.md
+++ b/howto/trigger-app-with-input-binding/README.md
@@ -29,7 +29,7 @@ Create the following YAML file, named binding.yaml, and save this to a `componen
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: myEvent
+  name: myevent
   namespace: default
 spec:
   type: bindings.kafka
@@ -42,13 +42,13 @@ spec:
     value: group1
 ```
 
-Here, you create a new binding component with the name of `myEvent`.
+Here, you create a new binding component with the name of `myevent`.
 
 Inside the `metadata` section, configure the Kafka related properties such as the topics to listen on, the brokers and more.
 
 ## 2. Listen for incoming events
 
-Now configure your application to receive incoming events. If using HTTP, you need to listen on a `POST` endpoint with the name of the binding as specified in `metadata.name` in the file.  In this example, this is `myEvent`.
+Now configure your application to receive incoming events. If using HTTP, you need to listen on a `POST` endpoint with the name of the binding as specified in `metadata.name` in the file.  In this example, this is `myevent`.
 
 *The following example shows how you would listen for the event in Node.js, but this is applicable to any programming language*
 
@@ -60,7 +60,7 @@ app.use(bodyParser.json())
 
 const port = 3000
 
-app.post('/myEvent', (req, res) => {
+app.post('/myevent', (req, res) => {
     console.log(req.body)
     res.status(200).send()
 })


### PR DESCRIPTION
## Description

howto/send-events-with-output-bindings/README.md and howto/trigger-app-with-input-binding/README.md contain incorrect Component's metadata name.

metadata.name: Invalid value: "myEvent": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

## Issue reference

N/A
