### PR TITLE
Update metrics doc to list how to disable the Dapr runtime metrics

### DIFF
--- a/concepts/observability/metrics.md
+++ b/concepts/observability/metrics.md
@@ -4,9 +4,24 @@ Dapr exposes a [Prometheus](https://prometheus.io/) metrics endpoint that you ca
 
 ## Configuration
 
-The metrics endpoint is enabled by default, you can disable it by passing the command line argument `--enable-metrics=false` to dapr system processes.
+The metrics endpoint is enabled by default, you can disable it by passing the command line argument `--enable-metrics=false` to Dapr system processes.
 
-The default metrics port is `9090`. This can be overridden by passing the command line argument `--metrics-port` to darpd.
+The default metrics port is `9090`. This can be overridden by passing the command line argument `--metrics-port` to Daprd.
+
+To disable the metrics in the Dapr side car, you can use the `metric` spec configuration and set `enabled: false` to disable the metrics in the Dapr runtime.
+
+```
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+name: tracing
+namespace: default
+spec:
+tracing:
+samplingRate: "1"
+metric:
+enabled: false
+```
 
 ## Metrics
 


### PR DESCRIPTION
Updating doc to show how to disable metrics in Dapr runtime.