### PR TITLE
Disable search page javascript

### DIFF
--- a/daprdocs/assets/js/search.js
+++ b/daprdocs/assets/js/search.js
@@ -1,0 +1,1 @@
+// Intentionally blank


### PR DESCRIPTION
Adds blank search page to disable Docsy's search keypress binding to the enter key

Closes #1045 