### PR TITLE
Document use of Content-Type as datacontenttype in pubsub.

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-publish-subscribe.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-publish-subscribe.md
@@ -308,7 +308,7 @@ Invoke-RestMethod -Method Post -ContentType 'application/json' -Body '{"status":
 
 {{< /tabs >}}
 
-Dapr automatically wraps the user payload in a Cloud Events v1.0 compliant envelope.
+Dapr automatically wraps the user payload in a Cloud Events v1.0 compliant envelope, using `Content-Type` header value for `datacontenttype` attribute.
 
 ## Step 4: ACK-ing a message
 

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-overview.md
@@ -33,7 +33,7 @@ When multiple instances of the same application ID subscribe to a topic, Dapr wi
 
 ### Cloud events
 
-Dapr follows the [CloudEvents 1.0 Spec](https://github.com/cloudevents/spec/tree/v1.0) and wraps any payload sent to a topic inside a Cloud Events envelope.
+Dapr follows the [CloudEvents 1.0 Spec](https://github.com/cloudevents/spec/tree/v1.0) and wraps any payload sent to a topic inside a Cloud Events envelope, using `Content-Type` header value for `datacontenttype` attribute.
 
 The following fields from the Cloud Events spec are implemented with Dapr:
 - `id`


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

If you are a new contributor, please see the [this contribution guidance](https://docs.dapr.io/contributing/contributing-docs/) which helps keep the Dapr documentation readable, consistent and useful for Dapr users.

Note that you must see that the suggested changes do not break the website [docs.dapr.io](https://docs.dapr.io). See [this overview](https://github.com/dapr/docs/blob/master/README.md#overview) on how to setup a local version of the website and make sure the website is built correctly.

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Document use of Content-Type as datacontenttype in pubsub.

## Issue reference

_Please reference the issue this PR will close: #998 
