### PR TITLE
Fixing v1.1.1 references in support table

### DIFF
--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -33,19 +33,23 @@ The table below shows the versions of Dapr releases that have been tested togeth
 |--------------------|:--------:|:--------|---------|---------|---------|
 | Feb 17th 2021 | 1.0.0</br>| 1.0.0 | Java 1.0.0 </br>Go 1.0.0 </br>PHP 1.0.0 </br>Python 1.0.0 </br>.NET 1.0.0 | 0.6.0 | Supported |
 | Mar 4th 2021  | 1.0.1</br>| 1.0.1 | Java 1.0.2 </br>Go 1.0.0 </br>PHP 1.0.0 </br>Python 1.0.0 </br>.NET 1.0.0 | 0.6.0 | Supported |
-| Apr 1st 2021 | 1.1.1</br> | 1.1.0 | Java 1.0.2 </br>Go 1.1.0 </br>PHP 1.0.0 </br>Python 1.1.0 </br>.NET 1.1.0 | 0.6.0 | Supported (current) |
+| Apr 1st 2021 | 1.1.0</br> | 1.1.0 | Java 1.0.2 </br>Go 1.1.0 </br>PHP 1.0.0 </br>Python 1.1.0 </br>.NET 1.1.0 | 0.6.0 | Supported |
+| Apr 6th 2021 | 1.1.1</br> | 1.1.0 | Java 1.0.2 </br>Go 1.1.0 </br>PHP 1.0.0 </br>Python 1.1.0 </br>.NET 1.1.0 | 0.6.0 | Supported (current) |
 
 ## Upgrade paths
 After the 1.0 release of the runtime there may be situations where it is necessary to explicitly upgrade through an additional release to reach the desired target. For example an upgrade from v1.0 to v1.2 may need go pass through v1.1
 
 The table below shows the tested upgrade paths for the Dapr runtime. For example you are able to upgrade from 1.0-rc4 to the 1.0 release. Any other combinations of upgrades have not been tested.
 
-|  Current Runtime version | Must upgrade through  | Target Runtime version   | Notes
-|--------------------------|-----------------------|------------------------- |------------------------- |
-| 0.11                     |                   N/A |                    1.0.1 | Use Dapr CLI to upgrade for both self hosted and Kubernetes
-|                          |                  1.0.1|                    1.1.0 |
-| 1.0-rc1 to 1.0-rc4       |                   N/A |                    1.0.1 | See Dapr 1.0 release notes
-| 1.0.0 or 1.0.1           |                   N/A |                    1.1.1 | See Dapr 1.1 release notes
+General guidance on upgrading can be found for [self hosted mode]({{<ref self-hosted-upgrade>}}) and [Kubernetes]({{<ref kubernetes-upgrade>}}) deployments. It is best to review the target version release notes for specific guidance.
+
+|  Current Runtime version | Must upgrade through  | Target Runtime version   |
+|--------------------------|-----------------------|------------------------- |
+| 0.11                     |                   N/A |                    1.0.1 | 
+|                          |                 1.0.1 |                    1.1.1 |
+| 1.0-rc1 to 1.0-rc4       |                   N/A |                    1.0.1 | 
+| 1.0.0 or 1.0.1           |                   N/A |                    1.1.1 | 
+| 1.1.0                    |                   N/A |                    1.1.1 | 
 
 ## Feature and deprecations
 There is a process for announcing feature deprecations.  Deprecations are applied two (2) releases after the release in which they were announced. For example Feature X is announced to be deprecated in the 1.0.0 release notes and will then be removed in 1.2.0.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
The addition of v1.1.1 requires new entries in the support table rather than overwriting v1.1.0 with v1.1.1

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
N/A