### PR TITLE
Deprecate Azure Event Hubs PubSub component

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/_index.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/_index.md
@@ -46,5 +46,5 @@ Table captions:
 
 | Name                                                      | Status | Component version | Since |
 |-----------------------------------------------------------|--------| ----------------| -- |
-| [Azure Events Hub]({{< ref setup-azure-eventhubs.md >}})  | Alpha  | v1 | 1.0 |
+| ~~[Azure Events Hub]({{< ref setup-azure-eventhubs.md >}})~~  | Deprecated  | ~~v1~~ | ~~1.0~~ |
 | [Azure Service Bus]({{< ref setup-azure-servicebus.md >}})| GA  | v1 | 1.0 |

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/_index.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/_index.md
@@ -46,5 +46,5 @@ Table captions:
 
 | Name                                                      | Status | Component version | Since |
 |-----------------------------------------------------------|--------| ----------------| -- |
-| ~~[Azure Events Hub]({{< ref setup-azure-eventhubs.md >}})~~  | Deprecated  | ~~v1~~ | ~~1.0~~ |
+| ~~[Azure Event Hubs]({{< ref setup-azure-eventhubs.md >}})~~  | Deprecated  | ~~v1~~ | ~~1.0~~ |
 | [Azure Service Bus]({{< ref setup-azure-servicebus.md >}})| GA  | v1 | 1.0 |

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 {{% alert title="Deprecated" color="warning" %}}
-The Azure Event Hubs pubsub component is deprecated and will be removed in release 1.6. Please use the [Azure Event Hubs bindings]({{< ref "supported-bindings/eventhubs.md" >}}) instead.
+The Azure Event Hubs pubsub component is deprecated and will be removed in release 1.6. Please use the [Azure Event Hubs bindings]({{< ref "eventhubs.md" >}}) instead.
 {{% /alert %}}
 
 ## Component format

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 {{% alert title="Deprecated" color="warning" %}}
-The Azure Event Hub pubsub component is deprecated and will no longer be available starting with release 1.4.
+The Azure Event Hubs pubsub component is deprecated and will no longer be available starting with release 1.4.
 {{% /alert %}}
 
 ## Component format

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 {{% alert title="Deprecated" color="warning" %}}
-The Azure Event Hubs pubsub component is deprecated and will no longer be available starting with release 1.4.
+The Azure Event Hubs pubsub component is deprecated and will be removed in release 1.6. Please use the [Azure Event Hubs bindings]({{< ref "supported-bindings/eventhubs.md" >}}) instead.
 {{% /alert %}}
 
 ## Component format

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 {{% alert title="Deprecated" color="warning" %}}
-The Azure Event Hubs pubsub component is deprecated and has been removed from starting with release 1.4.
+The Azure Event Hub pubsub component is deprecated and will no longer be available starting with release 1.4.
 {{% /alert %}}
 
 ## Component format

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -11,10 +11,6 @@ aliases:
 The Azure Event Hubs pubsub component is deprecated and has been removed from starting with release 1.4.
 {{% /alert %}}
 
-{{% alert title="Note" color="warning" %}}
-It is important to set an app-id, as the state keys are prefixed with this value. If you don't set it one is generated for you at runtime, and the next time you run the command a new one will be generated and you will no longer be able to access previously saved state.
-{{% /alert %}}
-
 ## Component format
 To setup Azure Event Hubs pubsub create a component of type `pubsub.azure.eventhubs`. See [this guide]({{< ref "howto-publish-subscribe.md#step-1-setup-the-pubsub-component" >}}) on how to create and apply a pubsub configuration.
 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -1,6 +1,6 @@
 ---
 type: docs
-title: "Azure Events Hub (deprecated)"
+title: "Azure Event Hubs (deprecated)"
 linkTitle: "Azure Events Hub (deprecated)"
 description: "Detailed documentation on the Azure Event Hubs pubsub component (deprecated)"
 aliases:

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -1,11 +1,19 @@
 ---
 type: docs
-title: "Azure Events Hub"
-linkTitle: "Azure Events Hub"
-description: "Detailed documentation on the Azure Event Hubs pubsub component"
+title: "Azure Events Hub (deprecated)"
+linkTitle: "Azure Events Hub (deprecated)"
+description: "Detailed documentation on the Azure Event Hubs pubsub component (deprecated)"
 aliases:
   - "/operations/components/setup-pubsub/supported-pubsub/setup-azure-eventhubs/"
 ---
+
+{{% alert title="Deprecated" color="warning" %}}
+The Azure Event Hubs pubsub component is deprecated and has been removed from starting with release 1.4.
+{{% /alert %}}
+
+{{% alert title="Note" color="warning" %}}
+It is important to set an app-id, as the state keys are prefixed with this value. If you don't set it one is generated for you at runtime, and the next time you run the command a new one will be generated and you will no longer be able to access previously saved state.
+{{% /alert %}}
 
 ## Component format
 To setup Azure Event Hubs pubsub create a component of type `pubsub.azure.eventhubs`. See [this guide]({{< ref "howto-publish-subscribe.md#step-1-setup-the-pubsub-component" >}}) on how to create and apply a pubsub configuration.

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -1,7 +1,7 @@
 ---
 type: docs
 title: "Azure Event Hubs (deprecated)"
-linkTitle: "Azure Events Hub (deprecated)"
+linkTitle: "Azure Event Hubs (deprecated)"
 description: "Detailed documentation on the Azure Event Hubs pubsub component (deprecated)"
 aliases:
   - "/operations/components/setup-pubsub/supported-pubsub/setup-azure-eventhubs/"


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

Deprecate Azure Event Hubs PubSub component

**Please follow this checklist before submitting:**

- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Deprecate Azure Event Hubs PubSub component

## Issue reference

https://github.com/dapr/components-contrib/issues/951

<!--Please reference the issue this PR will close: #[issue number]-->
