### PR TITLE
Issue 1113 fixed

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/secrets/howto-secrets.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/secrets/howto-secrets.md
@@ -48,7 +48,7 @@ To configure a different kind of secret store see the guidance on [how to config
 Now run the Dapr sidecar (with no application)
 
 ```bash
-dapr run --app-id my-app --port 3500 --components-path ./components
+dapr run --app-id my-app --dapr-http-port 3500 --components-path ./components
 ```
 
 And now you can get the secret by calling the Dapr sidecar using the secrets API:


### PR DESCRIPTION
Changed the dapr run example shown in the doc so that the http port label is correct, replacing the old, out-of-date label.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

I changed a single "word" in the sample dapr run command:  Changed --port to --dapr-http-port.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
#1113
