### PR TITLE
Fix Issue 1128 -- pfx file path guidance for the az kv secret store

### DIFF
--- a/daprdocs/content/en/operations/components/setup-secret-store/supported-secret-stores/azure-keyvault.md
+++ b/daprdocs/content/en/operations/components/setup-secret-store/supported-secret-stores/azure-keyvault.md
@@ -111,10 +111,15 @@ Azure Managed Identity can be used for Azure Key Vault access on Kubernetes. Ins
       - name: spnClientId
         value: "[your_service_principal_app_id]"
       - name: spnCertificateFile
-        value : "[pfx_certificate_file_local_path]"
+        value : "[pfx_certificate_file_fully_qualified_local_path]"
     ```
 
 Fill in the metadata fields with your Key Vault details from the above setup process.
+
+For Windows systems the [pfx_certificate_file_fully_qualified_local_path] value must use escaped backslashes, i.e. double backshashes, instead of a forward slash.
+On Linix C:/something/somethingelse/ttt.pfx will work.
+On Windows C:\\something\\somethingelse\\ttt.pfx will work. 
+
 {{% /codetab %}}
 
 {{% codetab %}}

--- a/daprdocs/content/en/operations/components/setup-secret-store/supported-secret-stores/azure-keyvault.md
+++ b/daprdocs/content/en/operations/components/setup-secret-store/supported-secret-stores/azure-keyvault.md
@@ -119,7 +119,6 @@ Fill in the metadata fields with your Key Vault details from the above setup pro
 For Windows systems the [pfx_certificate_file_fully_qualified_local_path] value must use escaped backslashes, i.e. double backshashes, instead of a forward slash.
 On Linix C:/something/somethingelse/ttt.pfx will work.
 On Windows C:\\something\\somethingelse\\ttt.pfx will work. 
-
 {{% /codetab %}}
 
 {{% codetab %}}

--- a/daprdocs/content/en/operations/components/setup-secret-store/supported-secret-stores/azure-keyvault.md
+++ b/daprdocs/content/en/operations/components/setup-secret-store/supported-secret-stores/azure-keyvault.md
@@ -116,21 +116,25 @@ Azure Managed Identity can be used for Azure Key Vault access on Kubernetes. Ins
 
 Fill in the metadata fields with your Key Vault details from the above setup process.
 
-For Windows systems the [pfx_certificate_file_fully_qualified_local_path] value must use escaped backslashes, i.e. double backshashes, instead of a forward slash.
-On Linix C:/something/somethingelse/ttt.pfx will work.
-On Windows C:\\something\\somethingelse\\ttt.pfx will work. 
+For Windows systems the [pfx_certificate_file_fully_qualified_local_path] value must use escaped backslashes, i.e. double backshashes, instead of a forward slash as done with Linux.
+- On Linix /something/somethingelse/ttt.pfx will work.
+- On Windows C:\\\\something\\\\somethingelse\\\\ttt.pfx will work. 
 {{% /codetab %}}
 
 {{% codetab %}}
 In Kubernetes mode, you store the certificate for the service principal into the Kubernetes Secret Store and then enable Azure Key Vault secret store with this certificate in Kubernetes secretstore.
 
+In all below steps: For Windows systems the [pfx_certificate_file_fully_qualified_local_path] value must use escaped backslashes, i.e. double backshashes, instead of a forward slash as done with Linux.
+- On Linix /something/somethingelse/ttt.pfx will work.
+- On Windows C:\\\\something\\\\somethingelse\\\\ttt.pfx will work.
+
 1. Create a kubernetes secret using the following command:
 
    ```bash
-   kubectl create secret generic [your_k8s_spn_secret_name] --from-file=[pfx_certificate_file_local_path]
+   kubectl create secret generic [your_k8s_spn_secret_name] --from-file=[pfx_certificate_file_fully_qualified_local_path]
    ```
 
-- `[pfx_certificate_file_local_path]` is the path of PFX cert file you downloaded above
+- `[pfx_certificate_file_fully_qualified_local_path]` is the path of PFX cert file you downloaded above
 - `[your_k8s_spn_secret_name]` is secret name in Kubernetes secret store
 
 2. Create a `azurekeyvault.yaml` component file
@@ -156,10 +160,11 @@ spec:
   - name: spnCertificate
     secretKeyRef:
       name: [your_k8s_spn_secret_name]
-      key: [pfx_certificate_file_local_name]
+      key: [pfx_certificate_file_fully_qualified_local_path]
 auth:
     secretStore: kubernetes
 ```
+   Fill in the metadata fields with your Key Vault details from the above setup process.
 
 3. Apply `azurekeyvault.yaml` component
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

In the component definition for the Azure Key Vault:

First the value for [pfx_certificate_file_local_path] was changed to make it clear that is must be a fully qualified pathname, specifically changed to [pfx_certificate_file_fully_qualified_local_path].  This change was done to both the Self Hosted and Kubernetes tabs.

Second and finally, a notice was inserted defining the path name syntax that must be used, i.e. forward slashes for Linux and back slashes for Windows (each escaped with an additional backslash.).

I have personally tested the fully qualified path name with backslashes for Windows in Self Hosted mode and it works.  I have NOT tested this for Linux (since I do not have a Linux system) nor have I tested it in the Kubernetes tab (since I do not know how to use Kubernetes).  Please test this for me in these two situations.  Thanks.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
#1128
