### PR TITLE
Add declarative subscription example to pubsub-raw.md

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-raw.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-raw.md
@@ -83,8 +83,7 @@ Dapr apps are also able to subscribe to raw events coming from existing pub/sub 
 
 <img src="/images/pubsub_subscribe_raw.png" alt="Diagram showing how to subscribe with Dapr when publisher does not use Dapr or CloudEvent" width=1000>
 
-
-### Programmatically subscribe to raw events 
+### Programmatically subscribe to raw events
 
 When subscribing programmatically, add the additional metadata entry for `rawPayload` so the Dapr sidecar automatically wraps the payloads into a CloudEvent that is compatible with current Dapr SDKs.
 
@@ -148,10 +147,25 @@ $app->start();
 
 {{< /tabs >}}
 
-
 ## Declaratively subscribe to raw events
 
-Subscription Custom Resources Definitions (CRDs) do not currently contain metadata attributes ([issue #3225](https://github.com/dapr/dapr/issues/3225)). At this time subscribing to raw events can only be done through programmatic subscriptions.
+Similarly, you can subscribe to raw events declaratively by adding the `rawPayload` metadata entry to your Subscription Custom Resource Definition (CRD):
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: myevent-subscription
+spec:
+  topic: deathStarStatus
+  route: /dsstatus
+  pubsubname: pubsub
+  metadata:
+    rawPayload: "true"
+scopes:
+- app1
+- app2
+```
 
 ## Related links
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Replace reference to fixed issue https://github.com/dapr/dapr/issues/3225 with an example for specifying `rawPayload` metadata in the Subscription CRD.

## Issue reference

Fixes #1674

