### PR TITLE
Add Kubernetes --wait and --timeout flags to the CLI documentation

### DIFF
--- a/daprdocs/content/en/developing-applications/middleware/supported-middleware/middleware-uppercase.md
+++ b/daprdocs/content/en/developing-applications/middleware/supported-middleware/middleware-uppercase.md
@@ -10,7 +10,7 @@ The uppercase [HTTP middleware]({{< ref middleware-concept.md >}}) converts the 
 
 ## Component format
 
-In the following definition, the maximum requests per second are set to 10:
+In the following definition, it make content of request body into uppercase:
 
 ```yaml
 apiVersion: dapr.io/v1alpha1

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -65,7 +65,6 @@ The default namespace when initializing Dapr is `dapr-system`. You can override 
 dapr init -k -n mynamespace
 ```
 
-
 ### Install in highly available mode
 
 You can run Dapr with 3 replicas of each control plane pod in the dapr-system namespace for [production scenarios]({{< ref kubernetes-production.md >}}).
@@ -80,6 +79,12 @@ Dapr is initialized by default with [mTLS]({{< ref "security-concept.md#sidecar-
 
 ```bash
 dapr init -k --enable-mtls=false
+```
+
+### Wait for the installation to complete (default timeout is 300s/5m)
+
+```bash
+dapr init -k --wait --timeout 600
 ```
 
 ### Uninstall Dapr on Kubernetes with CLI

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -81,7 +81,11 @@ Dapr is initialized by default with [mTLS]({{< ref "security-concept.md#sidecar-
 dapr init -k --enable-mtls=false
 ```
 
-### Wait for the installation to complete (default timeout is 300s/5m)
+### Wait for the installation to complete
+
+ You can wait for the installation to complete its deployment with the `--wait` flag. 
+ 
+ The default timeout is 300s (5 min), but can be customized with the `--timeout` flag.
 
 ```bash
 dapr init -k --wait --timeout 600

--- a/daprdocs/content/en/reference/cli/dapr-init.md
+++ b/daprdocs/content/en/reference/cli/dapr-init.md
@@ -46,7 +46,11 @@ dapr init
 dapr init -k
 ```
 
-### Initialize Dapr in Kubernetes and wait for the installation to complete (default timeout is 300s/5m)
+### Initialize Dapr in Kubernetes and wait for the installation to complete
+
+ You can wait for the installation to complete its deployment with the `--wait` flag. 
+ 
+ The default timeout is 300s (5 min), but can be customized with the `--timeout` flag.
 ```bash
 dapr init -k --wait --timeout 600
 ```

--- a/daprdocs/content/en/reference/cli/dapr-init.md
+++ b/daprdocs/content/en/reference/cli/dapr-init.md
@@ -27,6 +27,8 @@ dapr init [flags]
 | `--enable-mtls` | | `true` | Enable mTLS in your cluster |
 | `--help`, `-h` | | | Print this help message |
 | `--kubernetes`, `-k` | | `false` | Deploy Dapr to a Kubernetes cluster |
+| `--wait` | | `false` | Wait for Kubernetes initialization to complete |
+| `--timeout` | | `300` | The wait timeout for the Kubernetes installation |
 | `--namespace`, `-n` | | `dapr-system` | The Kubernetes namespace to install Dapr in |
 | `--network` | `DAPR_NETWORK` | | The Docker network on which to deploy the Dapr runtime |
 | `--runtime-version` | | `latest` | The version of the Dapr runtime to install, for example: `1.0.0` |
@@ -42,6 +44,11 @@ dapr init
 ### Initialize Dapr in Kubernetes
 ```bash
 dapr init -k
+```
+
+### Initialize Dapr in Kubernetes and wait for the installation to complete (default timeout is 300s/5m)
+```bash
+dapr init -k --wait --timeout 600
 ```
 
 ### Initialize specified version of Dapr runtime in self-hosted mode


### PR DESCRIPTION
## Description

This PR adds Kubernetes --wait and --timeout flags to the CLI documentation

Do not merge before dapr/cli#629

## Issue reference

Resolves #1313 
