### PR TITLE
Fix typo in Kubernetes binding docs

### DIFF
--- a/daprdocs/content/en/operations/components/setup-bindings/supported-bindings/kubernetes-binding.md
+++ b/daprdocs/content/en/operations/components/setup-bindings/supported-bindings/kubernetes-binding.md
@@ -63,7 +63,7 @@ Three different event types are available:
 - Delete : Only the `oldVal` field is populated, `newVal` field is an empty `v1.Event`, `event` is `delete`
 - Update : Both the `oldVal` and `newVal` fields are populated,  `event` is `update`
 
-## Required permisiions
+## Required permissions
 
 For consuming `events` from Kubernetes, permissions need to be assigned to a User/Group/ServiceAccount using [RBAC Auth] mechanism of Kubernetes.
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fix typo in Kubernetes binding docs.

## Issue reference

N/A