### PR TITLE
Fixing broken link - hosting platform

### DIFF
--- a/concepts/service-invocation/README.md
+++ b/concepts/service-invocation/README.md
@@ -97,7 +97,7 @@ By default, all calls between applications are traced and metrics are gathered t
 For more information read the [observability](../concepts/observability) article.
 
 ### Pluggable service discovery
-Dapr can run on any [hosting platform](../concepts/hosting). For the supported hosting platforms this means they have a [name resolution component](https://github.com/dapr/components-contrib/tree/master/nameresolution) developed for them that enables service discovery. For example, the Kubernetes name resolution component uses the Kubernetes DNS service to resolve the location of other applications running in the cluster.
+Dapr can run on any [hosting platform](../hosting). For the supported hosting platforms this means they have a [name resolution component](https://github.com/dapr/components-contrib/tree/master/nameresolution) developed for them that enables service discovery. For example, the Kubernetes name resolution component uses the Kubernetes DNS service to resolve the location of other applications running in the cluster.
 
 ## Next steps
 


### PR DESCRIPTION
## Description

In the concepts directory, the service invocation [README.md](https://github.com/dapr/docs/tree/v0.11.0/concepts/service-invocation#pluggable-service-discovery) has a broken link to the hosting README. Fixed the broken reference 

## Issue reference

No current issue exists for this fix
