### PR TITLE
Fix Zeebee overview link

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/zeebe-command.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/zeebe-command.md
@@ -9,7 +9,7 @@ description: "Detailed documentation on the Zeebe command binding component"
 
 To setup Zeebe command binding create a component of type `bindings.zeebe.command`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.
 
-See [this](https://docs.camunda.io/docs/product-manuals/zeebe/zeebe-overview/) for Zeebe documentation.
+See [this](https://docs.camunda.io/docs/product-manuals/zeebe/zeebe-overview) for Zeebe documentation.
 
 ```yaml
 apiVersion: dapr.io/v1alpha1


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fix the Zeebee documentation link for the zeebee-command bindings component docs which are causing the GitHub link validation workflow to fail

## Issue reference

See https://github.com/dapr/docs/runs/3062026002?check_suite_focus=true
