### PR TITLE
Fix aks cluster provisioning command

### DIFF
--- a/getting-started/cluster/setup-aks.md
+++ b/getting-started/cluster/setup-aks.md
@@ -31,10 +31,10 @@ az group create --name [your_resource_group] --location [region]
 
 4. Create an Azure Kubernetes Service cluster
 
-Use 1.13.x or newer version of Kubernetes with `--kubernetes-version`
+> **Note:** To use a specific version of Kubernetes use `--kubernetes-version` (1.13.x or newer version required)
 
 ```bash
-az aks create --resource-group [your_resource_group] --name [your_aks_cluster_name] --node-count 2 --kubernetes-version 1.14.7 --enable-addons http_application_routing --enable-rbac --generate-ssh-keys
+az aks create --resource-group [your_resource_group] --name [your_aks_cluster_name] --node-count 2 --enable-addons http_application_routing --generate-ssh-keys
 ```
 
 5. Get the access credentials for the Azure Kubernetes cluster
@@ -42,7 +42,6 @@ az aks create --resource-group [your_resource_group] --name [your_aks_cluster_na
 ```bash
 az aks get-credentials -n [your_aks_cluster_name] -g [your_resource_group]
 ```
-
 
 ## (optional) Install Helm v3
 


### PR DESCRIPTION
## Description

When originally written, the command to provision an aks cluster
had to specify a specific version of Kubernetes. The requirement
of having Kubernetes version 1.13.x or higher is now met by the
default version of Kubernetes in all regions.

Additionally, all clusters now have rbac enabled by default so this
option is also removed.

## Issue reference

https://github.com/dapr/docs/issues/832
