### PR TITLE
Add build-info CLI reference

### DIFF
--- a/daprdocs/content/en/reference/cli/dapr-build-info.md
+++ b/daprdocs/content/en/reference/cli/dapr-build-info.md
@@ -1,0 +1,23 @@
+---
+type: docs
+title: "build-info CLI command reference"
+linkTitle: "build-info"
+description: "Detailed build information on dapr-cli and daprd executables"
+---
+
+## Description
+
+Get the version and git commit data for `dapr-cli` and `daprd` executables.
+
+## Supported platforms
+
+- [Self-Hosted]({{< ref self-hosted >}})
+
+## Usage
+```bash
+dapr build-info
+```
+
+## Related facts
+
+You can get `daprd` build information directly by invoking `daprd --build-info` command.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Add build-info CLI reference
## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
#1653