### PR TITLE
Update cli ref for publish command.

### DIFF
--- a/daprdocs/content/en/reference/cli/dapr-publish.md
+++ b/daprdocs/content/en/reference/cli/dapr-publish.md
@@ -19,7 +19,7 @@ dapr publish [flags]
 
 | Name | Environment Variable | Default | Description
 | --- | --- | --- | --- |
-| `--publish-app-id` | `-i`| | The id for publishing application
+| `--publish-app-id` | `-i`| | The ID that represents the app from which you are publishing
 | `--pubsub` | `-p` | | The name of the pub/sub component
 | `--topic`, `-t` | | | The topic to be published to |
 | `--data`, `-d` | | | The JSON serialized string (optional) |

--- a/daprdocs/content/en/reference/cli/dapr-publish.md
+++ b/daprdocs/content/en/reference/cli/dapr-publish.md
@@ -19,7 +19,8 @@ dapr publish [flags]
 
 | Name | Environment Variable | Default | Description
 | --- | --- | --- | --- |
+| `--publish-app-id` | `-i`| | The id for publishing application
+| `--pubsub` | `-p` | | The name of the pub/sub component
+| `--topic`, `-t` | | | The topic to be published to |
 | `--data`, `-d` | | | The JSON serialized string (optional) |
 | `--help`, `-h` | | | Print this help message |
-| `--pubsub` | | | The name of the pub/sub component
-| `--topic`, `-t` | | | The topic to be published to |


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

If you are a new contributor, please see the [this contribution guidance](https://docs.dapr.io/contributing/contributing-docs/) which helps keep the Dapr documentation readable, consistent and useful for Dapr users.

Note that you must see that the suggested changes do not break the website [docs.dapr.io](https://docs.dapr.io). See [this overview](https://github.com/dapr/docs/blob/master/README.md#overview) on how to setup a local version of the website and make sure the website is built correctly.

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Update cli ref for publish command, adding publish-app-id.

## Issue reference

_Please reference the issue this PR will close: https://github.com/dapr/cli/issues/536
