### PR TITLE
Add global TTL option for Redis

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
@@ -35,6 +35,8 @@ spec:
     value: # Optional
   - name: maxRetryBackoff
     value: # Optional
+  - name: ttlInSeconds
+    value: <int> # Optional
 ```
 **TLS:** If the Redis instance supports TLS with public certificates it can be configured to enable or disable TLS `true` or `false`.
 
@@ -81,6 +83,7 @@ If you wish to use Redis as an actor store, append the following to the yaml.
 | idleCheckFrequency        | N        | Frequency of idle checks made by idle connections reaper. Default is `"1m"`. `"-1"` disables idle connections reaper. | `"-1"`
 | idleTimeout        | N        | Amount of time after which the client closes idle connections. Should be less than server's timeout. Default is `"5m"`. `"-1"` disables idle timeout check. | `"10m"`
 | actorStateStore    | N         | Consider this state store for actors. Defaults to `"false"` | `"true"`, `"false"`
+| ttlInSeconds       | N         | Allows specifying a default Time-to-live (TTL) in seconds that will be applied to every state store request unless TTL is explictly defined via the request metadata. This is especially useful because Redis does not offer a global default TTL feature. [Read more]({{< ref "state-store-ttl.md" >}}) about State Time-to-Live (TTL). | `600` 
 
 ## Setup Redis
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
@@ -83,7 +83,7 @@ If you wish to use Redis as an actor store, append the following to the yaml.
 | idleCheckFrequency        | N        | Frequency of idle checks made by idle connections reaper. Default is `"1m"`. `"-1"` disables idle connections reaper. | `"-1"`
 | idleTimeout        | N        | Amount of time after which the client closes idle connections. Should be less than server's timeout. Default is `"5m"`. `"-1"` disables idle timeout check. | `"10m"`
 | actorStateStore    | N         | Consider this state store for actors. Defaults to `"false"` | `"true"`, `"false"`
-| ttlInSeconds       | N         | Allows specifying a default Time-to-live (TTL) in seconds that will be applied to every state store request unless TTL is explictly defined via the request metadata. This is especially useful because Redis does not offer a global default TTL feature. [Read more]({{< ref "state-store-ttl.md" >}}) about State Time-to-Live (TTL). | `600` 
+| ttlInSeconds       | N         | Allows specifying a default Time-to-live (TTL) in seconds that will be applied to every state store request unless TTL is explicitly defined via the [request metadata]({{< ref "state-store-ttl.md" >}}). | `600` 
 
 ## Setup Redis
 


### PR DESCRIPTION
This is to document the new global TTL option for Redis

Implemented in https://github.com/dapr/components-contrib/pull/1059

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Documents the new `ttlInSeconds` Redis state store option

## Issue reference

https://github.com/dapr/components-contrib/issues/1060
