### PR TITLE
Fixing concurrency mode setting name: concurrency -> concurrencyMode

### DIFF
--- a/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-rabbitmq.md
+++ b/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-rabbitmq.md
@@ -33,7 +33,7 @@ spec:
     value: "0"
   - name: reconnectWait
     value: "0"
-  - name: concurrency
+  - name: concurrencyMode
     value: parallel
 ```
 {{% alert title="Warning" color="warning" %}}
@@ -52,7 +52,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | requeueInFailure  | N        | Whether or not to requeue when sending a [negative acknolwedgement](https://www.rabbitmq.com/nack.html) in case of a failure. Defaults to `"false"` | `"true"`, `"false"`
 | prefetchCount  | N        | Number of messages to [prefecth](https://www.rabbitmq.com/consumer-prefetch.html). Consider changing this to a non-zero value for production environments. Defaults to `"0"`, which means that all available messages will be pre-fetched. | `"2"`
 | reconnectWait  | N        | How long to wait (in seconds) before reconnecting if a connection failure occurs | `"0"`
-| concurrency    | N        | `paralell` is the default, and allows processing multiple messages in paralell (limited by the `app-max-concurrency` annotation, if configured). Set to `single` to disable paralell processing. In most situations there's no reason to change this. | `paralell`, `single`
+| concurrencyMode | N        | `paralell` is the default, and allows processing multiple messages in paralell (limited by the `app-max-concurrency` annotation, if configured). Set to `single` to disable paralell processing. In most situations there's no reason to change this. | `paralell`, `single`
 
 
 ## Create a RabbitMQ server


### PR DESCRIPTION
Per the code links below, the concurrency mode setting is `concurrencyMode`. It is currently documented as `concurrency`. Is the use opts for `single` it would be ignored and default to `parallel`.

https://github.com/dapr/components-contrib/blob/release-1.0/pubsub/rabbitmq/metadata.go#L82-L86
https://github.com/dapr/components-contrib/blob/release-1.0/pubsub/concurrency.go#L15
https://github.com/dapr/components-contrib/blob/release-1.0/pubsub/concurrency.go#L22