### PR TITLE
Fix the file name of secrets json

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/secrets/howto-secrets.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/secrets/howto-secrets.md
@@ -14,7 +14,7 @@ Before retrieving secrets in your application's code, you must have a secret sto
 
 >Note: The component used in this example is not secured and is not recommended for production deployments. You can find other alternatives [here]({{<ref supported-secret-stores >}}).
 
-Create a file named `secrets.json` with the following contents:
+Create a file named `mysecrets.json` with the following contents:
 
 ```json
 {


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fix the typo of file name. 

The docs call it secrets.json but the example shows mysecrets.json

Now using mysecrets.json in both places. 

## Issue reference
https://github.com/dapr/docs/issues/1545
