### PR TITLE
fix: cron format in the example

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cron.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cron.md
@@ -50,7 +50,7 @@ For example:
 * `30 * * * * *` - every 30 seconds
 * `0 15 * * * *` - every 15 minutes
 * `0 30 3-6,20-23 * * *` - every hour on the half hour in the range 3-6am, 8-11pm
-* `CRON_TZ=America/New_York 0 0 30 04 * * *` - every day at 4:30am New York time
+* `CRON_TZ=America/New_York 0 30 04 * * *` - every day at 4:30am New York time
 
 > You can learn more about cron and the supported formats [here](https://en.wikipedia.org/wiki/Cron)
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Cron format in one of the examples corrected.

When I tried with the example first (`CRON_TZ=America/New_York 0 0 30 04 * * *`), all the dapr apps went down with an error.
> Exec lifecycle hook ([/daprd --wait]) for Container "daprd" in Pod "REDACTED-c4cb6b4b5-k5dg7_REDACTED(d0035164-52ea-48ff-a41f-f3442147441b)" failed - error: rpc error: code = Unknown desc = container not running (daprd), message: ""

![image](https://user-images.githubusercontent.com/7039457/122726704-4e3d7300-d287-11eb-9baa-31fcf30e19c7.png)
Maybe the cron component failed. So I changed the cron format of the component and re-applied, then everything was fine.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
