### PR TITLE
At "list" permission for non-default namespace

### DIFF
--- a/daprdocs/content/en/operations/components/component-secrets.md
+++ b/daprdocs/content/en/operations/components/component-secrets.md
@@ -121,7 +121,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get"]
+  verbs: ["get", "list"]
 ---
 
 kind: RoleBinding


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

List permission is necessary to perform bulk secret read.
If not present Dapr sidecar will crash and restart on a new different gprc port.
