### PR TITLE
Fix typo. there were two step 2's

### DIFF
--- a/daprdocs/content/en/getting-started/get-started-api.md
+++ b/daprdocs/content/en/getting-started/get-started-api.md
@@ -42,7 +42,7 @@ Invoke-RestMethod -Method Post -ContentType 'application/json' -Body '[{ "key": 
 
 {{< /tabs >}}
 
-## Step 2: Get state
+## Step 3: Get state
 
 Now get the state you just stored using a key with the state management API:
 
@@ -64,7 +64,7 @@ Invoke-RestMethod -Uri 'http://localhost:3500/v1.0/state/statestore/name'
 
 {{< /tabs >}}
 
-## Step 3: See how the state is stored in Redis
+## Step 4: See how the state is stored in Redis
 
 You can look in the Redis container and verify Dapr is using it as a state store. Run the following to use the Redis CLI:
 


### PR DESCRIPTION
Updated the steps numbers. Step 2 (the number) was duplicated.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Typo on Step numbers

## Issue reference

No issue raised. Was quicker to just do the fix.
