### PR TITLE
feat: add shutdown docs

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-job.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-job.md
@@ -1,0 +1,60 @@
+---
+type: docs
+title: "Running Dapr with a Kubernetes Job"
+linkTitle: "Kubernetes Jobs"
+weight: 1000
+description: "Use Dapr API in a Kubernetes Job context"
+type: docs
+---
+
+# Kubernetes Job
+
+The Dapr sidecar is designed to be a long running process, in the context of a [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) this behaviour can block your job completion.
+To address this issue the Dapr sidecar has an endpoint to `Shutdown` the sidecar.
+
+When running a basic [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) you will need to call the `/shutdown` endpoint for the sidecar to gracefully stop and the job will be considered `Completed`.
+
+When a job is finish without calling `Shutdown` your job will be in a `NotReady` state with only the `daprd` container running endlessly.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-with-shutdown
+spec:
+  template:
+    metadata:
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "with-shutdown"
+    spec:
+      containers:
+      - name: job
+        image: busybox
+        command: ["/bin/sh", "-c", "sleep 20 && wget localhost:3500/v1.0/shutdown"]
+      restartPolicy: Never
+```
+
+You can also call the `Shutdown` from any of the Dapr SDK
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	dapr "github.com/dapr/go-sdk/client"
+)
+
+func main() {
+  client, err := dapr.NewClient()
+  if err != nil {
+    log.Panic(err)
+  }
+  defer client.Close()
+  defer client.Shutdown()
+  // Job
+}
+```


### PR DESCRIPTION
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

## Description

Add documentation for dapr/dapr#2828 (New Shutdown API for job)
