### PR TITLE
Update secret query example in namespace support

### DIFF
--- a/daprdocs/content/en/reference/api/secrets_api.md
+++ b/daprdocs/content/en/reference/api/secrets_api.md
@@ -100,3 +100,9 @@ curl http://localhost:3500/v1.0/secrets/vault/db-secret \
 ```shell
 curl http://localhost:3500/v1.0/secrets/vault/db-secret?metadata.version_id=15&metadata.version_stage=AAA \
 ```
+
+> Note, in case of deploying into namespace other than  default`, the above query will also have to include the namespace metadata (e.g. `production` below)
+
+```shell
+curl http://localhost:3500/v1.0/secrets/vault/db-secret?metadata.version_id=15&?metadata.namespace=production
+```


### PR DESCRIPTION
When deploying to namespace other than default the secret query must include namespace metadata

Example:

```shell
curl -i "http://localhost:3500/v1.0/secrets/kubernetes/test-secret?metadata.namespace=hardened"
```