### PR TITLE
Remove "http" code type from metadata_api.md

### DIFF
--- a/daprdocs/content/en/reference/api/metadata_api.md
+++ b/daprdocs/content/en/reference/api/metadata_api.md
@@ -18,7 +18,7 @@ Gets the Dapr sidecar information provided by the Metadata Endpoint.
 
 ### HTTP Request
 
-```http
+```
 GET http://localhost:<daprPort>/v1.0/metadata
 ```
 


### PR DESCRIPTION
Looking at this page, this line was highlighted.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
