### PR TITLE
Update OpenTelemetry Collector to not use queued_retry processor

### DIFF
--- a/daprdocs/static/docs/open-telemetry-collector/open-telemetry-collector.yaml
+++ b/daprdocs/static/docs/open-telemetry-collector/open-telemetry-collector.yaml
@@ -10,9 +10,6 @@ data:
     receivers:
       zipkin:
         endpoint: 0.0.0.0:9411
-    processors:
-      queued_retry:
-      batch:
     extensions:
       health_check:
       pprof:
@@ -37,7 +34,6 @@ data:
         traces:
           receivers: [zipkin]
           exporters: [azuremonitor,logging]
-          processors: [batch, queued_retry]
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description

Update OpenTelemetry Collector to not use queued_retry processor: The `queued_retry` processor has been deprecated, and we didn't use and retry settings. We remove it here to avoid errors with the latest version of the OpenTelemetry Collector agent.


## Issue reference

Fixes https://github.com/dapr/docs/issues/1124