### PR TITLE
Add skip upload if missing token

### DIFF
--- a/.github/workflows/azure-static-web-apps-green-hill-0d7377310.yml
+++ b/.github/workflows/azure-static-web-apps-green-hill-0d7377310.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GREEN_HILL_0D7377310 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          skip_deploy_on_missing_secrets: true
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match you app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
@@ -48,4 +49,5 @@ jobs:
         uses: Azure/static-web-apps-deploy@v0.0.1-preview
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GREEN_HILL_0D7377310 }}
+          skip_deploy_on_missing_secrets: true
           action: "close"


### PR DESCRIPTION
Adding config so upload is slipped if the PR submitter is not a collaborator and doesn't have access to repo secrets.