### PR TITLE
Fix mysql name in helm and Docker for v1.0

### DIFF
--- a/daprdocs/content/en/operations/components/setup-state-store/supported-state-stores/setup-mysql.md
+++ b/daprdocs/content/en/operations/components/setup-state-store/supported-state-stores/setup-mysql.md
@@ -64,7 +64,7 @@ Run an instance of MySQL. You can run a local instance of MySQL in Docker CE wit
 This example does not describe a production configuration because it sets the password in plain text and the user name is left as the MySQL default of "root".
 
 ```bash
-docker run --name dapr_mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:latest
+docker run --name dapr-mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:latest
 ```
 
 {{% /codetab %}}
@@ -78,7 +78,7 @@ We can use [Helm](https://helm.sh/) to quickly create a MySQL instance in our Ku
 
     ```bash
     helm repo add bitnami https://charts.bitnami.com/bitnami
-    helm install dapr_mysql bitnami/mysql
+    helm install dapr-mysql bitnami/mysql
     ```
 
 1. Run `kubectl get pods` to see the MySQL containers now running in your cluster.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fix helm name for mysql so it installs, otheriwse get error:
```txt
$ helm install dapr_mysql bitnami/mysql
Error: create: failed to create: Secret "sh.helm.release.v1.dapr_mysql.v1" is invalid: metadata.name: Invalid value: "sh.helm.release.v1.dapr_mysql.v1": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

Changed docker container name for consistency.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
