### PR TITLE
Add disclaimer about plaintext secrets

### DIFF
--- a/howto/configure-redis/README.md
+++ b/howto/configure-redis/README.md
@@ -59,6 +59,7 @@ We can use [Helm](https://helm.sh/) to quickly create a Redis instance in our Ku
    - name: redisPassword
      value: lhDOkwTlp0
    ```
+    > **Note:** the `redis.yaml` file provided in here takes plain text secrets. In a production-grade application, follow [secret management](https://github.com/dapr/docs/blob/master/concepts/secrets/) instructions to securely manage your secrets.
 
 ### Option 2: Creating an Azure Cache for Redis service
 

--- a/howto/configure-redis/README.md
+++ b/howto/configure-redis/README.md
@@ -59,7 +59,7 @@ We can use [Helm](https://helm.sh/) to quickly create a Redis instance in our Ku
    - name: redisPassword
      value: lhDOkwTlp0
    ```
-    > **Note:** the `redis.yaml` file provided in here takes plain text secrets. In a production-grade application, follow [secret management](https://github.com/dapr/docs/blob/master/concepts/secrets/) instructions to securely manage your secrets.
+    > **Note:** The above example uses secret in plain text, follow [these instructions](https://github.com/dapr/docs/blob/master/concepts/secrets/) to configure secrets securely in production.
 
 ### Option 2: Creating an Azure Cache for Redis service
 


### PR DESCRIPTION
## Description

Add a disclaimer similar to that of https://github.com/dapr/quickstarts/tree/master/hello-kubernetes#step-2---create-and-configure-a-state-store so that users know that plaintext secrets aren't the norm, and how they can do things more securely.

