### PR TITLE
Ensure MiniKube start command works by removing Kubernetes version an…

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-minikube.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-minikube.md
@@ -31,7 +31,7 @@ minikube config set vm-driver [driver_name]
 Use 1.13.x or newer version of Kubernetes with `--kubernetes-version`
 
 ```bash
-minikube start --cpus=4 --memory=4096 --kubernetes-version=1.16.2 --extra-config=apiserver.authorization-mode=RBAC
+minikube start --cpus=4 --memory=4096
 ```
 
 3. Enable dashboard and ingress addons


### PR DESCRIPTION
…d authorization params

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Removed the k8s version and authorization mode params from the minikube start command. RBAC is part of the default authorization mode in k8s versions (> 1.17.) 

## Issue reference

https://github.com/dapr/docs/issues/1646
