### PR TITLE
Clarify GCP PubSub binding support

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/gcppubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/gcppubsub.md
@@ -70,6 +70,8 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 ## Binding support
 
+This component supports both **input and output** binding interfaces.
+
 This component supports **output binding** with the following operations:
 
 - `create`


### PR DESCRIPTION
Adding "This component supports both **input and output** binding interfaces." to the GCP pubsub binding reference page.