### PR TITLE
Middleware pipelines: Fix link in next step section

### DIFF
--- a/daprdocs/content/en/concepts/middleware-concept.md
+++ b/daprdocs/content/en/concepts/middleware-concept.md
@@ -58,9 +58,9 @@ func GetHandler(metadata Metadata) fasthttp.RequestHandler {
 ```
 
 ## Adding new middleware components
-Your middleware component can be contributed to the [components-contrib repository](https://github.com/dapr/components-contrib/tree/master/middleware). 
+Your middleware component can be contributed to the [components-contrib repository](https://github.com/dapr/components-contrib/tree/master/middleware).
 
 Then submit another pull request against the [Dapr runtime repository](https://github.com/dapr/dapr) to register the new middleware type. You'll need to modify the **Load()** method in [registry.go]( https://github.com/dapr/dapr/blob/master/pkg/components/middleware/http/registry.go) to register your middleware using the **Register** method.
 
 ## Next steps
-* [How-To: Configure API authorization with OAuth({{< ref oauth.md >}})
+* [How-To: Configure API authorization with OAuth]({{< ref oauth.md >}})


### PR DESCRIPTION
## Description

This is a minor fix to the broken link in the middleware pipelines page.

Currently shows up as
[How-To: Configure API authorization with OAuth(https://docs.dapr.io/operations/security/oauth/)
instead of
[How-To: Configure API authorization with OAuth](https://docs.dapr.io/operations/security/oauth/)