### PR TITLE
fix: Broken link to Authenticate requests from Dapr using token authentication

### DIFF
--- a/daprdocs/assets/js/search.js
+++ b/daprdocs/assets/js/search.js
@@ -1,0 +1,1 @@
+// Intentionally blank

--- a/daprdocs/assets/scss/_code.scss
+++ b/daprdocs/assets/scss/_code.scss
@@ -1,14 +1,53 @@
 // Code formatting.
 
+.copy-code-button {
+    color: #272822;
+    background-color: #FFF;
+    border-color: #0D2192;
+    border: 2px solid;
+    border-radius: 3px 3px 0px 0px;
+
+    /* right-align */
+    display: block;
+    margin-left: auto;
+    margin-right: 0;
+
+    margin-bottom: -2px;
+    padding: 3px 8px;
+    font-size: 0.8em;
+}
+
+.copy-code-button:hover {
+    cursor: pointer;
+    background-color: #F2F2F2;
+}
+
+.copy-code-button:focus {
+    /* Avoid an ugly focus outline on click in Chrome,
+       but darken the button for accessibility.
+       See https://stackoverflow.com/a/25298082/1481479 */
+    background-color: #E6E6E6;
+    outline: 0;
+}
+
+.copy-code-button:active {
+    background-color: #D9D9D9;
+}
+
+.highlight pre {
+    /* Avoid pushing up the copy buttons. */
+    margin: 0;
+}
+
 .td-content {
 	// Highlighted code.
     .highlight {
         @extend .card;
 	
-        margin: 2rem 0;
-        padding: 0;
+        margin: 0rem 0;
+        padding: 0rem;
 
-        max-width: 80%;
+        max-width: 100%;
 	    
         pre {
             margin: 0;
@@ -37,7 +76,8 @@
         word-wrap: normal;
         background-color: $gray-100;
         padding: $spacer;
-     
+    
+        max-width: 100%;
 
         > code {
 	    background-color: inherit !important;

--- a/daprdocs/content/en/operations/components/setup-bindings/supported-bindings/kafka.md
+++ b/daprdocs/content/en/operations/components/setup-bindings/supported-bindings/kafka.md
@@ -27,10 +27,12 @@ spec:
     value: topic3
   - name: authRequired # Required. default: "true"
     value: "false"
-   - name: saslUsername # Optional.
+  - name: saslUsername # Optional.
     value: "user"
-   - name: saslPassword # Optional.
+  - name: saslPassword # Optional.
     value: "password"
+  - name: maxMessageBytes # Optional.
+    value: 1024
 ```
 
 - `topics` is a comma separated string of topics for an input binding.
@@ -39,7 +41,7 @@ spec:
 - `publishTopic` is the topic to publish for an output binding.
 - `authRequired` determines whether to use SASL authentication or not.
 - `saslUsername` is the SASL username for authentication. Only used if `authRequired` is set to - `"true"`.
-- `saslPassword` is the SASL password for authentication. Only used if `authRequired` is set to - `"true"`.
+- `maxMessageBytes` is the maximum message size allowed for a single Kafka message. Default is 1024.
 
 {{% alert title="Warning" color="warning" %}}
 The above example uses secrets as plain strings. It is recommended to use a secret store for the secrets as described [here]({{< ref component-secrets.md >}}).

--- a/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-apache-kafka.md
@@ -28,6 +28,8 @@ spec:
       value: "adminuser"
     - name: saslPassword
       value: "KeFg23!"
+    - name: maxMessageBytes
+      value: 1024
 ```
 
 {{% alert title="Warning" color="warning" %}}
@@ -42,7 +44,27 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | authRequired        | N  | Enable authentication on the Kafka broker. Defaults to `"false"`.   |`"true"`, `"false"`
 | saslUsername        | N  | Username used for authentication. Only required if authRequired is set to true.   | `"adminuser"`
 | saslPassword        | N  | Password used for authentication. Can be `secretKeyRef` to use a secret reference. Only required if authRequired is set to true. Can be `secretKeyRef` to use a [secret reference]({{< ref component-secrets.md >}})  |  `""`, `"KeFg23!"`
+| maxMessageBytes | N  | The maximum message size allowed for a single Kafka message. Default is 1024. | `2048`
 
+## Per-call metadata fields
+
+### Partition Key
+
+When invoking the Kafka pub/sub, its possible to provide an optional partition key by using the `metadata` query param in the request url.
+
+The param name is `partitionKey`.
+
+Example:
+
+```shell
+curl -X POST http://localhost:3500/v1.0/publish/myKafka/myTopic?metadata.partitionKey=key1 \
+  -H "Content-Type: application/json" \
+  -d '{
+        "data": {
+          "message": "Hi"
+        }
+      }'
+```
 
 ## Create a Kafka instance
 {{< tabs "Self-Hosted" "Kubernetes">}}

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
@@ -142,7 +142,7 @@ It is recommended that a production-ready deployment includes the following sett
 
 2. App to Dapr API authentication is enabled. This is the communication between your application and the Dapr sidecar. To secure the Dapr API from unauthorized application access, it is recommended to enable Dapr's token based auth. See [enable API token authentication in Dapr]({{< ref "api-token.md" >}}) for details
 
-3. Dapr to App API authentication is enabled. This is the communication between Dapr and your application. This ensures that Dapr knows that it is communicating with an authorized application. See [Authenticate requests from Dapr using token authentication] ({{< ref "app-api-token.md" >}}) for details
+3. Dapr to App API authentication is enabled. This is the communication between Dapr and your application. This ensures that Dapr knows that it is communicating with an authorized application. See [Authenticate requests from Dapr using token authentication]({{< ref "app-api-token.md" >}}) for details
 
 4. All component YAMLs should have secret data configured in a secret store and not hard-coded in the YAML file. See [here]({{< ref "component-secrets.md" >}}) on how to use secrets with Dapr components
 

--- a/daprdocs/layouts/partials/hooks/body-end.html
+++ b/daprdocs/layouts/partials/hooks/body-end.html
@@ -15,3 +15,5 @@
   });
 </script>
 {{ end }}
+
+<script src="/js/copy-code-button.js"></script>

--- a/daprdocs/static/js/copy-code-button.js
+++ b/daprdocs/static/js/copy-code-button.js
@@ -1,0 +1,49 @@
+function addCopyButtons(clipboard) {
+    document.querySelectorAll('pre > code').forEach(function(codeBlock) {
+        var button = document.createElement('button');
+        button.className = 'copy-code-button';
+        button.type = 'button';
+        button.innerText = 'Copy';
+
+        button.addEventListener('click', function() {
+            clipboard.writeText(codeBlock.textContent).then(
+                function() {
+                    button.blur();
+
+                    button.innerText = 'Copied!';
+                    setTimeout(function() {
+                        button.innerText = 'Copy';
+                    }, 2000);
+                },
+                function(error) {
+                    button.innerText = 'Error';
+                    console.error(error);
+                }
+            );
+        });
+
+        var pre = codeBlock.parentNode;
+        if (pre.parentNode.classList.contains('highlight')) {
+            var highlight = pre.parentNode;
+            highlight.parentNode.insertBefore(button, highlight);
+        } else {
+            pre.parentNode.insertBefore(button, pre);
+        }
+    });
+}
+
+if (navigator && navigator.clipboard) {
+    addCopyButtons(navigator.clipboard);
+} else {
+    var script = document.createElement('script');
+    script.src =
+        'https://cdnjs.cloudflare.com/ajax/libs/clipboard-polyfill/2.7.0/clipboard-polyfill.promise.js';
+    script.integrity = 'sha256-waClS2re9NUbXRsryKoof+F9qc1gjjIhc2eT7ZbIv94=';
+    script.crossOrigin = 'anonymous';
+
+    script.onload = function() {
+        addCopyButtons(clipboard);
+    };
+
+    document.body.appendChild(script);
+}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Broken link to Authenticate requests from Dapr using token authentication
