### PR TITLE
Fixed GCP Pub/Sub Binding required fields

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/gcppubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/gcppubsub.md
@@ -56,17 +56,17 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | Field              | Required  | Binding support | Details | Example |
 |--------------------|:--------:|-----------| -----|---------|
 | topic | Y | Output | GCP Pub/Sub topic name | `"topic1"` |
-| subscription | Y | GCP Pub/Sub subscription name | `"name1"` |
+| subscription | N | GCP Pub/Sub subscription name | `"name1"` |
 | type           | Y | Output | GCP credentials type  | `service_account`
 | project_id     | Y | Output | GCP project id| `projectId`
-| private_key_id | Y | Output | GCP private key id | `"privateKeyId"`
+| private_key_id | N | Output | GCP private key id | `"privateKeyId"`
 | private_key    | Y | Output | GCP credentials private key. Replace with x509 cert | `12345-12345`
 | client_email   | Y | Output | GCP client email  | `"client@email.com"`
-| client_id      | Y | Output | GCP client id | `0123456789-0123456789`
-| auth_uri       | Y | Output | Google account OAuth endpoint | `https://accounts.google.com/o/oauth2/auth`
-| token_uri      | Y | Output | Google account token uri | `https://oauth2.googleapis.com/token`
-| auth_provider_x509_cert_url | Y | Output |GCP credentials cert url | `https://www.googleapis.com/oauth2/v1/certs`
-| client_x509_cert_url | Y | Output | GCP credentials project x509 cert url | `https://www.googleapis.com/robot/v1/metadata/x509/<PROJECT_NAME>.iam.gserviceaccount.com`
+| client_id      | N | Output | GCP client id | `0123456789-0123456789`
+| auth_uri       | N | Output | Google account OAuth endpoint | `https://accounts.google.com/o/oauth2/auth`
+| token_uri      | N | Output | Google account token uri | `https://oauth2.googleapis.com/token`
+| auth_provider_x509_cert_url | N | Output |GCP credentials cert url | `https://www.googleapis.com/oauth2/v1/certs`
+| client_x509_cert_url | N | Output | GCP credentials project x509 cert url | `https://www.googleapis.com/robot/v1/metadata/x509/<PROJECT_NAME>.iam.gserviceaccount.com`
 
 ## Binding support
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixed incorrect listing of required field for GCP pub/sub binding

## Issue reference

https://github.com/dapr/docs/issues/1534
