### PR TITLE
Fixing dapr run command in rc.2 how to get state doc

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
@@ -42,7 +42,7 @@ The following example shows how to save two key/value pairs in a single call usi
 {{% codetab %}}
 Begin by ensuring a Dapr sidecar is running:
 ```bash
-dapr run --app-id myapp --dapr-http-port 3500 run
+dapr run --app-id myapp --dapr-http-port 3500
 ```
 {{% alert title="Note" color="info" %}}
 It is important to set an app-id, as the state keys are prefixed with this value. If you don't set it one is generated for you at runtime, and the next time you run the command a new one will be generated and you will no longer be able to access previously saved state.

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
@@ -42,7 +42,7 @@ The following example shows how to save two key/value pairs in a single call usi
 {{% codetab %}}
 Begin by ensuring a Dapr sidecar is running:
 ```bash
-dapr --app-id myapp --port 3500 run
+dapr run --app-id myapp --dapr-http-port 3500 run
 ```
 {{% alert title="Note" color="info" %}}
 It is important to set an app-id, as the state keys are prefixed with this value. If you don't set it one is generated for you at runtime, and the next time you run the command a new one will be generated and you will no longer be able to access previously saved state.


### PR DESCRIPTION
Fixing dapr run command

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Fixing dapr run command

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
closes #1052 