### PR TITLE
Fix profiling flag example

### DIFF
--- a/daprdocs/content/en/operations/troubleshooting/profiling-debugging.md
+++ b/daprdocs/content/en/operations/troubleshooting/profiling-debugging.md
@@ -21,7 +21,7 @@ To enable profiling in Standalone mode, pass the `--enable-profiling` and the `-
 Note that `profile-port` is not required, and if not provided Dapr will pick an available port.
 
 ```bash
-dapr run --enable-profiling true --profile-port 7777 python myapp.py
+dapr run --enable-profiling --profile-port 7777 python myapp.py
 ```
 
 ### Kubernetes


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

## Description

Fix use of the profiling flag in one example. This is in accordance with https://github.com/dapr/cli/pull/768
