### PR TITLE
Add Dapr Roadmap doc

### DIFF
--- a/daprdocs/content/en/roadmap/_index.md
+++ b/daprdocs/content/en/roadmap/_index.md
@@ -1,0 +1,24 @@
+---
+type: docs
+title: "Dapr Roadmap"
+linkTitle: "Dapr Roadmap"
+description: "The Dapr Roadmap is a tool to help with visibility into investments across the Dapr project"
+weight: 200
+no_list: true
+---
+
+[Dapr Roadmap](https://aka.ms/dapr/roadmap)
+
+Dapr encourages the community to help with prioritization. Please vote by adding a 👍 on the GitHub issues for the feature capabilities you would most like to see Dapr support. This will help the Dapr maintainers understand which features will provide the most value.
+
+Dapr welcomes contributions from the community. If there are features on the roadmap that you are interested in contributing to, please comment on the GitHub issue and include your solution proposal, if available.
+
+The Dapr Roadmap progresses through the following four stages:
+
+| Column | Description |
+|----------|------------|
+| [Backlog](https://github.com/orgs/dapr/projects/52#column-14691591) | GitHub issues (features) that have sparked interest from the Dapr community will be moved by maintainers into the Dapr Roadmap and by default added to the Backlog column. <br /><br />Please vote by adding a 👍 to the features you would most like to see Dapr support as this will help influence priority.<br /><br />Note: Currently, GitHub items are manually added to the Dapr Roadmap. Looking ahead, Dapr maintainers will automate this process based on the number of 👍 a GitHub issue (feature) receives.|
+| [Planned (Committed)](https://github.com/orgs/dapr/projects/52#column-14561691) | Once a GitHub issue (feature) has a proposal and/or has a targeted release milestone, it is moved into the “Planned” column. This is where design proposals are discussed before moving into the implementation phase (In progress).
+| [In Progress (Development)](https://github.com/orgs/dapr/projects/52#column-14561696) | [Implementation specifics have been agreed upon and the feature is under active development.
+| [Done](https://github.com/orgs/dapr/projects/52#column-14561700)| The feature capability has been completed and is scheduled for an upcoming release.
+| [Released](https://github.com/orgs/dapr/projects/52#column-14659973) | The feature is released and available for use.

--- a/daprdocs/content/en/roadmap/_index.md
+++ b/daprdocs/content/en/roadmap/_index.md
@@ -16,35 +16,27 @@ Dapr welcomes contributions from the community. If there are features on the roa
 <br />
 The Dapr Roadmap progresses through the following four stages:
 
-<div class="card-deck">
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14691591">Backlog</a></b></h5>
-      <p class="card-text">GitHub issues (features) that have sparked interest from the Dapr community will be moved by maintainers into the Dapr Roadmap and by default added to the Backlog column. <br /><br />Please vote by adding a 👍 to the features you would most like to see Dapr support as this will help influence priority.</p>
-    </div>
-  </div>
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14561691">Planned (Committed)</a></b></h5>
-      <p class="card-text">Once a GitHub issue (feature) has a proposal and/or has a targeted release milestone, it is moved into the “Planned” column. This is where design proposals are discussed before moving into the implementation phase (In progress).</p>
-    </div>
-  </div>
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14561696">In Progress (Development)</a></b></h5>
-      <p class="card-text">Implementation specifics have been agreed upon and the feature is under active development.</p>
-    </div>
-  </div>
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14561700">Done</a></b></h5>
-      <p class="card-text">The feature capability has been completed and is scheduled for an upcoming release.</p>
-    </div>
-  </div>
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14659973">Released</a></b></h5>
-      <p class="card-text">The feature is released and available for use.</p>
-    </div>
-  </div>
-</div>
+{{< cardpane >}}
+{{< card title="**[Backlog](https://github.com/orgs/dapr/projects/52#column-14691591)**" >}}
+  GitHub issues (features) that have sparked interest from the Dapr community will be moved by maintainers into the Dapr Roadmap and by default added to the Backlog column. 
+
+  Please vote by adding a 👍 to the features you would most like to see Dapr support as this will help influence priority.
+{{< /card >}}
+
+{{< card title="**[Planned (Committed)](https://github.com/orgs/dapr/projects/52#column-14561691)**" >}}
+  Once a GitHub issue (feature) has a proposal and/or has a targeted release milestone, it is moved into the “Planned” column. This is where design proposals are discussed before moving into the implementation phase (In progress).
+{{< /card >}}
+
+{{< card title="**[In Progress (Development)](https://github.com/orgs/dapr/projects/52#column-14561696)**" >}}
+ Implementation specifics have been agreed upon and the feature is under active development.
+{{< /card >}}
+
+{{< card title="**[Done](https://github.com/orgs/dapr/projects/52#column-14561700)**" >}}
+ The feature capability has been completed and is scheduled for an upcoming release.
+{{< /card >}}
+
+{{< card title="**[Released](https://github.com/orgs/dapr/projects/52#column-14659973)**" >}}
+ The feature is released and available for use.
+{{< /card >}}
+
+{{< /cardpane >}}

--- a/daprdocs/content/en/roadmap/_index.md
+++ b/daprdocs/content/en/roadmap/_index.md
@@ -7,18 +7,44 @@ weight: 200
 no_list: true
 ---
 
-[Dapr Roadmap](https://aka.ms/dapr/roadmap)
+### [Dapr Roadmap](https://aka.ms/dapr/roadmap)
 
 Dapr encourages the community to help with prioritization. Please vote by adding a 👍 on the GitHub issues for the feature capabilities you would most like to see Dapr support. This will help the Dapr maintainers understand which features will provide the most value.
 
 Dapr welcomes contributions from the community. If there are features on the roadmap that you are interested in contributing to, please comment on the GitHub issue and include your solution proposal, if available.
 
+<br />
 The Dapr Roadmap progresses through the following four stages:
 
-| Column | Description |
-|----------|------------|
-| [Backlog](https://github.com/orgs/dapr/projects/52#column-14691591) | GitHub issues (features) that have sparked interest from the Dapr community will be moved by maintainers into the Dapr Roadmap and by default added to the Backlog column. <br /><br />Please vote by adding a 👍 to the features you would most like to see Dapr support as this will help influence priority.<br /><br />Note: Currently, GitHub items are manually added to the Dapr Roadmap. Looking ahead, Dapr maintainers will automate this process based on the number of 👍 a GitHub issue (feature) receives.|
-| [Planned (Committed)](https://github.com/orgs/dapr/projects/52#column-14561691) | Once a GitHub issue (feature) has a proposal and/or has a targeted release milestone, it is moved into the “Planned” column. This is where design proposals are discussed before moving into the implementation phase (In progress).
-| [In Progress (Development)](https://github.com/orgs/dapr/projects/52#column-14561696) | [Implementation specifics have been agreed upon and the feature is under active development.
-| [Done](https://github.com/orgs/dapr/projects/52#column-14561700)| The feature capability has been completed and is scheduled for an upcoming release.
-| [Released](https://github.com/orgs/dapr/projects/52#column-14659973) | The feature is released and available for use.
+<div class="card-deck">
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14691591">Backlog</a></b></h5>
+      <p class="card-text">GitHub issues (features) that have sparked interest from the Dapr community will be moved by maintainers into the Dapr Roadmap and by default added to the Backlog column. <br /><br />Please vote by adding a 👍 to the features you would most like to see Dapr support as this will help influence priority.</p>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14561691">Planned (Committed)</a></b></h5>
+      <p class="card-text">Once a GitHub issue (feature) has a proposal and/or has a targeted release milestone, it is moved into the “Planned” column. This is where design proposals are discussed before moving into the implementation phase (In progress).</p>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14561696">In Progress (Development)</a></b></h5>
+      <p class="card-text">Implementation specifics have been agreed upon and the feature is under active development.</p>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14561700">Done</a></b></h5>
+      <p class="card-text">The feature capability has been completed and is scheduled for an upcoming release.</p>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title"><b><a href="https://github.com/orgs/dapr/projects/52#column-14659973">Released</a></b></h5>
+      <p class="card-text">The feature is released and available for use.</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add Dapr Roadmap docs page.
