### PR TITLE
Add maxLen for redis pubsub component

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
@@ -61,6 +61,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | minIdleConns        | N        | Minimum number of idle connections to keep open in order to avoid the performance degradation associated with creating new connections. Defaults to `"0"`. | `"2"`
 | idleCheckFrequency        | N        | Frequency of idle checks made by idle connections reaper. Default is `"1m"`. `"-1"` disables idle connections reaper. | `"-1"`
 | idleTimeout        | N        | Amount of time after which the client closes idle connections. Should be less than server's timeout. Default is `"5m"`. `"-1"` disables idle timeout check. | `"10m"`
+| maxLenApprox        | N        | Maximum number of items inside a stream.The old entries are automatically evicted when the specified length is reached, so that the stream is left at a constant size. Defaults to unlimited. | `"10000"`
 
 ## Create a Redis instance
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add maxLen for redis pubsub component.Redis stream do not delete message when message was acked. This provides a param to limit the items in one stream.

## Issue reference

Please reference the issue this PR will close: #1446
