### PR TITLE
Update output for Getting a secret

### DIFF
--- a/daprdocs/content/en/getting-started/get-started-component.md
+++ b/daprdocs/content/en/getting-started/get-started-component.md
@@ -86,8 +86,8 @@ Invoke-RestMethod -Uri 'http://localhost:3500/v1.0/secrets/my-secret-store/my-se
 
 You should see output with the secret you stored in the JSON file.
 
-```
-"I'm Batman"
+```json
+{"my-secret":"I'm Batman"}
 ```
 
 <a class="btn btn-primary" href="{{< ref quickstarts.md >}}" role="button">Next step: Explore Dapr quickstarts >></a>


### PR DESCRIPTION
Indicate that the response is JSON and not plain text.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The Getting started guide seems to indicate that the response from the secret store is plaintext containing only the secret value, when in fact it's a JSON object in format `{ "key": "value" }`.

## Issue reference
