### PR TITLE
Don't mark as stale if waiting on code pr

### DIFF
--- a/.github/workflows/stale-pr-monitor.yml
+++ b/.github/workflows/stale-pr-monitor.yml
@@ -17,5 +17,5 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'Stale PR, paging all reviewers'
         stale-pr-label: 'stale'
-        exempt-pr-labels: 'question,"help wanted",do-not-merge'
+        exempt-pr-labels: 'question,"help wanted",do-not-merge,waiting-on-code-pr'
         days-before-stale: 5


### PR DESCRIPTION
Adds the `waiting-on-code-pr` label to the exempt list so PRs won't be marked stale