### PR TITLE
Update howto-bindings.md

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
@@ -80,7 +80,7 @@ All that's left now is to invoke the output bindings endpoint on a running Dapr 
 You can do so using HTTP:
 
 ```bash
-curl -X POST -H  http://localhost:3500/v1.0/bindings/myevent -d '{ "data": { "message": "Hi!" }, "operation": "create" }'
+curl -X POST -H 'Content-Type: application/json' http://localhost:3500/v1.0/bindings/myevent -d '{ "data": { "message": "Hi!" }, "operation": "create" }'
 ```
 
 As seen above, you invoked the `/binding` endpoint with the name of the binding to invoke, in our case its `myevent`.


### PR DESCRIPTION
missed 'Content-Type: application/json'  in curl command for testing binding

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

curl fails on missing URL. due to 'Content-Type: application/json' missing after the "-H" in the command

## Issue reference

No known documented issue
