### PR TITLE
Add information to create a database named 'daprStore' in case no dat…

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mongodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mongodb.md
@@ -78,9 +78,7 @@ docker run --name some-mongo -d mongo
 
 You can then interact with the server using `localhost:27017`.
 
-{{% alert title="Note" %}}
-Please create a database named `daprStore` in case the `databaseName` is not specified in the component definition. 
-{{% /alert %}}
+If you do not specify a `databaseName` value in your component definition, make sure to create a database named `daprStore`. 
 
 {{% /codetab %}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mongodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mongodb.md
@@ -77,6 +77,11 @@ docker run --name some-mongo -d mongo
 ```
 
 You can then interact with the server using `localhost:27017`.
+
+{{% alert title="Note" %}}
+Please create a database named `daprStore` in case the `databaseName` is not specified in the component definition. 
+{{% /alert %}}
+
 {{% /codetab %}}
 
 {{% codetab %}}


### PR DESCRIPTION


Add information to create a database named 'daprStore' in case no databaseName is specified as Dapr Mongo Component defaults to `daprStore`. I spent a lot of time identifying and figuring out the issue when trying to use it without databaseName. 

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
