### PR TITLE
Update EventHubs bindings/pubsub docs with supported Azure IoT Hub properties

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/eventhubs.md
@@ -58,6 +58,40 @@ This component supports **output binding** with the following operations:
 
 - `create`
 
+## Input Binding to Azure IoT Hub Events
+
+Azure IoT Hub provides an [endpoint that is compatible with Event Hubs](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin#read-from-the-built-in-endpoint), so Dapr apps can create input bindings to read Azure IoT Hub events using the Event Hubs bindings component.
+
+The device-to-cloud events created by Azure IoT Hub devices will contain additional [IoT Hub System Properties](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-construct#system-properties-of-d2c-iot-hub-messages), and the Azure Event Hubs binding for Dapr will return the following as part of the response metadata:
+
+| System Property Name | Description |
+|--------------------|:--------|
+| `iothub-connection-auth-generation-id` | The **connectionDeviceGenerationId** of the device that sent the message. See [IoT Hub device identity properties](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#device-identity-properties). |
+| `iothub-connection-auth-method` | The authentication method used to authenticate the device that sent the message. |
+| `iothub-connection-device-id` | The **deviceId** of the device that sent the message. See [IoT Hub device identity properties](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#device-identity-properties). |
+| `iothub-connection-module-id` | The **moduleId** of the device that sent the message. See [IoT Hub device identity properties](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#device-identity-properties). |
+| `iothub-enqueuedtime` | The date and time in RFC3339 format that the device-to-cloud message was received by IoT Hub. |
+
+For example, the headers of a HTTP `Read()` response would contain:
+
+```nodejs
+{
+  'user-agent': 'fasthttp',
+  'host': '127.0.0.1:3000',
+  'content-type': 'application/json',
+  'content-length': '120',
+  'iothub-connection-device-id': 'my-test-device',
+  'iothub-connection-auth-generation-id': '637618061680407492',
+  'iothub-connection-auth-method': '{"scope":"module","type":"sas","issuer":"iothub","acceptingIpFilterRule":null}',
+  'iothub-connection-module-id': 'my-test-module-a',
+  'iothub-enqueuedtime': '2021-07-13T22:08:09Z',
+  'x-opt-sequence-number': '35',
+  'x-opt-enqueued-time': '2021-07-13T22:08:09Z',
+  'x-opt-offset': '21560',
+  'traceparent': '00-4655608164bc48b985b42d39865f3834-ed6cf3697c86e7bd-01'
+}
+```
+
 ## Related links
 
 - [Basic schema for a Dapr component]({{< ref component-schema >}})

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -58,6 +58,40 @@ For example, a Dapr app running on Kubernetes with `dapr.io/app-id: "myapp"` wil
 
 Note: Dapr passes the name of the Consumer group to the EventHub and so this is not supplied in the metadata.
 
+## Subscribing to Azure IoT Hub Events
+
+Azure IoT Hub provides an [endpoint that is compatible with Event Hubs](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin#read-from-the-built-in-endpoint), so the Azure Event Hubs pubsub component can also be used to subscribe to Azure IoT Hub events.
+
+The device-to-cloud events created by Azure IoT Hub devices will contain additional [IoT Hub System Properties](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-construct#system-properties-of-d2c-iot-hub-messages), and the Azure Event Hubs pubsub component for Dapr will return the following as part of the response metadata:
+
+| System Property Name | Description |
+|--------------------|:--------|
+| `iothub-connection-auth-generation-id` | The **connectionDeviceGenerationId** of the device that sent the message. See [IoT Hub device identity properties](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#device-identity-properties). |
+| `iothub-connection-auth-method` | The authentication method used to authenticate the device that sent the message. |
+| `iothub-connection-device-id` | The **deviceId** of the device that sent the message. See [IoT Hub device identity properties](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#device-identity-properties). |
+| `iothub-connection-module-id` | The **moduleId** of the device that sent the message. See [IoT Hub device identity properties](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#device-identity-properties). |
+| `iothub-enqueuedtime` | The date and time in RFC3339 format that the device-to-cloud message was received by IoT Hub. |
+
+For example, the headers of a delivered HTTP subscription message would contain:
+
+```nodejs
+{
+  'user-agent': 'fasthttp',
+  'host': '127.0.0.1:3000',
+  'content-type': 'application/json',
+  'content-length': '120',
+  'iothub-connection-device-id': 'my-test-device',
+  'iothub-connection-auth-generation-id': '637618061680407492',
+  'iothub-connection-auth-method': '{"scope":"module","type":"sas","issuer":"iothub","acceptingIpFilterRule":null}',
+  'iothub-connection-module-id': 'my-test-module-a',
+  'iothub-enqueuedtime': '2021-07-13T22:08:09Z',
+  'x-opt-sequence-number': '35',
+  'x-opt-enqueued-time': '2021-07-13T22:08:09Z',
+  'x-opt-offset': '21560',
+  'traceparent': '00-4655608164bc48b985b42d39865f3834-ed6cf3697c86e7bd-01'
+}
+```
+
 ## Related links
 - [Basic schema for a Dapr component]({{< ref component-schema >}})
 - Read [this guide]({{< ref "howto-publish-subscribe.md#step-2-publish-a-topic" >}}) for instructions on configuring pub/sub components


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added section on Azure IoT Hub Properties returned as metadata by EventHubs input binding and pubsub subscription in the respective component reference pages:
https://v1-3.docs.dapr.io/reference/components-reference/supported-pubsub/setup-azure-eventhubs/
https://v1-3.docs.dapr.io/reference/components-reference/supported-bindings/eventhubs/

This accompanies the merged code change for v1.3: https://github.com/dapr/components-contrib/pull/1009

## Issue reference

Closes: #1639
