### PR TITLE
Add PHP to SDK list

### DIFF
--- a/daprdocs/content/en/concepts/overview.md
+++ b/daprdocs/content/en/concepts/overview.md
@@ -73,6 +73,7 @@ To make using Dapr more natural for different languages, it also includes langua
 - **[Python SDK](https://github.com/dapr/python-sdk)**
 - **[RUST SDK](https://github.com/dapr/rust-sdk)**
 - **[.NET SDK](https://github.com/dapr/dotnet-sdk)**
+- **[PHP SDK](https://github.com/dapr/php-sdk)**
 
 > Note: Dapr is language agnostic and provides a [RESTful HTTP API]({{< ref api >}}) in addition to the protobuf clients.
 
@@ -85,6 +86,8 @@ Dapr can be used from  any developer framework. Here are some that have been int
  In the Dapr [Java SDK](https://github.com/dapr/java-sdk) you can find [Spring Boot](https://spring.io/) integration.
  
 Dapr integrates easily with Python [Flask](https://pypi.org/project/Flask/) and node [Express](http://expressjs.com/). See examples in the [Dapr quickstarts](https://github.com/dapr/quickstarts).
+
+In the Dapr [PHP-SDK](https://github.com/dapr/php-sdk) you can serve with Apache, Nginx, or Caddyserver.
 
 #### Actors
 Dapr SDKs support for [virtual actors]({{< ref actors >}}) which are stateful objects that make concurrency simple, have method and state encapsulation, and are designed for scalable, distributed applications.

--- a/daprdocs/content/en/developing-applications/sdks/_index.md
+++ b/daprdocs/content/en/developing-applications/sdks/_index.md
@@ -34,6 +34,7 @@ The Dapr SDKs are the easiest way for you to get Dapr into your application. Cho
 | [.NET](https://github.com/dapr/dotnet-sdk) | In Development | ✔ | ASP.NET Core | ✔ |
 | [Python]({{< ref python >}}) | In Development | ✔ | [gRPC]({{< ref python-grpc.md >}}) | [FastAPI]({{< ref python-fastapi.md >}})<br />[Flask]({{< ref python-flask.md >}}) |
 | [Java](https://github.com/dapr/java-sdk) | In Development | ✔ | Spring Boot | ✔ |
+| [PHP](https://github.com/dapr/php-sdk) | In Development | ✔ | ✔ | ✔ |
 | [Go](https://github.com/dapr/go-sdk) | In Development | ✔ | ✔ |  |
 | [C++](https://github.com/dapr/cpp-sdk) | Backlog | ✔ | |
 | [Rust]() | Backlog | ✔ | |  |


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Adds the PHP SDK to the list.

## Issue reference

#1196 
