### PR TITLE
Point to discord instead of gitter

### DIFF
--- a/daprdocs/config.toml
+++ b/daprdocs/config.toml
@@ -111,9 +111,9 @@ sidebar_search_disable = true
 	icon = "fab fa-github"
   desc = "Development takes place here!"
 [[params.links.developer]]
-	name = "Gitter"
-	url = "https://gitter.im/Dapr/community"
-	icon = "fab fa-gitter"
+	name = "Discord"
+	url = "https://aka.ms/dapr-discord"
+	icon = "fab fa-discord"
   desc = "Conversations happen here!"
 [[params.links.developer]]
 	name = "Zoom"


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

## Description

Updated the reference to gitter in config.toml to use discord.

## Issue reference

None <!-- _Please reference the issue this PR will close: #[issue number]_ -->
