### PR TITLE
Added single page of all the env variables used by Dapr

### DIFF
--- a/daprdocs/content/en/reference/cli/_index.md
+++ b/daprdocs/content/en/reference/cli/_index.md
@@ -3,4 +3,5 @@ type: docs
 title: "Dapr CLI reference"
 linkTitle: "Dapr CLI"
 description: "Detailed information on the Dapr CLI commands"
+weight: 200
 ---

--- a/daprdocs/content/en/reference/environment/_index.md
+++ b/daprdocs/content/en/reference/environment/_index.md
@@ -16,4 +16,4 @@ The following table lists the environment variables used by the Dapr runtime, CL
 | APP_TOKEN_API                    | Your application | The token used by the app to authenticate requests from Dapr. Read [authenticate requests from Dapr using token authentication]({{< ref app-api-token >}}) for more information.
 | DAPR_PLACEMENT_HOST              |Your application | The address for the Dapr Placement service. Only needed in self-hosted mode if you run your app (which creates actors) and you want to tell the app the location of the Placement service. This is never needed outside of local machine development.  
 | DAPR_NETWORK                     | Dapr CLI         | Optionally used by the Dapr CLI to specify the Docker network on which to deploy the Dapr runtime.
-| NAMESPACE                        | Dapr runtime     | Used to specify a component's [namespace in self-hosted mode](({{< ref component-scopes >}})
+| NAMESPACE                        | Dapr runtime     | Used to specify a component's [namespace in self-hosted mode]({{< ref component-scopes >}})

--- a/daprdocs/content/en/reference/environment/_index.md
+++ b/daprdocs/content/en/reference/environment/_index.md
@@ -2,7 +2,7 @@
 type: docs
 title: "Environment variable reference"
 linkTitle: "Environment variables"
-description: "A list of all environment variables used by Dapr"
+description: "A list of environment variables used by Dapr"
 weight: 300
 ---
 
@@ -12,7 +12,8 @@ Following table lists the environment variables used by the Dapr runtime, CLI, o
 |----------------------------------|------------------|-------------|
 | DAPR_HTTP_PORT                   | Your application | The HTTP port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
 | DAPR_GRPC_PORT                   | Your application | The gRPC port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
-| DAPR_TOKEN_API                   | Your application | The token value used for API authentication. Refer to the [API token auth page](/operations/security/api-token/) for more information.
+| DAPR_TOKEN_API                   | Your application | The token used for Dapr API authentication for requests from the application. Read [enable API token authentication in Dapr]({{< ref api-token >}}) for more information.
+| APP_TOKEN_API                    | Your application | The token used by the app to authenticate requests from Dapr. Read [authenticate requests from Dapr using token authentication]({{< ref app-api-token >}}) for more information.
+| DAPR_PLACEMENT_HOST              |Your application | The address for the Dapr Placement service. Only needed in self-hosted mode if you run your app (which creates actors) and you want to tell the app the location of the Placement service. This is never needed outside of local machine development.  
 | DAPR_NETWORK                     | Dapr CLI         | Optionally used by the Dapr CLI to specify the Docker network on which to deploy the Dapr runtime.
-| DAPR_PLACEMENT_HOST              | Your application | The host on which the placement service resides. Used for actors only.
-| NAMESPACE                        | Dapr runtime     | Used to specify a component's [namespace in self-hosted mode](/operations/components/component-scopes/#example-of-component-namespacing-in-self-hosted-mode).
+| NAMESPACE                        | Dapr runtime     | Used to specify a component's [namespace in self-hosted mode](({{< ref component-scopes >}})

--- a/daprdocs/content/en/reference/environment/_index.md
+++ b/daprdocs/content/en/reference/environment/_index.md
@@ -1,7 +1,7 @@
 ---
 type: docs
 title: "Environment variable reference"
-linkTitle: "Environment Variables"
+linkTitle: "Environment variables"
 description: "A list of all environment variables used by Dapr"
 weight: 300
 ---

--- a/daprdocs/content/en/reference/environment/_index.md
+++ b/daprdocs/content/en/reference/environment/_index.md
@@ -1,0 +1,18 @@
+---
+type: docs
+title: "Environment variable reference"
+linkTitle: "Environment Variables"
+description: "A list of all environment variables used by Dapr"
+weight: 300
+---
+
+Following table lists the environment variables used by the Dapr runtime, CLI, or your applications:
+
+| Environment Variable             | Used By          | Description |
+|----------------------------------|------------------|-------------|
+| DAPR_HTTP_PORT                   | Your application | The HTTP port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
+| DAPR_GRPC_PORT                   | Your application | The gRPC port that Dapr is listening on. Your application should use this variable to connect to Dapr instead of hardcoding the port value. Injected by the `dapr-sidecar-injector` into all the containers in the pod.
+| DAPR_TOKEN_API                   | Your application | The token value used for API authentication. Refer to the [API token auth page](/operations/security/api-token/) for more information.
+| DAPR_NETWORK                     | Dapr CLI         | Optionally used by the Dapr CLI to specify the Docker network on which to deploy the Dapr runtime.
+| DAPR_PLACEMENT_HOST              | Your application | The host on which the placement service resides. Used for actors only.
+| NAMESPACE                        | Dapr runtime     | Used to specify a component's [namespace in self-hosted mode](/operations/components/component-scopes/#example-of-component-namespacing-in-self-hosted-mode).

--- a/daprdocs/content/en/reference/environment/_index.md
+++ b/daprdocs/content/en/reference/environment/_index.md
@@ -6,7 +6,7 @@ description: "A list of environment variables used by Dapr"
 weight: 300
 ---
 
-Following table lists the environment variables used by the Dapr runtime, CLI, or your applications:
+The following table lists the environment variables used by the Dapr runtime, CLI, or from within your application:
 
 | Environment Variable             | Used By          | Description |
 |----------------------------------|------------------|-------------|


### PR DESCRIPTION
This adds a page to the docs that lists all environment variables used by Dapr.

This was mostly straight forward. I wanted to link the description of `DAPR_PLACEMENT_HOST` to a page that describes actors and the placement service itself but there wasn't one I could find.

Resolves #1114

**Checklist:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs