### PR TITLE
streamline kubernetes getting started

### DIFF
--- a/daprdocs/content/en/getting-started/_index.md
+++ b/daprdocs/content/en/getting-started/_index.md
@@ -15,8 +15,6 @@ If you are looking for an introductory overview of Dapr and learn more about bas
 
 This guide will walk you through a series of steps to install, initialize and start using Dapr. The recommended way to get started with Dapr is to setup a local development environment (also referred to as [_self-hosted_ mode]({{< ref self-hosted >}})) which includes the Dapr CLI, Dapr sidecar binaries, and some default components that can help you start using Dapr quickly.
 
-If you want to install Dapr in Kubernetes, click [here]({{<ref kubernetes-deploy.md>}}).
-
 The following steps in this guide are:
 1. Install the Dapr CLI
 1. Initialize Dapr

--- a/daprdocs/content/en/getting-started/_index.md
+++ b/daprdocs/content/en/getting-started/_index.md
@@ -15,6 +15,8 @@ If you are looking for an introductory overview of Dapr and learn more about bas
 
 This guide will walk you through a series of steps to install, initialize and start using Dapr. The recommended way to get started with Dapr is to setup a local development environment (also referred to as [_self-hosted_ mode]({{< ref self-hosted >}})) which includes the Dapr CLI, Dapr sidecar binaries, and some default components that can help you start using Dapr quickly.
 
+If you want to install Dapr in Kubernetes, click [here]({{<ref kubernetes-deploy.md>}}).
+
 The following steps in this guide are:
 1. Install the Dapr CLI
 1. Initialize Dapr

--- a/daprdocs/content/en/operations/hosting/kubernetes/cluster/_index.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/cluster/_index.md
@@ -2,7 +2,7 @@
 type: docs
 title: "Kubernetes cluster setup"
 linkTitle: "How-to: Setup clusters"
-weight: 60000
+weight: 70000
 description: >
   How to create a Kubernetes cluster
 ---

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-annotations.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-annotations.md
@@ -2,7 +2,7 @@
 type: docs
 title: "Dapr Kubernetes pod annotations spec"
 linkTitle: "Kubernetes annotations"
-weight: 40000
+weight: 50000
 description: "The available annotations available when configuring Dapr in your Kubernetes environment"
 ---
 

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -4,9 +4,8 @@ title: "Deploy Dapr on a Kubernetes cluster"
 linkTitle: "Deploy Dapr"
 weight: 20000
 description: "Follow these steps to deploy Dapr on Kubernetes."
-aliases: [
-    "/getting-started/install-dapr-kubernetes/"
-]
+aliases:
+    - /getting-started/install-dapr-kubernetes/
 ---
 
 When setting up Kubernetes you can use either the Dapr CLI or Helm.

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -4,6 +4,9 @@ title: "Deploy Dapr on a Kubernetes cluster"
 linkTitle: "Deploy Dapr"
 weight: 20000
 description: "Follow these steps to deploy Dapr on Kubernetes."
+aliases = [
+    "/getting-started/install-dapr-kubernetes/"
+]
 ---
 
 When setting up Kubernetes you can use either the Dapr CLI or Helm.

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -4,7 +4,7 @@ title: "Deploy Dapr on a Kubernetes cluster"
 linkTitle: "Deploy Dapr"
 weight: 20000
 description: "Follow these steps to deploy Dapr on Kubernetes."
