### PR TITLE
Replace button by alert section since there is some issue about crowdin

### DIFF
--- a/daprdocs/content/en/getting-started/_index.md
+++ b/daprdocs/content/en/getting-started/_index.md
@@ -22,5 +22,6 @@ The following steps in this guide are:
 1. Configure a component
 1. Explore Dapr quickstarts
 
-<a class="btn btn-primary" href="{{< ref install-dapr-cli.md >}}" role="button">First step: Install the Dapr CLI >></a>
-
+{{% alert color="primary" %}}
+[First step: Install the Dapr CLI >>]({{< ref install-dapr-cli.md >}})
+{{% /alert %}}

--- a/daprdocs/content/en/getting-started/_index.md
+++ b/daprdocs/content/en/getting-started/_index.md
@@ -22,6 +22,4 @@ The following steps in this guide are:
 1. Configure a component
 1. Explore Dapr quickstarts
 
-{{% alert color="primary" %}}
-[First step: Install the Dapr CLI >>]({{< ref install-dapr-cli.md >}})
-{{% /alert %}}
+{{< button text="First step: Install the Dapr CLI >>" page="install-dapr-cli" >}}

--- a/daprdocs/content/en/getting-started/get-started-api.md
+++ b/daprdocs/content/en/getting-started/get-started-api.md
@@ -101,4 +101,6 @@ Exit the redis-cli with:
 exit
 ```
 
-<a class="btn btn-primary" href="{{< ref get-started-component.md >}}" role="button">Next step: Define a component >></a>
+{{% alert color="primary" %}}
+[Next step: Define a component >>]({{< ref get-started-component.md >}})
+{{% /alert %}}

--- a/daprdocs/content/en/getting-started/get-started-api.md
+++ b/daprdocs/content/en/getting-started/get-started-api.md
@@ -101,6 +101,4 @@ Exit the redis-cli with:
 exit
 ```
 
-{{% alert color="primary" %}}
-[Next step: Define a component >>]({{< ref get-started-component.md >}})
-{{% /alert %}}
+{{< button text="Next step: Define a component >>" page="get-started-component" >}}

--- a/daprdocs/content/en/getting-started/get-started-component.md
+++ b/daprdocs/content/en/getting-started/get-started-component.md
@@ -90,4 +90,6 @@ You should see output with the secret you stored in the JSON file.
 {"my-secret":"I'm Batman"}
 ```
 
-<a class="btn btn-primary" href="{{< ref quickstarts.md >}}" role="button">Next step: Explore Dapr quickstarts >></a>
+{{% alert color="primary" %}}
+[Next step: Explore Dapr quickstarts >>]({{< ref quickstarts.md >}})
+{{% /alert %}}

--- a/daprdocs/content/en/getting-started/get-started-component.md
+++ b/daprdocs/content/en/getting-started/get-started-component.md
@@ -90,6 +90,4 @@ You should see output with the secret you stored in the JSON file.
 {"my-secret":"I'm Batman"}
 ```
 
-{{% alert color="primary" %}}
-[Next step: Explore Dapr quickstarts >>]({{< ref quickstarts.md >}})
-{{% /alert %}}
+{{< button text="Next step: Explore Dapr quickstarts >>" page="quickstarts" >}}

--- a/daprdocs/content/en/getting-started/install-dapr-cli.md
+++ b/daprdocs/content/en/getting-started/install-dapr-cli.md
@@ -110,5 +110,6 @@ Flags:
 Use "dapr [command] --help" for more information about a command.
 ```
 
-<a class="btn btn-primary" href="{{< ref install-dapr-selfhost.md >}}" role="button">Next step: Initialize Dapr >></a>
-
+{{% alert color="primary" %}}
+[Next step: Initialize Dapr >>]({{< ref install-dapr-selfhost.md >}})
+{{% /alert %}}

--- a/daprdocs/content/en/getting-started/install-dapr-cli.md
+++ b/daprdocs/content/en/getting-started/install-dapr-cli.md
@@ -110,6 +110,4 @@ Flags:
 Use "dapr [command] --help" for more information about a command.
 ```
 
-{{% alert color="primary" %}}
-[Next step: Initialize Dapr >>]({{< ref install-dapr-selfhost.md >}})
-{{% /alert %}}
+{{< button text="Next step: Initialize Dapr >>" page="install-dapr-selfhost" >}}

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -109,6 +109,4 @@ You will see the Dapr config, Dapr binaries directory, and the default component
 
 {{< /tabs >}}
 
-{{% alert color="primary" %}}
-[Next step: Use the Dapr API >>]({{< ref get-started-api.md >}})
-{{% /alert %}}
+{{< button text="Next step: Use the Dapr API >>" page="get-started-api" >}}

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -109,5 +109,6 @@ You will see the Dapr config, Dapr binaries directory, and the default component
 
 {{< /tabs >}}
 
-<a class="btn btn-primary" href="{{< ref get-started-api.md >}}" role="button">Next step: Use the Dapr API >></a>
-
+{{% alert color="primary" %}}
+[Next step: Use the Dapr API >>]({{< ref get-started-api.md >}})
+{{% /alert %}}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

These special a tags are not properly recognized in crowdin.com (the translation management tool we are using). I have tried very many other approaches that do not work properly. So, I modified these a tags to alert tags. This retains the eye-catching effect and solves the recognition problem.
