### PR TITLE
fix: Jaeger docker setup command

### DIFF
--- a/daprdocs/content/en/operations/monitoring/tracing/supported-tracing-backends/jaeger.md
+++ b/daprdocs/content/en/operations/monitoring/tracing/supported-tracing-backends/jaeger.md
@@ -20,7 +20,7 @@ Jaeger image published to DockerHub:
 
 ```bash
 docker run -d --name jaeger \
-  -e COLLECTOR_ZIPKIN_HTTP_PORT=9412 \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9412 \
   -p 16686:16686 \
   -p 9412:9412 \
   jaegertracing/all-in-one:1.22


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

`COLLECTOR_ZIPKIN_HTTP_PORT=9412` shoule be `COLLECTOR_ZIPKIN_HOST_PORT=:9412`, docs is here https://www.jaegertracing.io/docs/1.22/getting-started/#all-in-one

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
