### PR TITLE
Fixing references to samples that are now quickstarts

### DIFF
--- a/concepts/hosting/README.md
+++ b/concepts/hosting/README.md
@@ -21,7 +21,7 @@ You can use the [Dapr CLI](https://github.com/dapr/cli#launch-dapr-and-your-app)
 
 ## Running Dapr in Kubernetes mode
 
-Dapr can be configured to run on any [Kubernetes cluster](https://github.com/dapr/samples/tree/master/2.hello-kubernetes). In Kubernetes the `dapr-sidecar-injector` and `dapr-operator` services provide first class integration to launch Dapr as a sidecar container in the same pod as the service container and provide notifications of Dapr component updates provisioned into the cluster. Additionally, the `dapr-sidecar-injector` also injects the environment variables `DAPR_HTTP_PORT` and `DAPR_GRPC_PORT` into **all** the containers in the pod to enable user defined applications to easily communicate with Dapr without hardcoding Dapr port values. 
+Dapr can be configured to run on any [Kubernetes cluster](https://github.com/dapr/quickstarts/tree/master/hello-kubernetes). In Kubernetes the `dapr-sidecar-injector` and `dapr-operator` services provide first class integration to launch Dapr as a sidecar container in the same pod as the service container and provide notifications of Dapr component updates provisioned into the cluster. Additionally, the `dapr-sidecar-injector` also injects the environment variables `DAPR_HTTP_PORT` and `DAPR_GRPC_PORT` into **all** the containers in the pod to enable user defined applications to easily communicate with Dapr without hardcoding Dapr port values. 
 
 The `dapr-sentry` service is a certificate authority that enables mutual TLS between Dapr sidecar instances for secure data encryption. For more information on the `Sentry` service read the [security overview](../concepts/security/README.md#dapr-to-dapr-communication)
 
@@ -36,6 +36,6 @@ Deploying and running a Dapr enabled application into your Kubernetes cluster is
     dapr.io/port: "3000"
     dapr.io/config: "tracing"
 ```
-You can see some examples [here](https://github.com/dapr/samples/tree/master/2.hello-kubernetes/deploy) in the Kubernetes getting started sample.
+You can see some examples [here](https://github.com/dapr/quickstarts/tree/master/hello-kubernetes/deploy) in the Kubernetes getting started sample.
 
 Read [Kubernetes how to topics](https://github.com/dapr/docs/tree/master/howto#kubernetes-configuration) for more information about setting up Kubernetes and Dapr.

--- a/concepts/observability/W3C-traces.md
+++ b/concepts/observability/W3C-traces.md
@@ -106,4 +106,4 @@ In the gRPC API calls, trace context is passed through `grpc-trace-bin` header.
 * [How To set up Zipkin for distributed tracing](../../howto/diagnose-with-tracing/zipkin.md)
 * [How to use Trace Context](../../howto/use-w3c-tracecontext)
 * [W3C trace context specification](https://www.w3.org/TR/trace-context/)
-* [Observability sample](https://github.com/dapr/samples/tree/master/8.observability)
+* [Observability sample](https://github.com/dapr/quickstarts/tree/master/observability)

--- a/concepts/service-invocation/README.md
+++ b/concepts/service-invocation/README.md
@@ -13,7 +13,7 @@ Below is a high level overview of how Dapr's service invocation system works.
 5. Dapr forwards the response to Service A's Dapr sidecar.
 6. Service A receives the response.
 
-As an example for all the above, suppose we have the collection of apps described in the following sample, where a python app invokes a Node.js app: https://github.com/dapr/samples/blob/master/2.hello-kubernetes/README.md
+As an example for all the above, suppose we have the collection of apps described in the following sample, where a python app invokes a Node.js app: https://github.com/dapr/quickstarts/blob/master/hello-kubernetes/README.md
 
 In such a scenario, the python app would be "Service A" above, and the Node.js app would be "Service B".
 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -16,6 +16,6 @@ Dapr can be run locally or in Kubernetes. We recommend starting with a local set
 
 ## Next steps
 
-1. Once Dapr is installed, continue to the [Hello World sample](https://github.com/dapr/samples/tree/master/1.hello-world).
-2. Explore additional [samples](https://github.com/dapr/samples) for more advanced concepts, such as service invocation, pub/sub, and state management.
+1. Once Dapr is installed, continue to the [Hello World quickstart](https://github.com/dapr/quickstarts/tree/master/hello-world).
+2. Explore additional [quickstarts](https://github.com/dapr/quickstarts) for more advanced concepts, such as service invocation, pub/sub, and state management.
 3. Follow [How To guides](../howto) to understand how Dapr solves specific problems, such as creating a [rate limited app](../howto/control-concurrency).

--- a/howto/pubsub-namespaces/README.md
+++ b/howto/pubsub-namespaces/README.md
@@ -2,7 +2,7 @@
 
 In some scenarios, applications can be spread across namespaces and share a queue or topic via PubSub. In this case, the PubSub component must be provisioned on each namespace.
 
-In this example, we will use the [PubSub sample](https://github.com/dapr/samples/tree/master/4.pub-sub). Redis installation and the subscribers will be in `namespace-a` while the publisher UI will be on `namespace-b`. This solution should also work if Redis was installed on another namespace or if we used a managed cloud service like Azure ServiceBus.
+In this example, we will use the [PubSub sample](https://github.com/dapr/quickstarts/tree/master/pub-sub). Redis installation and the subscribers will be in `namespace-a` while the publisher UI will be on `namespace-b`. This solution should also work if Redis was installed on another namespace or if we used a managed cloud service like Azure ServiceBus.
 
 The table below shows which resources are deployed to which namespaces:
 | Resource | namespace-a | namespace-b |
@@ -17,7 +17,7 @@ The table below shows which resources are deployed to which namespaces:
 ## Pre-requisites
 
 * [Dapr installed](https://github.com/dapr/docs/blob/master/getting-started/environment-setup.md.) on any namespace since Dapr works at the cluster level.
-* Checkout and cd into directory for [PubSub sample](https://github.com/dapr/samples/tree/master/4.pub-sub).
+* Checkout and cd into directory for [PubSub sample](https://github.com/dapr/quickstarts/tree/master/pub-sub).
 
 ## Setup `namespace-a`
 

--- a/howto/run-with-docker/README.md
+++ b/howto/run-with-docker/README.md
@@ -133,16 +133,16 @@ services:
 
 > For those running the Docker daemon on a Linux host, you can also use `network_mode: host` to leverage host networking if needed.
 
-To further learn how to run Dapr with Docker Compose, see the [Docker-Compose Sample](https://github.com/dapr/samples/10.hello-docker-compose).
+To further learn how to run Dapr with Docker Compose, see the [Docker-Compose Sample](https://github.com/dapr/samples/hello-docker-compose).
 
 ## Run Dapr in a Docker container on Kubernetes
 If your deployment target is Kubernetes then you're probably better of running your applicaiton and Dapr sidecars directly on
 a Kubernetes platform. Running Dapr on Kubernetes is a first class experience and is documented separately. Please refer to the
 following references:
 - [Setup Dapr on a Kubernetes cluster](https://github.com/dapr/docs/blob/ea5b1918778a47555dbdccff0ed6c5b987ed10cf/getting-started/environment-setup.md#installing-dapr-on-a-kubernetes-cluster)
-- [Hello Kubernetes Sample](https://github.com/dapr/samples/tree/master/2.hello-kubernetes)
+- [Hello Kubernetes Sample](https://github.com/dapr/quickstarts/tree/master/hello-kubernetes)
 - [Configuring the Dapr sidecar on Kubernetes](https://github.com/dapr/docs/blob/c88d247a2611d6824d41bb5b6adfeb38152dbbc6/howto/configure-k8s/README.md)
 - [Running Dapr in Kubernetes mode](https://github.com/dapr/docs/blob/a7668cab5e16d12f364a42d2fe7d75933c6398e9/overview/README.md#running-dapr-in-kubernetes-mode)
 
 ## Related links
-- [Docker-Compose Sample](https://github.com/dapr/samples/10.hello-docker-compose)
+- [Docker-Compose Sample](https://github.com/dapr/samples/hello-docker-compose)

--- a/howto/self-hosted-no-docker/README.md
+++ b/howto/self-hosted-no-docker/README.md
@@ -16,10 +16,10 @@ dapr init --slim
 
 In this mode two different binaries are installed `daprd` and `placement`. The `placement` binary is needed to enable [actors](../../concepts/actors/README.md) in a Dapr self-hosted installation. 
 
-In this mode no default components such as Redis are installed for state managment or pub/sub. This means, that aside from [Service Invocation](../../concepts/service-invocation/README.md), no other building block functionality is availble on install out of the box. Users are free to setup their own environemnt and custom components. Furthermore, actor based service invocation is possible if a statestore is configured as explained in the following sections.
+In this mode no default components such as Redis are installed for state management or pub/sub. This means, that aside from [Service Invocation](../../concepts/service-invocation/README.md), no other building block functionality is available on install out of the box. Users are free to setup their own environment and custom components. Furthermore, actor based service invocation is possible if a state store is configured as explained in the following sections.
 
 ## Service invocation
-See [this sample](https://github.com/dapr/samples/tree/master/11.hello-dapr-slim) for an example on how to perform service invocation in this mode. 
+See [this sample](https://github.com/dapr/samples/tree/master/hello-dapr-slim) for an example on how to perform service invocation in this mode. 
 
 ## Enabling state management or pub/sub
 
@@ -27,7 +27,7 @@ See configuring Redis in self hosted mode [without docker](../../howto/configure
 
 ## Enabling actors
 
-The placement service must be run locally to enable actor placement. Also a [transactoinal state store](#Enabling-state-management-or-pub/sub) must be enabled for actors. 
+The placement service must be run locally to enable actor placement. Also a [transactional state store](#Enabling-state-management-or-pub/sub) must be enabled for actors. 
 
 By default for Linux/MacOS the `placement` binary is installed in `/usr/local/bin` or for Windows at `c:\dapr`.
 

--- a/howto/setup-secret-store/azure-keyvault.md
+++ b/howto/setup-secret-store/azure-keyvault.md
@@ -162,7 +162,7 @@ auth:
 
 You can check that `secretstores.azure.keyvault` component is loaded and redis server connects successfully by looking at the log output when using the dapr `run` command
 
-Here is the log when you run [HelloWorld sample](https://github.com/dapr/samples/tree/master/1.hello-world) with Azure Key Vault secret store.
+Here is the log when you run [HelloWorld sample](https://github.com/dapr/quickstarts/tree/master/hello-world) with Azure Key Vault secret store.
 
 ```bash
 $ dapr run --app-id mynode --app-port 3000 --port 3500 node app.js
@@ -268,7 +268,7 @@ auth:
 
 Make sure that `secretstores.azure.keyvault` is loaded successfully in `daprd` sidecar log
 
-Here is the nodeapp log of [HelloWorld Kubernetes sample](https://github.com/dapr/samples/tree/master/2.hello-kubernetes). Note: use the nodeapp name for your deployed container instance.
+Here is the nodeapp log of [HelloWorld Kubernetes sample](https://github.com/dapr/quickstarts/tree/master/hello-kubernetes). Note: use the nodeapp name for your deployed container instance.
 
 ```bash
 $ kubectl logs nodeapp-f7b7576f4-4pjrj daprd

--- a/howto/setup-secret-store/local-secret-store.md
+++ b/howto/setup-secret-store/local-secret-store.md
@@ -97,7 +97,7 @@ auth:
 
 You can check that `secretstores.local.localsecretstore` component is loaded and redis server connects successfully by looking at the log output when using the dapr `run` command.
 
-Here is the log when you run [HelloWorld sample](https://github.com/dapr/samples/tree/master/1.hello-world) with Local Secret secret store.
+Here is the log when you run [HelloWorld sample](https://github.com/dapr/quickstarts/tree/master/hello-world) with Local Secret secret store.
 
 ```bash
 $ dapr run --app-id mynode --app-port 3000 --port 3500 node app.js
@@ -120,4 +120,4 @@ $ dapr run --app-id mynode --app-port 3000 --port 3500 node app.js
 
 - [Secrets Component](../../concepts/secrets/README.md)
 - [Secrets API](../../reference/api/secrets_api.md)
-- [Secrets API Samples](https://github.com/dapr/samples/blob/master/9.secretstore/README.md)
+- [Secrets API Samples](https://github.com/dapr/quickstarts/blob/master/secretstore/README.md)

--- a/howto/trigger-app-with-input-binding/README.md
+++ b/howto/trigger-app-with-input-binding/README.md
@@ -12,7 +12,7 @@ Dapr bindings allow you to:
 
 For more info on bindings, read [this](../../concepts/bindings/README.md) link.
 
-For a complete sample showing bindings, visit this [link](https://github.com/dapr/samples/tree/master/5.bindings).
+For a complete sample showing bindings, visit this [link](https://github.com/dapr/quickstarts/tree/master/bindings).
 
 ## 1. Create a binding
 

--- a/howto/use-w3c-tracecontext/README.md
+++ b/howto/use-w3c-tracecontext/README.md
@@ -298,6 +298,6 @@ You can now correlate the calls in your app and across services with Dapr using 
 * [How to set up Application Insights for distributed tracing](../../howto/diagnose-with-tracing/azure-monitor.md)
 * [How to set up Zipkin for distributed tracing](../../howto/diagnose-with-tracing/zipkin.md)
 * [W3C trace context specification](https://www.w3.org/TR/trace-context/)
-* [Observability sample](https://github.com/dapr/samples/tree/master/8.observability)
+* [Observability quickstart](https://github.com/dapr/quickstarts/tree/master/observability)
 
 

--- a/overview/README.md
+++ b/overview/README.md
@@ -122,4 +122,4 @@ The `dapr-sentry` service is a certificate authority that enables mutual TLS bet
 
 <img src="../images/overview_kubernetes.png" width=800>
 
-Deploying and running a Dapr enabled application into your Kubernetes cluster is a simple as adding a few annotations to the deployment schemes. You can see some examples [here](https://github.com/dapr/samples/tree/master/2.hello-kubernetes/deploy) in the Kubernetes getting started sample. Try this out with the [Kubernetes getting started sample](https://github.com/dapr/samples/tree/master/2.hello-kubernetes)
+Deploying and running a Dapr enabled application into your Kubernetes cluster is a simple as adding a few annotations to the deployment schemes. You can see some examples [here](https://github.com/dapr/quickstarts/tree/master/hello-kubernetes/deploy) in the Kubernetes getting started sample. Try this out with the [Kubernetes getting started sample](https://github.com/dapr/quickstarts/tree/master/hello-kubernetes)

--- a/presentations/README.md
+++ b/presentations/README.md
@@ -17,4 +17,4 @@ There are other Dapr resources on the [community](https://github.com/dapr/dapr#c
 
 - Next, review the [Docs](../README.md) to make sure you understand the [concepts](../concepts) and [best-practices](../best-practices).
 
-- Use the Dapr [samples](https://github.com/dapr/samples) repo to show demos of how to use Dapr
+- Use the Dapr [quickstarts](https://github.com/dapr/quickstarts) repo and [samples](https://github.com/dapr/samples) repo to show demos of how to use Dapr

--- a/reference/api/pubsub_api.md
+++ b/reference/api/pubsub_api.md
@@ -95,4 +95,4 @@ Dapr Pub/Sub adheres to version 1.0 of Cloud Events.
 ## Related links
 
 * [How to consume topics](https://github.com/dapr/docs/tree/master/howto/consume-topic)
-* [Sample for pub/sub](https://github.com/dapr/samples/tree/master/4.pub-sub) 
+* [Sample for pub/sub](https://github.com/dapr/quickstarts/tree/master/pub-sub) 

--- a/walkthroughs/daprrun.md
+++ b/walkthroughs/daprrun.md
@@ -1,6 +1,6 @@
 # Sequence of Events on a dapr run in Self Hosting Mode
 
-The doc describes the sequence of events that occur when `dapr run` is executed in self hosting mode.  It uses [sample 1](https://github.com/dapr/samples/tree/master/1.hello-world) as an example.
+The doc describes the sequence of events that occur when `dapr run` is executed in self hosting mode.  It uses [sample 1](https://github.com/dapr/quickstarts/tree/master/hello-world) as an example.
 
 Terminology used below:
 


### PR DESCRIPTION
## Description

This PR aims to fix broken links to samples after the renaming of the dapr/samples repo to dapr/quickstarts

## Issue reference

Closes #736 
