### PR TITLE
Fix casing typo in OPA rego example for Authorization

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-opa.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-opa.md
@@ -61,7 +61,7 @@ spec:
             my_claim := jwt.payload["my-claim"]
         }
         jwt = { "payload": payload } {
-            auth_header := input.request.headers["authorization"]
+            auth_header := input.request.headers["Authorization"]
             [_, jwt] := split(auth_header, " ")
             [_, payload, _] := io.jwt.decode(jwt)
         }


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fix casing in OPA middleware rego example.

## Issue reference

Resolves #1728

