### PR TITLE
Amolenk/pubsubconsumerids

### DIFF
--- a/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-nats-streaming.md
+++ b/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-nats-streaming.md
@@ -66,9 +66,6 @@ spec:
     # value: "" # Optional. See: https://docs.nats.io/developing-with-nats-streaming/acks#acknowledgements
   # - name: maxInFlight
     # value: "" # Optional. See: https://docs.nats.io/developing-with-nats-streaming/acks#acknowledgements
-    # blow two, consumerID and durableSubscriptionName always uncomment together. See: More info: https://docs.nats.io/nats-streaming-concepts/client-connections
-  # - name: consumerID
-    # value: <REPLACE-WITH-consumerID> # Optional. Any String would be accept. 
   # - name: durableSubscriptionName
   #   value: ""
   # following subscription options - only one can be used

--- a/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-rabbitmq.md
+++ b/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-rabbitmq.md
@@ -55,8 +55,6 @@ spec:
   metadata:
   - name: host
     value: <REPLACE-WITH-HOST> # Required. Example: "amqp://rabbitmq.default.svc.cluster.local:5672", "amqp://localhost:5672"
-  - name: consumerID
-    value: <REPLACE-WITH-CONSUMER-ID> # Required. Any unique ID. Example: "myConsumerID"
   - name: durable
     value: <REPLACE-WITH-DURABLE> # Optional. Default: "false"
   - name: deletedWhenUnused


### PR DESCRIPTION
## Description

For the pub/sub building block components, the consumerID is always set to the application id by the runtime. Therefore, the consumerID property should be removed from configuration samples that still include it.

## Issue reference

This PR will close https://github.com/dapr/components-contrib/issues/521
