### PR TITLE
Update Secrets API reference

### DIFF
--- a/daprdocs/content/en/reference/api/secrets_api.md
+++ b/daprdocs/content/en/reference/api/secrets_api.md
@@ -132,9 +132,9 @@ secret-store-name | the name of the secret store to get the secret from
 
 #### Response Body
 
-The returned response is a JSON containing the secrets. The JSON object will contain the secret keys as fields and the secret value as the field value.
+The returned response is a JSON containing the secrets. The JSON object will contain the secret names as fields and a map of secret keys and values as the field value.
 
-##### Response with multiple keys in a secret (eg. Kubernetes): 
+##### Response with multiple secrets and multiple key / values in a secret (eg. Kubernetes): 
 
 ```shell
 curl http://localhost:3500/v1.0/secrets/kubernetes/bulk
@@ -142,8 +142,14 @@ curl http://localhost:3500/v1.0/secrets/kubernetes/bulk
 
 ```json
 {
-  "key1": "value1",
-  "key2": "value2"
+    "secret1": {
+        "key1": "value1",
+        "key2": "value2"
+    },
+    "secret2": {
+        "key3": "value3",
+        "key4": "value4"
+    }
 }
 ```
 
@@ -160,9 +166,15 @@ Code | Description
 
 ```shell
 curl http://localhost:3500/v1.0/secrets/vault/bulk \
+```
 
+```json
 {
-  "key1": "value1",
-  "key2": "value2"
+    "key1": {
+        "key1": "value1"
+    },
+    "key2": {
+        "key2": "value2"
+    }
 }
 ```


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Bulk Secrets API now returns  `map[string]map[string]string`

Context:
https://github.com/dapr/components-contrib/issues/590
https://github.com/dapr/dapr/issues/2652

## Issue reference

Please reference the issue this PR will close: #1089