### PR TITLE
Fix incorrect postgresql connection string example

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-postgresql.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-postgresql.md
@@ -34,7 +34,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 | Field              | Required | Details | Example |
 |--------------------|:--------:|---------|---------|
-| connectionString   | Y        | The connection string for PostgreSQL | `"User ID=root;Password=myPassword;Host=localhost;Port=5432"`
+| connectionString   | Y        | The connection string for PostgreSQL | `"host=localhost user=postgres password=example port=5432 connect_timeout=10 database=dapr_test"`
 | actorStateStore    | N         | Consider this state store for actors. Defaults to `"false"` | `"true"`, `"false"`
 
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fix incorrect postgresql connection string example.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->

#1523 