### PR TITLE
Adding dapr HTTP max request size reference for CLI

### DIFF
--- a/daprdocs/content/en/reference/cli/dapr-run.md
+++ b/daprdocs/content/en/reference/cli/dapr-run.md
@@ -38,6 +38,7 @@ dapr run [flags] [command]
 | `--log-level` | | `info` | The log verbosity. Valid values are: `debug`, `info`, `warn`, `error`, `fatal`, or `panic` |
 | `--placement-host-address` | `DAPR_PLACEMENT_HOST` | `localhost` | The host on which the placement service resides |
 | `--profile-port` | | `7777` | The port for the profile server to listen on |
+| `--dapr-http-max-request-size` | | `4` | Max size of request body in MB.|
 
 ## Examples
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Corresponding CLI PR: https://github.com/dapr/cli/pull/703
Add the `--dapr-http-max-request-size` argument for the run command. 
Added the default value set by daprd 4MB.

## Issue reference

closes #1481 
