### PR TITLE
Updating notes for rc.2

### DIFF
--- a/daprdocs/content/en/_index.md
+++ b/daprdocs/content/en/_index.md
@@ -6,6 +6,6 @@ type: docs
 
 Welcome to the Dapr documentation site!
 
-{{% alert title="New Release Candidate" color="primary" %}}
-[v1.0-rc.1 is now available](https://github.com/dapr/dapr/releases/tag/v1.0.0-rc.1) to download and test as part of our upcoming v1.0 release. Visit the [v1.0-rc.1 docs](https://v1-rc1.docs.dapr.io/getting-started/install-dapr/#install-the-dapr-cli) to upgrade and try it out.
+{{% alert title="New release candidate" color="primary" %}}
+v1.0-rc.2 preview is now available to download and test as part of the upcoming Dapr v1.0 release. Visit the [v1.0-rc.2 version of the docs](https://v1-rc2.docs.dapr.io) if you would like to upgrade and use the latest preview version.
 {{% /alert %}}

--- a/daprdocs/content/en/getting-started/install-dapr-cli.md
+++ b/daprdocs/content/en/getting-started/install-dapr-cli.md
@@ -11,7 +11,7 @@ description: "Install the Dapr CLI to get started with Dapr"
 Begin by downloading and installing the Dapr CLI for v0.11. This is used to initialize your environment on your desired platform.
 
 {{% alert title="Note" color="warning" %}}
-This command downloads and install Dapr CLI v0.11. To install v1.0-rc2, our latest preview release prior to the release of the [upcoming v1.0 release](https://blog.dapr.io/posts/2020/10/20/the-path-to-v.1.0-production-ready-dapr/), please visit the [v1.0-rc1 docs](https://v1-rc1.docs.dapr.io).
+This command downloads and install Dapr CLI v0.11. To install the latest preview release, please visit the [v1.0-rc2 version of this page](https://v1-rc2.docs.dapr.io/getting-started/install-dapr-cli/).
 {{% /alert %}}
 
 {{< tabs Linux Windows MacOS Binaries>}}

--- a/daprdocs/content/en/getting-started/install-dapr-kubernetes.md
+++ b/daprdocs/content/en/getting-started/install-dapr-kubernetes.md
@@ -40,7 +40,7 @@ Both the Dapr CLI and the Dapr Helm chart automatically deploy with affinity for
 You can install Dapr to a Kubernetes cluster using the [Dapr CLI]({{< ref install-dapr-cli.md >}}).
 
 {{% alert title="Release candidate" color="warning" %}}
-This command downloads and install Dapr runtime v0.11. To install v1.0-rc1, the latest release prior to the release candidates for the [upcoming v1.0 release](https://blog.dapr.io/posts/2020/10/20/the-path-to-v.1.0-production-ready-dapr/), please visit the [v1.0-rc1 docs](https://v1-rc1.docs.dapr.io).
+This command downloads and installs Dapr runtime v0.11. To install v1.0-rc2 preview, the release candidate for the upcoming v1.0 release please visit the [v1.0-rc2 docs version of this page](https://v1-rc1.docs.dapr.io/getting-started/install-dapr-kubernetes/). Note you will need to ensure you are also using the preview version of the CLI (instructions to install the latest preview CLI can be found [here](https://v1-rc2.docs.dapr.io/getting-started/install-dapr-cli/)).
 {{% /alert %}}
 
 ### Install Dapr

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -23,7 +23,7 @@ This step installs the latest Dapr Docker containers and setup a developer envir
 - For Windows Dapr is initialized to `%USERPROFILE%\.dapr\`
 
 {{% alert title="Note" color="warning" %}}
-This command downloads and installs Dapr runtime v0.11. To install v1.0-rc1, the release candidates for the [upcoming v1.0 release](https://blog.dapr.io/posts/2020/10/20/the-path-to-v.1.0-production-ready-dapr/), please visit the [v1.0-rc1 docs](https://v1-rc1.docs.dapr.io).
+This command downloads and installs Dapr runtime v0.11. To install v1.0-rc2 preview, the release candidate for the upcoming v1.0 release please visit the [v1.0-rc2 docs version of this page](https://v1-rc1.docs.dapr.io/getting-started/install-dapr-selfhost/). Note you will need to ensure you are also using the preview version of the CLI (instructions to install the latest preview CLI can be found [here](https://v1-rc2.docs.dapr.io/getting-started/install-dapr-cli/)).
 {{% /alert %}}
 
 1. Ensure you are in an elevated terminal:


### PR DESCRIPTION
**DO NOT MERGE UNTIL RC.2 RELEASE**

## Description
- Update notes to rc.2
- Keeping a single link for a clearer CTA
- Links updated to the context of the note (same page but in the rc version)


## Issue reference

Closes #1029 
