### PR TITLE
Updating PubSub documentation to remove slave wording

### DIFF
--- a/daprdocs/content/en/getting-started/configure-state-pubsub.md
+++ b/daprdocs/content/en/getting-started/configure-state-pubsub.md
@@ -52,8 +52,8 @@ You can use [Helm](https://helm.sh/) to quickly create a Redis instance in our K
     $ kubectl get pods
     NAME             READY   STATUS    RESTARTS   AGE
     redis-master-0   1/1     Running   0          69s
-    redis-slave-0    1/1     Running   0          69s
-    redis-slave-1    1/1     Running   0          22s
+    redis-replicas-0    1/1     Running   0          69s
+    redis-replicas-1    1/1     Running   0          22s
     ```
 
 Note that the hostname is `redis-master.default.svc.cluster.local:6379`, and a Kubernetes secret, `redis`, is created automatically.

--- a/daprdocs/content/en/operations/components/setup-pubsub/pubsub-namespaces.md
+++ b/daprdocs/content/en/operations/components/setup-pubsub/pubsub-namespaces.md
@@ -24,7 +24,7 @@ The table below shows which resources are deployed to which namespaces:
 | Resource                | namespace-a | namespace-b |
 |------------------------ |-------------|-------------|
 | Redis master            | X           |             |
-| Redis slave             | X           |             |
+| Redis replicas          | X           |             |
 | Dapr's PubSub component | X           | X           |
 | Node subscriber         | X           |             |
 | Python subscriber       | X           |             |


### PR DESCRIPTION
Bitnami has updated their Redis Helm chart to change redis-slave to redis-replicas. I am updating the documentation for PubSub to reflect this change and avoid confusion for any readers.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
