### PR TITLE
Fix invokation example on powershell when using mTLS

### DIFF
--- a/daprdocs/content/en/operations/configuration/invoke-allowlist.md
+++ b/daprdocs/content/en/operations/configuration/invoke-allowlist.md
@@ -263,9 +263,9 @@ The following steps run the Sentry service locally with mTLS enabled, set up nec
 
    {{% codetab %}}
    ```powershell
-   $env:DAPR_TRUST_ANCHORS=$(Get-Content $env:USERPROFILE\.dapr\certs\ca.crt)
-   $env:DAPR_CERT_CHAIN=$(Get-Content $env:USERPROFILE\.dapr\certs\issuer.crt)
-   $env:DAPR_CERT_KEY=$(Get-Content $env:USERPROFILE\.dapr\certs\issuer.key)
+   $env:DAPR_TRUST_ANCHORS=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\ca.crt)
+   $env:DAPR_CERT_CHAIN=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\issuer.crt)
+   $env:DAPR_CERT_KEY=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\issuer.key)
    $env:NAMESPACE="default"
    ```
 

--- a/daprdocs/content/en/operations/configuration/invoke-allowlist.md
+++ b/daprdocs/content/en/operations/configuration/invoke-allowlist.md
@@ -300,9 +300,9 @@ The following steps run the Sentry service locally with mTLS enabled, set up nec
 
    {{% codetab %}}
    ```powershell
-   $env:DAPR_TRUST_ANCHORS=$(Get-Content $env:USERPROFILE\.dapr\certs\ca.crt)
-   $env:DAPR_CERT_CHAIN=$(Get-Content $env:USERPROFILE\.dapr\certs\issuer.crt)
-   $env:DAPR_CERT_KEY=$(Get-Content $env:USERPROFILE\.dapr\certs\issuer.key)
+   $env:DAPR_TRUST_ANCHORS=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\ca.crt)
+   $env:DAPR_CERT_CHAIN=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\issuer.crt)
+   $env:DAPR_CERT_KEY=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\issuer.key)
    $env:NAMESPACE="default"
    ```
    {{% /codetab %}}

--- a/daprdocs/content/en/operations/security/mtls.md
+++ b/daprdocs/content/en/operations/security/mtls.md
@@ -229,7 +229,7 @@ If using `daprd` directly, use the following flags to enable mTLS:
 daprd --app-id myapp --enable-mtls --sentry-address localhost:50001 --config=./config.yaml
 ```
 
-Several environment variables should be filled in with the information of the certificates when invoking services with the dapr sidecar. Check the [Service Invocation access control]({{< ref "invoke-allowlist.md" >}}) self-hosted example using mTLS for more detail.
+Extra configuration is required using environment variables that be filled in with the information of the certificates when invoking services with the dapr sidecar. Check the [Service Invocation access control]({{< ref "invoke-allowlist.md" >}}) self-hosted example using mTLS for more detail.
 
 #### Sentry configuration
 

--- a/daprdocs/content/en/operations/security/mtls.md
+++ b/daprdocs/content/en/operations/security/mtls.md
@@ -217,6 +217,32 @@ spec:
     enabled: true
 ```
 
+In addition to the Dapr configuration, you will also need to provide the TLS certificates to each Dapr sidecar instance. You can do so by setting the following environment variables before running the Dapr instance:
+
+{{< tabs "Linux/MacOS" Windows >}}
+
+{{% codetab %}}
+```bash
+export DAPR_TRUST_ANCHORS=`cat $HOME/.dapr/certs/ca.crt`
+export DAPR_CERT_CHAIN=`cat $HOME/.dapr/certs/issuer.crt`
+export DAPR_CERT_KEY=`cat $HOME/.dapr/certs/issuer.key`
+export NAMESPACE=default
+```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+```powershell
+$env:DAPR_TRUST_ANCHORS=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\ca.crt)
+$env:DAPR_CERT_CHAIN=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\issuer.crt)
+$env:DAPR_CERT_KEY=$(Get-Content -raw $env:USERPROFILE\.dapr\certs\issuer.key)
+$env:NAMESPACE="default"
+```
+
+{{% /codetab %}}
+
+{{< /tabs >}}
+
 If using the Dapr CLI, point Dapr to the config file above to run the Dapr instance with mTLS enabled:
 
 ```
@@ -228,8 +254,6 @@ If using `daprd` directly, use the following flags to enable mTLS:
 ```bash
 daprd --app-id myapp --enable-mtls --sentry-address localhost:50001 --config=./config.yaml
 ```
-
-Extra configuration is required using environment variables that be filled in with the information of the certificates when invoking services with the dapr sidecar. Check the [Service Invocation access control]({{< ref "invoke-allowlist.md" >}}) self-hosted example using mTLS for more detail.
 
 #### Sentry configuration
 

--- a/daprdocs/content/en/operations/security/mtls.md
+++ b/daprdocs/content/en/operations/security/mtls.md
@@ -229,6 +229,8 @@ If using `daprd` directly, use the following flags to enable mTLS:
 daprd --app-id myapp --enable-mtls --sentry-address localhost:50001 --config=./config.yaml
 ```
 
+Several environment variables should be filled in with the information of the certificates when invoking services with the dapr sidecar. Check the [Service Invocation access control]({{< ref "invoke-allowlist.md" >}}) self-hosted example using mTLS for more detail.
+
 #### Sentry configuration
 
 Here's an example of a configuration for Sentry that changes the workload cert TTL to 25 seconds:


### PR DESCRIPTION
## Description

Environment variables should be fullfiled using -raw on WIndows Powershell to make end of lines be treated correctly.

Following error is shown if not using -raw:

```
time="2021-08-20T10:55:22.7991229+02:00" level=info msg="starting Dapr Runtime -- version 1.3.0 -- commit 4bab7576ed68a9ece1a4743a7925f18ef583775a" app_id=nodeappedge instance=le-instance scope=dapr.runtime type=log ver=1.3.0
time="2021-08-20T10:55:22.800095+02:00" level=info msg="log level set to: info" app_id=nodeappedge instance=le-instance scope=dapr.runtime type=log ver=1.3.0
time="2021-08-20T10:55:22.800095+02:00" level=info msg="metrics server started on :9091/" app_id=nodeappedge instance=le-instance scope=dapr.metrics type=log ver=1.3.0
time="2021-08-20T10:55:22.8051523+02:00" level=info msg="loading default configuration" app_id=nodeappedge instance=le-instance scope=dapr.runtime type=log ver=1.3.0
time="2021-08-20T10:55:22.8051523+02:00" level=info msg="standalone mode configured" app_id=nodeappedge instance=le-instance scope=dapr.runtime type=log ver=1.3.0
time="2021-08-20T10:55:22.8051523+02:00" level=info msg="app id: nodeappedge" app_id=nodeappedge instance=le-instance scope=dapr.runtime type=log ver=1.3.0
time="2021-08-20T10:55:22.8060945+02:00" level=info msg="mTLS enabled. creating sidecar authenticator" app_id=nodeappedge instance=le-instance scope=dapr.runtime type=log ver=1.3.0
time="2021-08-20T10:55:22.8060945+02:00" level=fatal msg="**fatal error from runtime: failed to append PEM root cert to x509 CertPool**" app_id=nodeappedge instance=le-instance scope=dapr.runtime type=log ver=1.3.0
```

## Issue reference

#1739 
