### PR TITLE
MQTT & Hazelcast retries and Redis redelivery settings

### DIFF
--- a/daprdocs/content/en/developing-applications/middleware/supported-middleware/middleware-uppercase.md
+++ b/daprdocs/content/en/developing-applications/middleware/supported-middleware/middleware-uppercase.md
@@ -10,7 +10,7 @@ The uppercase [HTTP middleware]({{< ref middleware-concept.md >}}) converts the 
 
 ## Component format
 
-In the following definition, the maximum requests per second are set to 10:
+In the following definition, it make content of request body into uppercase:
 
 ```yaml
 apiVersion: dapr.io/v1alpha1

--- a/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-hazelcast.md
+++ b/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-hazelcast.md
@@ -31,6 +31,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | Field              | Required | Details | Example |
 |--------------------|:--------:|---------|---------|
 | connectionString    | Y  | A comma delimited string of servers. Example: "hazelcast:3000,hazelcast2:3000"  | `"hazelcast:3000,hazelcast2:3000"`
+| backOffMaxRetries   | N  | The maximum number of retries to process the message before returning an error. Defaults to `"0"` which means the component will not retry processing the message. `"-1"` will retry indefinitely until the message is processed or the application is shutdown. And positive number is treated as the maximum retry count. The component will wait 5 seconds between retries. | `"3"` |
 
 
 ## Create a Hazelcast instance

--- a/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-mqtt.md
+++ b/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-mqtt.md
@@ -39,6 +39,7 @@ spec:
 | caCert | Required for using TLS | Certificate authority certificate. Can be `secretKeyRef` to use a secret reference | `0123456789-0123456789`
 | clientCert | Required for using TLS | Client certificate. Can be `secretKeyRef` to use a secret reference | `0123456789-0123456789`
 | clientKey | Required for using TLS | Client key. Can be `secretKeyRef` to use a secret reference | `012345`
+| backOffMaxRetries   | N  | The maximum number of retries to process the message before returning an error. Defaults to `"0"` which means the component will not retry processing the message. `"-1"` will retry indefinitely until the message is processed or the application is shutdown. And positive number is treated as the maximum retry count. The component will wait 5 seconds between retries. | `"3"`
 
 
 ### Communication using TLS

--- a/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-redis-pubsub.md
+++ b/daprdocs/content/en/operations/components/setup-pubsub/supported-pubsub/setup-redis-pubsub.md
@@ -39,8 +39,12 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 |--------------------|:--------:|---------|---------|
 | redisHost          | Y        | Connection-string for the redis host  | `localhost:6379`, `redis-master.default.svc.cluster.local:6379`
 | redisPassword      | Y        | Password for Redis host. No Default. Can be `secretKeyRef` to use a secret reference  | `""`, `"KeFg23!"`
-| consumerID        | N         | The consumer group ID   | `"myGroup"`
-| enableTLS         | N         | If the Redis instance supports TLS with public certificates, can be configured to be enabled or disabled. Defaults to `"false"` | `"true"`, `"false"`
+| consumerID         | N        | The consumer group ID   | `"myGroup"`
+| enableTLS          | N        | If the Redis instance supports TLS with public certificates, can be configured to be enabled or disabled. Defaults to `"false"` | `"true"`, `"false"`
+| redeliverInterval  | N        | The interval between checking for pending messages to redelivery. Defaults to `"60s"`. `"0"` disables redelivery. | `"30s"`
+| processingTimeout  | N        | The amount time a message must be pending before attempting to redeliver it. Defaults to `"15s"`. `"0"` disables redelivery. | `"30s"`
+| queueDepth         | N        | The size of the message queue for processing. Defaults to `"100"`. | `"1000"`
+| concurrency        | N        | The number of concurrent workers that are processing messages. Defaults to `"10"`. | `"15"`
 
 ## Create a Redis instance
 


### PR DESCRIPTION
## Description

This PR adds details on backOffMaxRetries for MQTT and Hazelcast and redelivery settings to Redis.

Note: By rebasing from `v1.0` to `v1.1`, this includes a commit that updates `middleware-uppercase.md`

## Issue reference

Resolves #1267
Resolves #1270
Resolves #1255