### PR TITLE
Add JetStream documentation

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/_index.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/_index.md
@@ -26,6 +26,7 @@ Table captions:
 | [Hazelcast]({{< ref setup-hazelcast.md >}})           | Alpha  | v1 | 1.0 |
 | [MQTT]({{< ref setup-mqtt.md >}})                     | Alpha  | v1 | 1.0 |
 | [NATS Streaming]({{< ref setup-nats-streaming.md >}}) | Beta  | v1 | 1.0 |
+| [JetStream]({{< ref setup-jetstream.md >}}) | Alpha  | v1 | 1.4 |
 | [Pulsar]({{< ref setup-pulsar.md >}})                 | Alpha  | v1 | 1.0 |
 | [RabbitMQ]({{< ref setup-rabbitmq.md >}})             | Alpha  | v1 | 1.0 |
 | [Redis Streams]({{< ref setup-redis-pubsub.md >}})    | GA  | v1 | 1.0 |

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-jetstream.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-jetstream.md
@@ -1,0 +1,97 @@
+---
+type: docs
+title: "JetStream"
+linkTitle: "JetStream"
+description: "Detailed documentation on the NATS JetStream component"
+aliases:
+  - "/operations/components/setup-pubsub/supported-pubsub/setup-jetstream/"
+---
+
+## Component format
+To setup JetStream pubsub create a component of type `pubsub.jetstream`. See
+[this guide]({{< ref
+"howto-publish-subscribe.md#step-1-setup-the-pubsub-component" >}}) on how to
+create and apply a pubsub configuration.
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: jetstream-pubsub
+  namespace: default
+spec:
+  type: pubsub.jetstream
+  version: v1
+  metadata:
+  - name: natsURL
+    value: "nats://localhost:4222"
+  - name: name
+    value: "connection name"
+  - name: durableName
+    value: "consumer durable name"
+  - name: queueGroupName
+    value: "queue group name"
+  - name: startSequence
+    value: 1
+  - name: startTime # in Unix format
+    value: 1630349391
+  - name: deliverAll
+    value: false
+  - name: flowControl
+    value: false
+```
+
+## Spec metadata fields
+
+| Field          | Required | Details | Example |
+|----------------|:--------:|---------|---------|
+| natsURL        |        Y | NATS server address URL   | "`nats://localhost:4222`"|
+| name           |        N | NATS connection name | `"my-conn-name"`|
+| durableName    |        N | [Durable name] | `"my-durable"` |
+| queueGroupName |        N | Queue group name | `"my-queue"` |
+| startSequence  |        N | [Start Sequence] | `1` |
+| startTime      |        N | [Start Time] in Unix format | `1630349391` |
+| deliverAll     |        N | Set deliver all as [Replay Policy] | `true` |
+| flowControl    |        N | [Flow Control] | `true` |
+
+## Create a NATS server
+
+{{< tabs "Self-Hosted" "Kubernetes">}}
+
+{{% codetab %}}
+You can run a NATS Server with JetStream enabled locally using Docker:
+
+```bash
+docker run -d -p 4222:4222 nats:latest -js
+```
+
+You can then interact with the server using the client port: `localhost:4222`.
+{{% /codetab %}}
+
+{{% codetab %}}
+Install NATS JetStream on Kubernetes by using the [helm](https://github.com/nats-io/k8s/tree/main/helm/charts/nats#jetstream):
+
+```bash
+helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+helm install my-nats nats/nats
+```
+
+This installs a single NATS server into the `default` namespace. To interact
+with NATS, find the service with: `kubectl get svc my-nats`.
+{{% /codetab %}}
+
+{{< /tabs >}}
+
+## Related links
+- [Basic schema for a Dapr component]({{< ref component-schema >}})
+- Read [this guide]({{< ref "howto-publish-subscribe.md#step-2-publish-a-topic" >}}) for instructions on configuring pub/sub components
+- [Pub/Sub building block]({{< ref pubsub >}})
+- [JetStream Documentation](https://docs.nats.io/jetstream/jetstream)
+- [NATS CLI](https://github.com/nats-io/natscli)
+
+
+[Durable Name]: https://docs.nats.io/jetstream/concepts/consumers#durable-name
+[Start Sequence]: https://docs.nats.io/jetstream/concepts/consumers#deliverbystartsequence
+[Start Time]: https://docs.nats.io/jetstream/concepts/consumers#deliverbystarttime
+[Replay Policy]: https://docs.nats.io/jetstream/concepts/consumers#replaypolicy
+[Flow Control]: https://docs.nats.io/jetstream/concepts/consumers#flowcontrol

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-nats-streaming.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-nats-streaming.md
@@ -54,6 +54,11 @@ spec:
 The above example uses secrets as plain strings. It is recommended to use a secret store for the secrets as described [here]({{< ref component-secrets.md >}}).
 {{% /alert %}}
 
+{{% alert title="Warning" color="warning" %}}
+NATS Streaming has been [deprecated](https://github.com/nats-io/nats-streaming-server/#warning--deprecation-notice-warning).
+Please consider using [NATS JetStream]({{< ref setup-jetstream >}}) going forward.
+{{% /alert %}}
+
 ## Spec metadata fields
 
 | Field              | Required | Details | Example |
@@ -111,3 +116,4 @@ For example, if installing using the example above, the NATS Streaming address w
 - [Basic schema for a Dapr component]({{< ref component-schema >}})
 - Read [this guide]({{< ref "howto-publish-subscribe.md#step-2-publish-a-topic" >}}) for instructions on configuring pub/sub components
 - [Pub/Sub building block]({{< ref pubsub >}})
+- [NATS Streaming Deprecation Notice](https://github.com/nats-io/nats-streaming-server/#warning--deprecation-notice-warning)


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This change adds NATS JetStream documentation. In addition, it adds a [deprecation warning](https://github.com/nats-io/nats-streaming-server/#warning--deprecation-notice-warning) to the NATS Streaming PubSub component.

## Issue reference

This PR is an accompaniment for PR https://github.com/dapr/components-contrib/pull/1101.