### PR TITLE
Alphabetically order Microsoft Azure bindings

### DIFF
--- a/daprdocs/content/en/operations/components/setup-bindings/supported-bindings/_index.md
+++ b/daprdocs/content/en/operations/components/setup-bindings/supported-bindings/_index.md
@@ -49,9 +49,9 @@ Every binding has its own unique set of properties. Click the name link to see t
 | Name | Input<br>Binding | Output<br>Binding | Status |
 |------|:----------------:|:-----------------:|--------|
 | [Azure Blob Storage]({{< ref blobstorage.md >}})            |    | ✅ | Experimental |
-| [Azure EventHubs]({{< ref eventhubs.md >}})                 | ✅ | ✅ | Experimental |
 | [Azure CosmosDB]({{< ref cosmosdb.md >}})                   |    | ✅ | Experimental |
+| [Azure Event Grid]({{< ref eventgrid.md >}})                | ✅ | ✅ | Experimental |
+| [Azure Event Hubs]({{< ref eventhubs.md >}})                 | ✅ | ✅ | Experimental |
 | [Azure Service Bus Queues]({{< ref servicebusqueues.md >}}) | ✅ | ✅ | Experimental |
 | [Azure SignalR]({{< ref signalr.md >}})                     |    | ✅ | Experimental |
 | [Azure Storage Queues]({{< ref storagequeues.md >}})        | ✅ | ✅ | Experimental |
-| [Azure Event Grid]({{< ref eventgrid.md >}})                | ✅ | ✅ | Experimental |


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

- Alphabetically order Microsoft Azure bindings
- Change `EventHubs` to `Event Hubs`

## Issue reference

N/A
