### PR TITLE
Update dapr-run.md

### DIFF
--- a/daprdocs/content/en/reference/cli/dapr-run.md
+++ b/daprdocs/content/en/reference/cli/dapr-run.md
@@ -30,8 +30,8 @@ dapr run [flags] [command]
 | `--app-ssl` | | `false` | Enable https when Dapr invokes the application
 | `--components-path`, `-d` | | `Linux & Mac: $HOME/.dapr/components`, `Windows: %USERPROFILE%\.dapr\components` | The path for components directory
 | `--config`, `-c` | | `Linux & Mac: $HOME/.dapr/config.yaml`, `Windows: %USERPROFILE%\.dapr\config.yaml` | Dapr configuration file |
-| `--dapr-grpc-port` | | `3500` | The gRPC port for Dapr to listen on |
-| `--dapr-http-port` | | `50001` | The HTTP port for Dapr to listen on |
+| `--dapr-grpc-port` | | `50001` | The gRPC port for Dapr to listen on |
+| `--dapr-http-port` | | `3500` | The HTTP port for Dapr to listen on |
 | `--enable-profiling` | | `false` | Enable `pprof` profiling via an HTTP endpoint 
 | `--help`, `-h` | | | Print this help message |
 | `--image` | | | The image to build the code in. Input is: `repository/image` |


### PR DESCRIPTION
Default http port and grpc were swapped

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Set default grpc port to 50001 and http port to 3500.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
