### PR TITLE
Add downgrade language to the dapr upgrade cli docs

### DIFF
--- a/daprdocs/content/en/reference/cli/dapr-upgrade.md
+++ b/daprdocs/content/en/reference/cli/dapr-upgrade.md
@@ -7,7 +7,11 @@ description: "Detailed information on the upgrade CLI command"
 
 ## Description
 
-Upgrade Dapr on supported hosting platforms.
+Upgrade or downgrade Dapr on supported hosting platforms. 
+
+> Note: Version steps should be done incrementally, including minor versions as you upgrade or downgrade.
+
+> Note: Prior to downgrading, confirm components are backwards compatible and application code does ultilize APIs that are not supported in previous versions of Dapr. 
 
 ## Supported platforms
 
@@ -23,8 +27,8 @@ dapr upgrade [flags]
 | Name | Environment Variable | Default | Description
 | --- | --- | --- | --- |
 | `--help`, `-h` | | | Print this help message |
-| `--kubernetes`, `-k` | | `false` | Upgrade Dapr in a Kubernetes cluster |
-| `--runtime-version` | | `latest` | The version of the Dapr runtime to upgrade to, for example: `1.0.0` |
+| `--kubernetes`, `-k` | | `false` | Upgrade/Downgrade Dapr in a Kubernetes cluster |
+| `--runtime-version` | | `latest` | The version of the Dapr runtime to upgrade/downgrade to, for example: `1.0.0` |
 | `--set` | | | Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2) |
 
 ## Examples
@@ -34,15 +38,16 @@ dapr upgrade [flags]
 dapr upgrade -k
 ```
 
-### Upgrade specified version of Dapr runtime in Kubernetes
+### Upgrade or downgrade to a specified version of Dapr runtime in Kubernetes
 ```bash
 dapr upgrade -k --runtime-version 1.2
 ```
 
-### Upgrade specified version of Dapr runtime in Kubernetes with value set
+### Upgrade or downgrade to a specified version of Dapr runtime in Kubernetes with value set
 ```bash
 dapr upgrade -k --runtime-version 1.2 --set global.logAsJson=true
 ```
+
 # Related links
 
 - [Upgrade Dapr on a Kubernetes cluster]({{< ref kubernetes-upgrade.md >}})


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Added language to the CLI 'upgrade' docs that the command can also be used to downgrade or rollback a version bump. 

Note: Would like to see a separate command for "downgrading" offered in the CLI.