### PR TITLE
Update docs on using Codespaces with Dapr repos

### DIFF
--- a/daprdocs/content/en/contributing/codespaces.md
+++ b/daprdocs/content/en/contributing/codespaces.md
@@ -4,6 +4,8 @@ title: "Contributing with GitHub Codespaces"
 linkTitle: "GitHub Codespaces"
 weight: 2500
 description: "How to work with Dapr repos in GitHub Codespaces"
+aliases:
+  - "/developing-applications/ides/codespaces/"
 ---
 
 [GitHub Codespaces](https://github.com/features/codespaces) are the easiest way to get up and running for contributing to a Dapr repo. In as little as a single click, you can have an environment with all of the prerequisites ready to go in your browser.

--- a/daprdocs/content/en/contributing/codespaces.md
+++ b/daprdocs/content/en/contributing/codespaces.md
@@ -2,7 +2,7 @@
 type: docs
 title: "Contributing with GitHub Codespaces"
 linkTitle: "GitHub Codespaces"
-weight: 3000
+weight: 2500
 description: "How to work with Dapr repos in GitHub Codespaces"
 ---
 
@@ -37,7 +37,7 @@ If you haven't already forked the repo, creating the Codespace will also create 
 Developing a new Dapr component requires working with both the [components-contrib](https://github.com/dapr/components-contrib) and [dapr](https://github.com/dapr/dapr) repos together under the `$GOPATH` tree for testing purposes. To facilitate this, the `/go/src/github.com/dapr` folder in the components-contrib Codespace will already be set up with your fork of components-contrib, and a clone of the dapr repo as described in the [component development documentation](https://github.com/dapr/components-contrib/blob/master/docs/developing-component.md). A few things to note in this configuration:
 
 - The components-contrib and dapr repos only define Codespaces for the Linux amd64 environment at the moment.
-- The default `/go/src/github.com/dapr/components-contrib` folder is a soft link to Codespace's default `/workspace/components-contrib` folder, so changes in one will be automatically reflected in the other.
+- The `/go/src/github.com/dapr/components-contrib` folder is a soft link to Codespace's default `/workspace/components-contrib` folder, so changes in one will be automatically reflected in the other.
 - Since the `/go/src/github.com/dapr/dapr` folder uses a clone of the official dapr repo rather than a fork, you will not be able to make a pull request from changes made in that folder directly. You can use the dapr Codespace separately for that PR, or if you would like to use the same Codespace for the dapr changes as well, you should remap the dapr repo origin to your fork in the components-contrib Codespace. For example, to use a dapr fork under `my-git-alias`:
 
 ```bash

--- a/daprdocs/content/en/contributing/contributing-overview.md
+++ b/daprdocs/content/en/contributing/contributing-overview.md
@@ -49,6 +49,7 @@ All contributions come through pull requests. To submit a proposed change, follo
 
 1. Make sure there's an issue (bug or proposal) raised, which sets the expectations for the contribution you are about to make.
 1. Fork the relevant repo and create a new branch
+    - Some Dapr repos support [Codespaces]({{< ref codespaces.md >}}) to provide an instant environment for you to build and test your changes.
 1. Create your change
     - Code changes require tests
 1. Update relevant documentation for the change

--- a/daprdocs/content/en/developing-applications/ides/codespaces.md
+++ b/daprdocs/content/en/developing-applications/ides/codespaces.md
@@ -1,12 +1,12 @@
 ---
 type: docs
-title: "Developing with GitHub Codespaces"
+title: "Contributing with GitHub Codespaces"
 linkTitle: "GitHub Codespaces"
 weight: 3000
-description: "How to get up and running with Dapr in a GitHub Codespace"
+description: "How to work with Dapr repos in GitHub Codespaces"
 ---
 
-[GitHub Codespaces](https://github.com/features/codespaces) are the easiest way to get up and running in a Dapr environment. In as little as a single click you have the environment, packages, code, samples, and documentation all ready to go in your browser.
+[GitHub Codespaces](https://github.com/features/codespaces) are the easiest way to get up and running for contributing to a Dapr repo. In as little as a single click, you can have an environment with all of the prerequisites ready to go in your browser.
 
 {{% alert title="Private Beta" color="warning" %}}
 GitHub Codespaces is currently in a private beta. Sign up [here](https://github.com/features/codespaces/signup).
@@ -24,9 +24,28 @@ To open a Dapr repository in a Codespace simply select "Code" from the repo home
 
 <img src="/images/codespaces-create.png" alt="Screenshot of creating a Dapr Codespace" width="300">
 
+If you haven't already forked the repo, creating the Codespace will also create a fork for you and use it inside the Codespace.
+
 ### Supported repos
 
+- [Dapr](https://github.com/dapr/dapr)
+- [Components-contrib](https://github.com/dapr/components-contrib)
 - [Python SDK](https://github.com/dapr/python-sdk)
+
+### Developing Dapr Components in a Codespace
+
+Developing a new Dapr component requires working with both the [components-contrib](https://github.com/dapr/components-contrib) and [dapr](https://github.com/dapr/dapr) repos together under the `$GOPATH` tree for testing purposes. To facilitate this, the `/go/src/github.com/dapr` folder in the components-contrib Codespace will already be set up with your fork of components-contrib, and a clone of the dapr repo as described in the [component development documentation](https://github.com/dapr/components-contrib/blob/master/docs/developing-component.md). A few things to note in this configuration:
+
+- The components-contrib and dapr repos only define Codespaces for the Linux amd64 environment at the moment.
+- The default `/go/src/github.com/dapr/components-contrib` folder is a soft link to Codespace's default `/workspace/components-contrib` folder, so changes in one will be automatically reflected in the other.
+- Since the `/go/src/github.com/dapr/dapr` folder uses a clone of the official dapr repo rather than a fork, you will not be able to make a pull request from changes made in that folder directly. You can use the dapr Codespace separately for that PR, or if you would like to use the same Codespace for the dapr changes as well, you should remap the dapr repo origin to your fork in the components-contrib Codespace. For example, to use a dapr fork under `my-git-alias`:
+
+```bash
+cd /go/src/github.com/dapr/dapr
+git remote set-url origin https://github.com/my-git-alias/dapr
+git fetch
+git reset --hard
+```
 
 ## Related links
 - [GitHub documentation](https://docs.github.com/en/github/developing-online-with-codespaces/about-codespaces)


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

- Update codespaces.md to:
   - Change name and description of page to indicate the use of Codespaces as developing for Dapr, instead of developing apps with Dapr as is the case with other entries under the IDE Support section of the docs.
   - Include dapr and components-contrib repos as supporting Codespaces
   - Add notes for specific scenario of developing Dapr components using components-contrib Codespace.
- Update contributing-overview.md to link to codespaces.md in process for submitting a PR.

Needs to wait on code PRs for:
- [ ] https://github.com/dapr/dapr/pull/3230
- [ ] NYI: https://github.com/dapr/components-contrib/pull/????

## Issue reference

Resolves #1520
