### PR TITLE
Added single page of all the env variables used by Dapr

### DIFF
--- a/daprdocs/content/en/reference/api/environment_variables.md
+++ b/daprdocs/content/en/reference/api/environment_variables.md
@@ -1,0 +1,18 @@
+---
+type: docs
+title: "Enrivonment variable reference"
+linkTitle: "Enrivonment Variables"
+description: "A list of all environment variables used by Dapr"
+weight: 1500
+---
+
+Following table lists the environment variables used by the Dapr runtime, CLI, or your applications:
+
+| Environent Variable              | Description |
+|----------------------------------|-------------|
+| DAPR_HTTP_PORT                   | The HTTP port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
+| DAPR_GRPC_PORT                   | The gRPC port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
+| DAPR_TOKEN_API                   | The token value used for API authentication. Refer to the [API token auth page](/operations/security/api-token/) for more information.
+| DAPR_NETWORK                     | Optionally used by the Dapr CLI to specify the Docker network on which to deploy the Dapr runtime.
+| DAPR_PLACEMENT_HOST              | The host on which the placement service resides. Used for actors only.
+| NAMESPACE                        | Used to specify a component's [namespace in self-hosted mode](/operations/components/component-scopes/#example-of-component-namespacing-in-self-hosted-mode).

--- a/daprdocs/content/en/reference/api/environment_variables.md
+++ b/daprdocs/content/en/reference/api/environment_variables.md
@@ -8,11 +8,11 @@ weight: 1500
 
 Following table lists the environment variables used by the Dapr runtime, CLI, or your applications:
 
-| Environent Variable              | Description |
-|----------------------------------|-------------|
-| DAPR_HTTP_PORT                   | The HTTP port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
-| DAPR_GRPC_PORT                   | The gRPC port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
-| DAPR_TOKEN_API                   | The token value used for API authentication. Refer to the [API token auth page](/operations/security/api-token/) for more information.
-| DAPR_NETWORK                     | Optionally used by the Dapr CLI to specify the Docker network on which to deploy the Dapr runtime.
-| DAPR_PLACEMENT_HOST              | The host on which the placement service resides. Used for actors only.
-| NAMESPACE                        | Used to specify a component's [namespace in self-hosted mode](/operations/components/component-scopes/#example-of-component-namespacing-in-self-hosted-mode).
+| Environent Variable              | Used By          | Description |
+|----------------------------------|------------------|-------------|
+| DAPR_HTTP_PORT                   | Your application | The HTTP port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
+| DAPR_GRPC_PORT                   | Your application | The gRPC port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
+| DAPR_TOKEN_API                   | Your application | The token value used for API authentication. Refer to the [API token auth page](/operations/security/api-token/) for more information.
+| DAPR_NETWORK                     | Dapr CLI         | Optionally used by the Dapr CLI to specify the Docker network on which to deploy the Dapr runtime.
+| DAPR_PLACEMENT_HOST              | Your application | The host on which the placement service resides. Used for actors only.
+| NAMESPACE                        | Dapr runtime     | Used to specify a component's [namespace in self-hosted mode](/operations/components/component-scopes/#example-of-component-namespacing-in-self-hosted-mode).


### PR DESCRIPTION
This adds a page to the docs that lists all environment variables used by Dapr.

This was mostly straight forward. I wanted to link the description of `DAPR_PLACEMENT_HOST` to a page that describes actors and the placement service itself but there wasn't one I could find.

Resolves #1114

**Checklist:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
