### PR TITLE
Remove `consistency`  from bulk API doc.

### DIFF
--- a/reference/api/state_api.md
+++ b/reference/api/state_api.md
@@ -194,7 +194,6 @@ Parameter | Description
 --------- | -----------
 daprPort | the Dapr port
 storename | ```metadata.name``` field in the user configured state store component yaml. Please refer Dapr State Store configuration structure mentioned above.
-consistency | (optional) read consistency mode, see [state operation options](#optional-behaviors)
 metadata | (optional) metadata as query parameters to the state store
 
 ### HTTP Response


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

If you are a new contributor, please see the [this contribution guidance](https://github.com/dapr/docs/blob/master/contributing/README.md) which helps keep the Dapr documentation readable, consistent and useful for Dapr users.

If you are contributing a new authored "How To" article, [this template](https://github.com/dapr/docs/blob/master/contributing/howto-template.md) was created to assist you.

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Remove `consistency` from HTTP bulk get API doc since it is not supported.

## Issue reference

_Please reference the issue this PR will close: #783 
