### PR TITLE
Update Method names for Python SDK example

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
@@ -273,10 +273,10 @@ with DaprClient() as d:
     s1 = StateItem(key="key1", value="value1")
     s2 = StateItem(key="key2", value="value2")
 
-    d.save_states(store_name="statestore", states=[s1,s2])
+    d.save_bulk_state(store_name="statestore", states=[s1,s2])
     print("States have been stored")
 
-    items = d.get_states(store_name="statestore", keys=["key1", "key2"]).items
+    items = d.get_bulk_state(store_name="statestore", keys=["key1", "key2"]).items
     print(f"Got items: {[i.data for i in items]}")
 ```
 
@@ -357,10 +357,10 @@ with DaprClient() as d:
     s1 = StateItem(key="key1", value="value1")
     s2 = StateItem(key="key2", value="value2")
 
-    d.save_states(store_name="statestore", states=[s1,s2])
+    d.save_bulk_state(store_name="statestore", states=[s1,s2])
     print("States have been stored")
 
-    d.execute_transaction(
+    d.execute_state_transaction(
         store_name="statestore",
         operations=[
             TransactionalStateOperation(key="key1", data="newValue1", operation_type=TransactionOperationType.upsert),
@@ -369,7 +369,7 @@ with DaprClient() as d:
     )
     print("State transactions have been completed")
 
-    items = d.get_states(store_name="statestore", keys=["key1", "key2"]).items
+    items = d.get_bulk_state(store_name="statestore", keys=["key1", "key2"]).items
     print(f"Got items: {[i.data for i in items]}")
 ```
 


### PR DESCRIPTION
The function names for saving, getting and executing transactions with multiple state items were incorrect for v1-rc3 in the current documentation.
I have updated them "save_bulk_state",  "get_bulk_state" and "execute_state_transaction".

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The codetabs for Python SDK were still using old function names "get_states", "save_states", "execute_transaction".
I updated them to "get_bulk_state", "save_bulk_state" and "execute_state_transaction".

## Issue reference
none
