### PR TITLE
Add a note about installing rosetta amd64 compatibility layer on M1 macs

### DIFF
--- a/daprdocs/content/en/getting-started/install-dapr-cli.md
+++ b/daprdocs/content/en/getting-started/install-dapr-cli.md
@@ -41,6 +41,17 @@ Or you can install via [Homebrew](https://brew.sh):
 ```bash
 brew install dapr/tap/dapr-cli@1.0.0-rc.3
 ```
+
+{{% alert title="Note for M1 Macs" color="primary" %}}
+For M1 Macs, homebrew is not supported. You will need to use the dapr install script and have the rosetta amd64 compatibility layer installed. If you do not have it installed already, you can run the following:
+
+```bash
+softwareupdate --install-rosetta
+```
+
+{{% /alert %}}
+
+
 {{% /codetab %}}
 
 {{% codetab %}}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Added a note regarding install requirements for M1 macs.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
close: #1064