### PR TITLE
Fix typo

### DIFF
--- a/daprdocs/content/en/operations/components/component-scopes.md
+++ b/daprdocs/content/en/operations/components/component-scopes.md
@@ -30,7 +30,7 @@ spec:
 
 In this example, the Redis component is only accessible to Dapr instances running inside the `production` namespace.
 
-### Example of component namsespacing in self-hosted mode
+### Example of component namespacing in self-hosted mode
 
 In self hosted mode, a developer can specify the namespace to a Dapr instance by setting the `NAMESPACE` environment variable.
 If the `NAMESPACE` environment variable is set, Dapr will not load any component that does not specify the same namespace in its metadata.


### PR DESCRIPTION
## Description

Fix typo in `namespacing`
