### PR TITLE
Update with new cli commands

### DIFF
--- a/getting-started/environment-setup.md
+++ b/getting-started/environment-setup.md
@@ -130,8 +130,6 @@ $ dapr uninstall --install-path /path/to/binary
 
 When setting up Kubernetes, you can do this either via the Dapr CLI or Helm.
 
-*Note that installing Dapr using the CLI is recommended for testing purposes only.*
-
 Dapr installs the following pods:
 
 * dapr-operator: Manages component updates and kubernetes services endpoints for Dapr (state stores, pub-subs, etc.)

--- a/getting-started/environment-setup.md
+++ b/getting-started/environment-setup.md
@@ -157,21 +157,37 @@ You can install Dapr on any Kubernetes cluster. Here are some helpful links:
 
 You can install Dapr to a Kubernetes cluster using CLI.
 
-> **Note:** that using the CLI does not support non-default namespaces.  
-> If you need a non-default namespace, Helm installation has to be used (see below).
-
 #### Install Dapr to Kubernetes
 
-```bash
-$ dapr init --kubernetes
-ℹ️  Note: this installation is recommended for testing purposes. For production environments, please use Helm
+*Note: The default namespace is dapr-system*
+
+```
+$ dapr init -k
 
 ⌛  Making the jump to hyperspace...
-✅  Deploying the Dapr Operator to your cluster...
-✅  Success! Dapr has been installed. To verify, run 'kubectl get pods -w' in your terminal. To get started, go here: https://aka.ms/dapr-getting-started
+ℹ️  Note: To install Dapr using Helm, see here:  https://github.com/dapr/docs/blob/master/getting-started/environment-setup.md#using-helm-advanced
+
+✅  Deploying the Dapr control plane to your cluster...
+✅  Success! Dapr has been installed to namespace dapr-system. To verify, run "dapr status -k" in your terminal. To get started, go here: https://aka.ms/dapr-getting-started
 ```
 
-Dapr CLI installs Dapr to `default` namespace of Kubernetes cluster using [this](https://daprreleases.blob.core.windows.net/manifest/dapr-operator.yaml) manifest.
+Install to a custom namespace:
+
+```
+dapr init -k -n mynamespace
+```
+
+Installing in highly available mode:
+
+```
+dapr init -k --enable-ha=true
+```
+
+Disable mTLS:
+
+```
+dapr init -k --enable-mtls=false
+```
 
 #### Uninstall Dapr on Kubernetes
 

--- a/howto/configure-mtls/README.md
+++ b/howto/configure-mtls/README.md
@@ -35,9 +35,7 @@ The file here shows the default `daprsystem` configuration settings. The example
 ### Setting up mTLS with the configuration resource
 
 In Kubernetes, Dapr creates a default configuration resource with mTLS enabled.
-Sentry, the certificate authority system pod, is installed both with Helm and with the Dapr CLI using `dapr init --kubernetes`. 
-
-Depending on how you install Dapr, this resource may reside in the `default` namespace if you installed Dapr using the Dapr CLI, or the `dapr-system` namespace if deployed using Helm.
+Sentry, the certificate authority system pod, is installed both with Helm and with the Dapr CLI using `dapr init --kubernetes`.
 
 You can view the configuration resource with the following command:
 
@@ -69,6 +67,12 @@ helm install \
   --namespace dapr-system \
   dapr \
   dapr/dapr
+```
+
+### Disabling mTLS with the CLI
+
+```
+dapr init --kubernetes --enable-mtls=false
 ```
 
 ### Viewing logs

--- a/howto/deploy-k8s-prod/README.md
+++ b/howto/deploy-k8s-prod/README.md
@@ -90,6 +90,18 @@ After you downloaded the binary, it's recommended you put the CLI binary in your
 
 When upgrading to a new version of Dapr, it is recommended you carry over the root and issuer certificates instead of re-generating them, which might cause a downtime for applications that make use of service invocation or actors.
 
+#### Exporting certs with the Dapr CLI
+
+To get your current certs with the Dapr CLI, run the following command:
+
+```
+dapr mtls export -o ./certs
+```
+
+This will save any existing root cert, issuer cert and issuer key in the output dir of your choice.
+
+### Exporting certs manually
+
 To get the current root and issuer certificates, run the following command:
 
 ```


### PR DESCRIPTION
This PR updates the docs with the following:

1. Updates regarding new `dapr init -k` command and flags
2. Adds new `dapr mtls export` command to the deployment guide