### PR TITLE
Add state prefix how-to

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state copy.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state copy.md
@@ -1,0 +1,95 @@
+---
+type: docs
+title: "How-To: Change a state sharing strategy"
+linkTitle: "How-To: Change a state sharing strategy"
+weight: 400
+description: "Choose a strategy for sharing state between different applications"
+---
+
+## Introduction
+
+Dapr offers developers differnet ways to share state between applications.
+
+Different architectures might have different needs when it comes to sharing state. For example, in one scenario you many want to encapsulate all state within a given application and have Dapr manage the access for you. In a different scenario, you may need to have two applications working on the same state be able to get and save the same keys.
+
+To enable state sharing, Dapr supports the following key prefixes settings, set on Dapr Component:
+
+* `appid` - This is the default strategy. the `appid` prefix allows state to be managed only by the app with the specified `appid`. All state keys will be prefixed with the `appid`.
+
+* `name` - This setting uses the name of the state store component as the prefix.
+
+* `none` - This setting uses no prefixing.
+
+## Specifying a state prefix strategy
+
+To specify a prefix strategy, add a metadata key named `keyPrefix` on a state component:
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+  namespace: production
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: keyPrefix
+    value: <key-prefix-strategy>
+```
+
+## Examples
+
+The following examples will show you how state retrieval looks like with each of the supported prefix strategies:
+
+### `appid` prefix strategy (Default)
+
+A Dapr application with app id `myApp` is saving state into a state store named `redis`:
+
+```shell
+curl -X POST http://localhost:3500/v1.0/state/redis \
+  -H "Content-Type: application/json"
+  -d '[
+        {
+          "key": "darth",
+          "value": "nihilus"
+        }
+      ]'
+```
+
+The key will be saved as `myApp||darth`.
+
+### `name` prefix strategy
+
+A Dapr application with app id `myApp` is saving state into a state store named `redis`:
+
+```shell
+curl -X POST http://localhost:3500/v1.0/state/redis \
+  -H "Content-Type: application/json"
+  -d '[
+        {
+          "key": "darth",
+          "value": "nihilus"
+        }
+      ]'
+```
+
+The key will be saved as `redis||darth`.
+
+### `none` prefix strategy
+
+A Dapr application with app id `myApp` is saving state into a state store named `redis`:
+
+```shell
+curl -X POST http://localhost:3500/v1.0/state/redis \
+  -H "Content-Type: application/json"
+  -d '[
+        {
+          "key": "darth",
+          "value": "nihilus"
+        }
+      ]'
+```
+
+The key will be saved as `darth`.
+

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state copy.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state copy.md
@@ -12,7 +12,7 @@ Dapr offers developers differnet ways to share state between applications.
 
 Different architectures might have different needs when it comes to sharing state. For example, in one scenario you many want to encapsulate all state within a given application and have Dapr manage the access for you. In a different scenario, you may need to have two applications working on the same state be able to get and save the same keys.
 
-To enable state sharing, Dapr supports the following key prefixes settings, set on Dapr component:
+To enable state sharing, Dapr supports the following key prefixes settings:
 
 * `appid` - This is the default strategy. the `appid` prefix allows state to be managed only by the app with the specified `appid`. All state keys will be prefixed with the `appid`.
 

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state copy.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state copy.md
@@ -12,7 +12,7 @@ Dapr offers developers differnet ways to share state between applications.
 
 Different architectures might have different needs when it comes to sharing state. For example, in one scenario you many want to encapsulate all state within a given application and have Dapr manage the access for you. In a different scenario, you may need to have two applications working on the same state be able to get and save the same keys.
 
-To enable state sharing, Dapr supports the following key prefixes settings, set on Dapr Component:
+To enable state sharing, Dapr supports the following key prefixes settings, set on Dapr component:
 
 * `appid` - This is the default strategy. the `appid` prefix allows state to be managed only by the app with the specified `appid`. All state keys will be prefixed with the `appid`.
 

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
@@ -1,9 +1,9 @@
 ---
 type: docs
-title: "How-To: Change a state sharing strategy"
-linkTitle: "How-To: Change a state sharing strategy"
+title: "How-To: Share state between applications"
+linkTitle: "How-To: CShare state between applications"
 weight: 400
-description: "Choose a strategy for sharing state between different applications"
+description: "Choose different strategies for sharing state between different applications"
 ---
 
 ## Introduction

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
@@ -1,7 +1,7 @@
 ---
 type: docs
 title: "How-To: Share state between applications"
-linkTitle: "How-To: CShare state between applications"
+linkTitle: "How-To: Share state between applications"
 weight: 400
 description: "Choose different strategies for sharing state between different applications"
 ---

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
@@ -14,11 +14,11 @@ Different architectures might have different needs when it comes to sharing stat
 
 To enable state sharing, Dapr supports the following key prefixes strategies:
 
-* `appid` - This is the default strategy. the `appid` prefix allows state to be managed only by the app with the specified `appid`. All state keys will be prefixed with the `appid`, and are scoped for the application.
+* **`appid`** - This is the default strategy. the `appid` prefix allows state to be managed only by the app with the specified `appid`. All state keys will be prefixed with the `appid`, and are scoped for the application.
 
-* `name` - This setting uses the name of the state store component as the prefix. Multiple applications can share the same state for a given state store.
+* **`name`** - This setting uses the name of the state store component as the prefix. Multiple applications can share the same state for a given state store.
 
-* `none` - This setting uses no prefixing. Multiple applications share state across different state stores.
+* **`none`** - This setting uses no prefixing. Multiple applications share state across different state stores.
 
 ## Specifying a state prefix strategy
 
@@ -42,7 +42,7 @@ spec:
 
 The following examples will show you how state retrieval looks like with each of the supported prefix strategies:
 
-### `appid` prefix strategy (Default)
+### `appid` (default)
 
 A Dapr application with app id `myApp` is saving state into a state store named `redis`:
 
@@ -59,7 +59,7 @@ curl -X POST http://localhost:3500/v1.0/state/redis \
 
 The key will be saved as `myApp||darth`.
 
-### `name` prefix strategy
+### `name`
 
 A Dapr application with app id `myApp` is saving state into a state store named `redis`:
 
@@ -76,7 +76,7 @@ curl -X POST http://localhost:3500/v1.0/state/redis \
 
 The key will be saved as `redis||darth`.
 
-### `none` prefix strategy
+### `none`
 
 A Dapr application with app id `myApp` is saving state into a state store named `redis`:
 

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
@@ -8,11 +8,11 @@ description: "Choose a strategy for sharing state between different applications
 
 ## Introduction
 
-Dapr offers developers differnet ways to share state between applications.
+Dapr offers developers different ways to share state between applications.
 
-Different architectures might have different needs when it comes to sharing state. For example, in one scenario you many want to encapsulate all state within a given application and have Dapr manage the access for you. In a different scenario, you may need to have two applications working on the same state be able to get and save the same keys.
+Different architectures might have different needs when it comes to sharing state. For example, in one scenario you may want to encapsulate all state within a given application and have Dapr manage the access for you. In a different scenario, you may need to have two applications working on the same state be able to get and save the same keys.
 
-To enable state sharing, Dapr supports the following key prefixes settings:
+To enable state sharing, Dapr supports the following key prefixes strategies:
 
 * `appid` - This is the default strategy. the `appid` prefix allows state to be managed only by the app with the specified `appid`. All state keys will be prefixed with the `appid`.
 

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-share-state.md
@@ -14,11 +14,11 @@ Different architectures might have different needs when it comes to sharing stat
 
 To enable state sharing, Dapr supports the following key prefixes strategies:
 
-* `appid` - This is the default strategy. the `appid` prefix allows state to be managed only by the app with the specified `appid`. All state keys will be prefixed with the `appid`.
+* `appid` - This is the default strategy. the `appid` prefix allows state to be managed only by the app with the specified `appid`. All state keys will be prefixed with the `appid`, and are scoped for the application.
 
-* `name` - This setting uses the name of the state store component as the prefix.
+* `name` - This setting uses the name of the state store component as the prefix. Multiple applications can share the same state for a given state store.
 
-* `none` - This setting uses no prefixing.
+* `none` - This setting uses no prefixing. Multiple applications share state across different state stores.
 
 ## Specifying a state prefix strategy
 

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/query-state-store/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/query-state-store/_index.md
@@ -2,7 +2,7 @@
 type: docs
 title: "Work with backend state stores"
 linkTitle: "Backend stores"
-weight: 400
+weight: 500
 description: "Guides for working with specific backend states stores"
 ---
 


### PR DESCRIPTION
This PR adds information for a new feature that enables developers to set a key prefix for a state store.