-aliases = [
+aliases: [
     "/getting-started/install-dapr-kubernetes/"
 ]
 ---

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -1,9 +1,9 @@
 ---
 type: docs
-title: "How-To: Install Dapr into a Kubernetes cluster"
-linkTitle: "(optional) Init Dapr on Kubernetes"
-weight: 70
-description: "Install Dapr in a Kubernetes cluster"
+title: "Deploy Dapr on a Kubernetes cluster"
+linkTitle: "Deploy Dapr"
+weight: 20000
+description: "Follow these steps to deploy Dapr on Kubernetes."
 ---
 
 When setting up Kubernetes you can use either the Dapr CLI or Helm.

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-hybrid-clusters.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-hybrid-clusters.md
@@ -1,8 +1,8 @@
 ---
 type: docs
-title: "How-To: Deploy to hybrid Linux/Windows Kubernetes clusters"
+title: "Deploy to hybrid Linux/Windows Kubernetes clusters"
 linkTitle: "Hybrid clusters"
-weight: 20000
+weight: 60000
 description: "How to run Dapr apps on Kubernetes clusters with windows nodes"
 ---
 

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
@@ -1,8 +1,8 @@
 ---
 type: docs
-title: "Guidelines for production ready deployments on Kubernetes"
+title: "Production guidelines on Kubernetes"
 linkTitle: "Production guidelines"
-weight: 10000
+weight: 40000
 description: "Recommendations and practices for deploying Dapr to a Kubernetes cluster in a production ready configuration"
 ---
 

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-upgrade.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-upgrade.md
@@ -57,7 +57,7 @@ From version 1.0.0-rc.3 onwards, upgrading Dapr using Helm is no longer a disrup
    kubectl rollout restart deploy/<DEPLOYMENT-NAME>
    ```
 
-4. All don!
+4. All done!
 
 ## Next steps
 

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-upgrade.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-upgrade.md
@@ -1,8 +1,8 @@
 ---
 type: docs
-title: "Steps to upgrade Dapr on a Kubernetes cluster"
+title: "Upgrade Dapr on a Kubernetes cluster"
 linkTitle: "Upgrade Dapr"
-weight: 50000
+weight: 30000
 description: "Follow these steps to upgrade Dapr on Kubernetes and ensure a smooth upgrade."
 ---
 
@@ -20,7 +20,10 @@ The example below shows how to upgrade to version 1.0.0-rc.3
   ```bash
   dapr upgrade -k --runtime-version=1.0.0-rc.3  
   ```
-  
+
+You can provide all the available Helm chart configurations using the Dapr CLI.
+See [here](https://github.com/dapr/cli#supplying-helm-values) for more info.
+
 ### Helm
 From version 1.0.0-rc.3 onwards, upgrading Dapr using Helm is no longer a disruptive action since existing certificate values will automatically be re-used.
 
@@ -31,7 +34,7 @@ From version 1.0.0-rc.3 onwards, upgrading Dapr using Helm is no longer a disrup
    ```
    
    ```bash
-   helm upgrade dapr dapr/dapr --version 1.0.0-rc.3 --namespace dapr-system --set global.ha.enabled=true --wait
+   helm upgrade dapr dapr/dapr --version 1.0.0-rc.3 --namespace dapr-system --wait
    ```
    *If you're using a values file, remember to add the `--values` option when running the upgrade command.*
 
@@ -43,17 +46,9 @@ From version 1.0.0-rc.3 onwards, upgrading Dapr using Helm is no longer a disrup
    NAME                                     READY   STATUS    RESTARTS   AGE
    dapr-dashboard-69f5c5c867-mqhg4          1/1     Running   0          42s
    dapr-operator-5cdd6b7f9c-9sl7g           1/1     Running   0          41s
-   dapr-operator-5cdd6b7f9c-jkzjs           1/1     Running   0          29s
-   dapr-operator-5cdd6b7f9c-qzp8n           1/1     Running   0          34s
    dapr-placement-server-0                  1/1     Running   0          41s
-   dapr-placement-server-1                  1/1     Running   0          41s
-   dapr-placement-server-2                  1/1     Running   0          41s
    dapr-sentry-84565c747b-7bh8h             1/1     Running   0          35s
-   dapr-sentry-84565c747b-fdlls             1/1     Running   0          41s
-   dapr-sentry-84565c747b-ldnsf             1/1     Running   0          29s
    dapr-sidecar-injector-68f868668f-6xnbt   1/1     Running   0          41s
-   dapr-sidecar-injector-68f868668f-j7jcq   1/1     Running   0          29s
-   dapr-sidecar-injector-68f868668f-ltxq4   1/1     Running   0          36s
    ```
 
 3. Restart your application deployments to update the Dapr runtime:
@@ -62,84 +57,7 @@ From version 1.0.0-rc.3 onwards, upgrading Dapr using Helm is no longer a disrup
    kubectl rollout restart deploy/<DEPLOYMENT-NAME>
    ```
 
-4. All done!
-
-
-## Upgrade existing cluster to 1.0.0-rc.2
-If you have an older Dapr version installed and want to upgrade to a version lower than 1.0.0-rc.3 (for example, upgrade from 0.11.1 to 1.0.0-rc.2), follow these steps:
-
-1. Run these two commands to prevent `helm upgrade` from uninstalling `0.11.x` placement service:
-
-   ```bash
-   kubectl annotate deployment dapr-placement helm.sh/resource-policy=keep -n dapr-system
-   ```
-   ```bash
-   kubectl annotate svc dapr-placement helm.sh/resource-policy=keep -n dapr-system
-   ```
-
-2. Export certificates: 
-
-   ```bash
-   dapr mtls export -o ./certs
-   ```
-
-3. Upgrade Dapr to 1.0.0-rc.2:
-
-   ```bash
-   helm repo update
-   ```
-   ```bash
-   helm upgrade dapr dapr/dapr --version 1.0.0-rc.2 --namespace dapr-system --reset-values --set-file dapr_sentry.tls.root.certPEM=./certs/ca.crt --set-file    dapr_sentry.tls.issuer.certPEM=./certs/issuer.crt --set-file dapr_sentry.tls.issuer.keyPEM=./certs/issuer.key --set global.ha.enabled=true --wait
-   ```
-
-4. Upgrade CRDs:
-
-   ```bash
-   kubectl replace -f https://raw.githubusercontent.com/dapr/dapr/21636a9237f2dcecd9c80f329e99b512e8377739/charts/dapr/crds/configuration.yaml
-   ```
-   ```bash
-   kubectl replace -f https://raw.githubusercontent.com/dapr/dapr/21636a9237f2dcecd9c80f329e99b512e8377739/charts/dapr/crds/components.yaml
-   ```
-
-5. Ensure 0.11.x dapr-placement service is still running and wait until all pods are running:
-
-   ```bash
-   kubectl get pods -n dapr-system -w
-   
-   NAME                                     READY   STATUS    RESTARTS   AGE
-   dapr-dashboard-69f5c5c867-mqhg4          1/1     Running   0          42s
-   dapr-operator-5cdd6b7f9c-9sl7g           1/1     Running   0          41s
-   dapr-operator-5cdd6b7f9c-jkzjs           1/1     Running   0          29s
-   dapr-operator-5cdd6b7f9c-qzp8n           1/1     Running   0          34s
-   dapr-placement-5dcb574777-nlq4t          1/1     Running   0          76s  <---- 0.11.x placement
-   dapr-placement-server-0                  1/1     Running   0          41s
-   dapr-placement-server-1                  1/1     Running   0          41s
-   dapr-placement-server-2                  1/1     Running   0          41s
-   dapr-sentry-84565c747b-7bh8h             1/1     Running   0          35s
-   dapr-sentry-84565c747b-fdlls             1/1     Running   0          41s
-   dapr-sentry-84565c747b-ldnsf             1/1     Running   0          29s
-   dapr-sidecar-injector-68f868668f-6xnbt   1/1     Running   0          41s
-   dapr-sidecar-injector-68f868668f-j7jcq   1/1     Running   0          29s
-   dapr-sidecar-injector-68f868668f-ltxq4   1/1     Running   0          36s
-   ```
-
-6. Restart your application deployments to update the Dapr runtime.
-
-   ```bash
-   kubectl rollout restart deploy/<DEPLOYMENT-NAME>
-   ```
-
-7. Once the deployment is completed, delete the 0.11.x dapr-placement service:
-
-   ```bash
-   kubectl delete deployment dapr-placement -n dapr-system
-   ```
-
-   ```bash
-   kubectl delete svc dapr-placement -n dapr-system
-   ```
-
-8. All done!
+4. All don!
 
 ## Next steps
 


### PR DESCRIPTION
This PR makes the getting started experience with Kubernetes better by:

1. Until now, the Kubernetes section under Operations was missing how to deploy Dapr to a cluster. The Kubernetes deploy section moved here.
2. Order of elements changed to have the most commonly used items prioritized.
3. Removes redundant rc.2 upgrade steps.