### PR TITLE
Add info about accessing container images from private registries

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-overview.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-overview.md
@@ -32,6 +32,15 @@ Deploying and running a Dapr enabled application into your Kubernetes cluster is
     dapr.io/config: "tracing"
 ```
 
+## Pulling container images from private registries
+
+Dapr works seamlessly with any user application container image, regardless of its origin. Simply init Dapr and add the [Dapr annotations]({{< ref kubernetes-annotations >}}) to your Kubernetes definition to add the Dapr sidecar.
+
+The Dapr control-plane and sidecar images come from the [daprio Docker Hub](https://hub.docker.com/u/daprio) container registry, which is a public registry.
+
+For information about pulling your application images from a private registry, reference the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). If you are using Azure Container Registry with Azure Kubernetes Service, reference the [AKS documentation](https://docs.microsoft.com/en-us/azure/aks/cluster-container-registry-integration).
+
+
 ## Quickstart
 
 You can see some examples [here](https://github.com/dapr/quickstarts/tree/master/hello-kubernetes) in the Kubernetes getting started quickstart.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Add info about accessing container images from private registries

<!--Please explain the changes you've made-->

## Issue reference

https://github.com/dapr/dapr/issues/3298
