### PR TITLE
Fix binding spec of rabbitmq

### DIFF
--- a/reference/specs/bindings/rabbitmq.md
+++ b/reference/specs/bindings/rabbitmq.md
@@ -14,13 +14,13 @@ spec:
   - name: host
     value: amqp://[username][:password]@host.domain[:port]
   - name: durable
-    value: true
+    value: "true"
   - name: deleteWhenUnused
-    value: false
+    value: "false"
   - name: ttlInSeconds
-    value: 60
+    value: "60"
   - name: prefetchCount
-    value: 0
+    value: "0"
 ```
 
 - `queueName` is the RabbitMQ queue name.


### PR DESCRIPTION
## Description

The updated metadata's value should be string with double quote. Without these quotes, the binding will fail in dapr version 0.11 with the following error (in Pod dapr-operator console):

```
E1004 16:17:22.016796       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.2/tools/cache/reflector.go:105: Failed to list *v1alpha1.Component: v1alpha1.ComponentList.Items: []v1alpha1.Component: v1alpha1.Component.v1alpha1.Component.Spec: v1alpha1.ComponentSpec.Metadata: []v1alpha1.MetadataItem: v1alpha1.MetadataItem.Value: ReadString: expects " or n, but found t, error found in dapr#10 byte of ...|,"value":true},{"nam|..., bigger context ...|e":"rabbitmq-secret"}},{"name":"durable","value":true},{"name":"deleteWhenUnused","value":false},{"n|...
```
