### PR TITLE
Removed unused link in the bindings api docs

### DIFF
--- a/reference/api/bindings_api.md
+++ b/reference/api/bindings_api.md
@@ -9,7 +9,6 @@ Examples for bindings include ```Kafka```, ```Rabbit MQ```, ```Azure Event Hubs`
 
 - [Bindings Structure](#bindings-structure)
 - [Invoking Service Code Through Input Bindings](#invoking-service-code-through-input-bindings)
-- [Sending Messages to Output Bindings](#sending-messages-to-output-bindings)
 
 ## Bindings Structure
 

--- a/reference/api/bindings_api.md
+++ b/reference/api/bindings_api.md
@@ -9,7 +9,7 @@ Examples for bindings include ```Kafka```, ```Rabbit MQ```, ```Azure Event Hubs`
 
 - [Bindings Structure](#bindings-structure)
 - [Invoking Service Code Through Input Bindings](#invoking-service-code-through-input-bindings)
-- [Sending Messages to Output Bindings](https://github.com/dapr/docs/blob/be9a77d4580ac925ed8461e3cc17173210c75c43/reference/api/bindings_api.md#invoking-output-bindings)
+- [Sending Messages to Output Bindings](#invoking-output-bindings)
 
 ## Bindings Structure
 

--- a/reference/api/bindings_api.md
+++ b/reference/api/bindings_api.md
@@ -9,6 +9,7 @@ Examples for bindings include ```Kafka```, ```Rabbit MQ```, ```Azure Event Hubs`
 
 - [Bindings Structure](#bindings-structure)
 - [Invoking Service Code Through Input Bindings](#invoking-service-code-through-input-bindings)
+- [Sending Messages to Output Bindings](https://github.com/dapr/docs/blob/be9a77d4580ac925ed8461e3cc17173210c75c43/reference/api/bindings_api.md#invoking-output-bindings)
 
 ## Bindings Structure
 


### PR DESCRIPTION
Removed the "Sending Messages to Output Bindings" link

Thank you for helping make the Dapr documentation better!

If you are a new contributor, please see the [this contribution guidance](https://github.com/dapr/docs/blob/master/contributing/README.md) which helps keep the Dapr documentation readable, consistent and useful for Dapr users.

If you are contributing a new authored "How To" article, [this template](https://github.com/dapr/docs/blob/master/contributing/howto-template.md) was created to assist you.

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The "Sending Messages to Output Bindings" link was listed in the TOC but is not present

## Issue reference

N/A
