### PR TITLE
fixed typo in Service invocation overview

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/service-invocation-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/service-invocation-overview.md
@@ -108,7 +108,7 @@ The diagram below shows sequence 1-7 again on a local machine showing the API ca
 4. The Node.js app's sidecar forwards the request to the Node.js app. The Node.js app performs its business logic, logging the incoming message and then persist the order ID into Redis (not shown in the diagram)
 5. The Node.js app sends a response to the Python app through the Node.js sidecar.
 6. Dapr forwards the response to the Python Dapr sidecar
-7. The Python app receives the resposne.
+7. The Python app receives the response.
 
 ## Next steps
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Changed 'resposne' to 'response' in the Service invocation overview docs.

## Issue reference

None
