### PR TITLE
Override GitHub links partial

### DIFF
--- a/daprdocs/layouts/partials/page-meta-links.html
+++ b/daprdocs/layouts/partials/page-meta-links.html
@@ -23,10 +23,6 @@
 
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
-{{ if $gh_project_repo }}
-{{ $project_issueURL := printf "%s/issues/new/choose" $gh_project_repo }}
-<a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
-{{ end }}
 </div>
 {{ end }}
 {{ end }}

--- a/daprdocs/layouts/partials/page-meta-links.html
+++ b/daprdocs/layouts/partials/page-meta-links.html
@@ -1,0 +1,32 @@
+{{ if .Path }}
+{{ $pathFormatted := replace .Path "\\" "/" }}
+{{ $gh_repo := ($.Param "github_repo") }}
+{{ $gh_subdir := ($.Param "github_subdir") }}
+{{ $gh_project_repo := ($.Param "github_project_repo") }}
+{{ $gh_branch := (default "master" ($.Param "github_branch")) }}
+{{ if $gh_repo }}
+<div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
+{{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted }}
+{{ if and ($gh_subdir) (.Site.Language.Lang) }}
+{{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
+{{ else if .Site.Language.Lang }}
+{{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted }}
+{{ else if $gh_subdir }}
+{{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted }}
+{{ end }}
+{{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
+{{ $createURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
+{{ $issuesURL := printf "%s/issues/new/choose" $gh_repo}}
+{{ $newPageStub := resources.Get "stubs/new-page-template.md" }}
+{{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
+{{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
+
+<a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+{{ if $gh_project_repo }}
+{{ $project_issueURL := printf "%s/issues/new/choose" $gh_project_repo }}
+<a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+{{ end }}
+</div>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

Closes #1278 
