### PR TITLE
Added missing word

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/query-state-store/query-redis-store.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/query-state-store/query-redis-store.md
@@ -6,7 +6,7 @@ weight: 2000
 description: "Use Redis as a backend state store"
 ---
 
-Dapr doesn't transform state values while saving and retrieving states. Dapr requires all state store implementations to abide by a certain key format scheme (see [Dapr state management spec]({{<ref state_api.md>}}). You can directly interact with the underlying store to manipulate the state data, such querying states, creating aggregated views and making backups.
+Dapr doesn't transform state values while saving and retrieving states. Dapr requires all state store implementations to abide by a certain key format scheme (see [Dapr state management spec]({{<ref state_api.md>}}). You can directly interact with the underlying store to manipulate the state data, such as querying states, creating aggregated views and making backups.
 
 >**NOTE:** The following examples uses Redis CLI against a Redis store using the default Dapr state store implementation.
 


### PR DESCRIPTION
I changed "such querying states" to "such as querying states" by adding the word 'as'.