### PR TITLE
Fix incorrect link under observability index page

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/observability/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/observability/_index.md
@@ -6,4 +6,4 @@ weight: 60
 description: See and measure the message calls across components and networked services
 ---
 
-This section includes guides for developers in the context of observability. See other sections for a [general overview of the observability concept]({{< ref observability >}}) in Dapr and for [operations guidance on monitoring]({{< ref monitoring >}}).
+This section includes guides for developers in the context of observability. See other sections for a [general overview of the observability concept]({{< ref observability-concept >}}) in Dapr and for [operations guidance on monitoring]({{< ref monitoring >}}).


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Currently link point to "observability" (current section) but should point to "observability-concept"

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
