### PR TITLE
Adding a few updates for versioning

### DIFF
--- a/daprdocs/content/en/developing-applications/middleware/supported-middleware/_index.md
+++ b/daprdocs/content/en/developing-applications/middleware/supported-middleware/_index.md
@@ -9,11 +9,11 @@ no_list: true
 
 ### HTTP
 
-| Name                                                                           | Description                                                                                                                     | Status                     |
-|--------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------|
-| [Rate limit]({{< ref middleware-rate-limit.md >}})                             | Restricts the maximum number of allowed HTTP requests per second                                                                | Alpha                      |
-| [OAuth2]({{< ref middleware-oauth2.md >}})                                     | Enables the [OAuth2 Authorization Grant flow](https://tools.ietf.org/html/rfc6749#section-4.1) on a Web API                     | Alpha                      |
-| [OAuth2 client credentials]({{< ref middleware-oauth2clientcredentials.md >}}) | Enables the [OAuth2 Client Credentials Grant flow](https://tools.ietf.org/html/rfc6749#section-4.4) on a Web API                | Alpha                      |
-| [Bearer]({{< ref middleware-bearer.md >}})                                     | Verifies a [Bearer Token](https://tools.ietf.org/html/rfc6750) using [OpenID Connect](https://openid.net/connect/) on a Web API | Alpha                      |
-| [Open Policy Agent]({{< ref middleware-opa.md >}})                             | Applies [Rego/OPA Policies](https://www.openpolicyagent.org/) to incoming Dapr HTTP requests                                    | Alpha                      |
-| [Uppercase]({{< ref middleware-uppercase.md >}})                               | Converts the body of the request to uppercase letters                                                                           | GA (For local development) |
+| Name       | Description    | Status    |  Component version |
+|------------|----------------|-----------|--------------------|
+| [Rate limit]({{< ref middleware-rate-limit.md >}})                             | Restricts the maximum number of allowed HTTP requests per second                                                                | Alpha                      | v1|
+| [OAuth2]({{< ref middleware-oauth2.md >}})                                     | Enables the [OAuth2 Authorization Grant flow](https://tools.ietf.org/html/rfc6749#section-4.1) on a Web API                     | Alpha                      | v1|
+| [OAuth2 client credentials]({{< ref middleware-oauth2clientcredentials.md >}}) | Enables the [OAuth2 Client Credentials Grant flow](https://tools.ietf.org/html/rfc6749#section-4.4) on a Web API                | Alpha                      | v1|
+| [Bearer]({{< ref middleware-bearer.md >}})                                     | Verifies a [Bearer Token](https://tools.ietf.org/html/rfc6750) using [OpenID Connect](https://openid.net/connect/) on a Web API | Alpha                      | v1|
+| [Open Policy Agent]({{< ref middleware-opa.md >}})                             | Applies [Rego/OPA Policies](https://www.openpolicyagent.org/) to incoming Dapr HTTP requests                                    | Alpha                      | v1|
+| [Uppercase]({{< ref middleware-uppercase.md >}})                               | Converts the body of the request to uppercase letters                                                                           | GA (For local development) | v1|

--- a/daprdocs/content/en/developing-applications/middleware/supported-middleware/middleware-rate-limit.md
+++ b/daprdocs/content/en/developing-applications/middleware/supported-middleware/middleware-rate-limit.md
@@ -18,6 +18,7 @@ metadata:
   name: ratelimit
 spec:
   type: middleware.http.ratelimit
+  version: v1
   metadata:
   - name: maxRequestsPerSecond
     value: 10

--- a/daprdocs/content/en/developing-applications/middleware/supported-middleware/middleware-uppercase.md
+++ b/daprdocs/content/en/developing-applications/middleware/supported-middleware/middleware-uppercase.md
@@ -11,6 +11,7 @@ The uppercase [HTTP middleware]({{< ref middleware-concept.md >}}) converts the 
 ## Component format
 
 In the following definition, the maximum requests per second are set to 10:
+
 ```yaml
 apiVersion: dapr.io/v1alpha1
 kind: Component
@@ -18,6 +19,7 @@ metadata:
   name: uppercase
 spec:
   type: middleware.http.uppercase
+  version: v1
 ```
 
 This component has no `metadata` to configure.

--- a/daprdocs/content/en/operations/support/support-versioning.md
+++ b/daprdocs/content/en/operations/support/support-versioning.md
@@ -61,6 +61,8 @@ Note: Components have a production usage lifecycle status: Alpha, Beta and GA (s
 * List of [secret store components]({{< ref supported-secret-stores.md >}})
 * List of [binding components]({{< ref supported-bindings.md >}})
 
+For more information on component versioning  read [Version 2 and beyond of a component](https://github.com/dapr/components-contrib/blob/master/docs/developing-component.md#version-2-and-beyond-of-a-component)
+
 ### Component schemas 
 
 Versioning for component YAMLs comes in two forms:
@@ -84,6 +86,7 @@ spec:
   - name: redisPassword
     value: general-kenobi
 ```
+
 ### Component manifest version
 The Component YAML manifest is versioned with `dapr.io/v1alpha1`. 
 


### PR DESCRIPTION
The middleware components did not have version number in the table.
Also added a link to the Component Contrib authoring guidance in the repo from the versioning doc
