### PR TITLE
fix website pubsub api docs to 0.11.0 tag content

### DIFF
--- a/daprdocs/content/en/reference/api/pubsub_api.md
+++ b/daprdocs/content/en/reference/api/pubsub_api.md
@@ -101,8 +101,7 @@ path | route path from the subscription configuration
 
 #### Expected HTTP Response
 
-An HTTP 2xx response denotes successful processing of message.
-For richer response handling, a JSON encoded payload body with the processing status can be sent:
+An HTTP 200 response with JSON encoded payload body with the processing status:
 
 ```json
 {
@@ -115,9 +114,8 @@ Status | Description
 SUCCESS | message is processed successfully
 RETRY | message to be retried by Dapr
 DROP | warning is logged and message is dropped
-Others | error, message to be retried by Dapr
 
-Dapr assumes a JSON encoded payload response without `status` field or an empty payload responses with HTTP 2xx, as `SUCCESS`.
+For empty payload responses in HTTP 2xx, Dapr assumes `SUCCESS`.
 
 The HTTP response might be different from HTTP 2xx, the following are Dapr's behavior in different HTTP statuses:
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

If you are a new contributor, please see the [this contribution guidance](https://docs.dapr.io/contributing/contributing-docs/) which helps keep the Dapr documentation readable, consistent and useful for Dapr users.

Note that you must see that the suggested changes do not break the website [docs.dapr.io](https://docs.dapr.io). See [this overview](https://github.com/dapr/docs/blob/master/README.md#overview) on how to setup a local version of the website and make sure the website is built correctly.

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Synchronize website content to 0.11.0 tag
From https://github.com/dapr/docs/blob/v0.11.0/reference/api/pubsub_api.md#expected-http-response

## Issue reference

_Please reference the issue this PR will close: #[issue number]_
