### PR TITLE
add consumerID in spec.metadata which is required

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -89,4 +89,4 @@ To run Kafka on Kubernetes, you can use any Kafka operator, such as [Strimzi](ht
 ## Related links
 - [Basic schema for a Dapr component]({{< ref component-schema >}})
 - Read [this guide]({{< ref "howto-publish-subscribe.md##step-1-setup-the-pubsub-component" >}}) for instructions on configuring pub/sub components
-- [Pub/Sub building block]({{< ref pubsub >}})
+- [Pub/Sub building block]({{< ref pubsub >}}) 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -89,4 +89,4 @@ To run Kafka on Kubernetes, you can use any Kafka operator, such as [Strimzi](ht
 ## Related links
 - [Basic schema for a Dapr component]({{< ref component-schema >}})
 - Read [this guide]({{< ref "howto-publish-subscribe.md##step-1-setup-the-pubsub-component" >}}) for instructions on configuring pub/sub components
-- [Pub/Sub building block]({{< ref pubsub >}}) 
+- [Pub/Sub building block]({{< ref pubsub >}})

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -24,6 +24,8 @@ spec:
       # Kafka broker connection setting
     - name: brokers
       value: "dapr-kafka.myapp.svc.cluster.local:9092"
+    - name: consumerID
+      value: "consumerIDVal"
     - name: authRequired
       value: "true"
     - name: saslUsername
@@ -43,6 +45,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | Field              | Required | Details | Example |
 |--------------------|:--------:|---------|---------|
 | brokers             | Y  | Comma separated list of kafka brokers  | `localhost:9092`, `dapr-kafka.myapp.svc.cluster.local:9092`
+| consumerID          | Y  | Using it as ConsumerGroup name         | `consumerIDVal`
 | authRequired        | N  | Enable authentication on the Kafka broker. Defaults to `"false"`.   |`"true"`, `"false"`
 | saslUsername        | N  | Username used for authentication. Only required if authRequired is set to true.   | `"adminuser"`
 | saslPassword        | N  | Password used for authentication. Can be `secretKeyRef` to use a secret reference. Only required if authRequired is set to true. Can be `secretKeyRef` to use a [secret reference]({{< ref component-secrets.md >}})  |  `""`, `"KeFg23!"`


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Kafka pubsub configuration require consumerID in spec.metadata

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->

#1529 
