### PR TITLE
Fixing link that sometimes fails link validation auto tests

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/zeebe-command.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/zeebe-command.md
@@ -9,7 +9,7 @@ description: "Detailed documentation on the Zeebe command binding component"
 
 To setup Zeebe command binding create a component of type `bindings.zeebe.command`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.
 
-See [this](https://docs.camunda.io/docs/product-manuals/zeebe/zeebe-overview/) for Zeebe documentation.
+See [this](https://docs.camunda.io/docs/product-manuals/zeebe/zeebe-overview) for Zeebe documentation.
 
 ```yaml
 apiVersion: dapr.io/v1alpha1
@@ -59,8 +59,7 @@ This component supports **output binding** with the following operations:
 
 ### Output binding
 
-Zeebe uses gRPC under the hood for the Zeebe client we use in this binding. Please consult the gRPC API reference for more information: 
-https://stage.docs.zeebe.io/reference/grpc.html  
+Zeebe uses gRPC under the hood for the Zeebe client we use in this binding. Please consult the [gRPC API reference](https://stage.docs.zeebe.io/reference/grpc.html) for more information. 
 
 #### topology
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Fixing a link that at times causes failures in validation test (original link is ok but seems to be redirected along the way through a "page not found")

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
