### PR TITLE
Document changes from #1099 of dapr/components-contrib

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-gcp-pubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-gcp-pubsub.md
@@ -46,6 +46,8 @@ spec:
     value: <PRIVATE_KEY> # replace x509 cert
   - name: disableEntityManagement
     value: "false"
+  - name: enableMessageOrdering
+    value: "false"
 ```
 {{% alert title="Warning" color="warning" %}}
 The above example uses secrets as plain strings. It is recommended to use a secret store for the secrets as described [here]({{< ref component-secrets.md >}}).
@@ -67,6 +69,11 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | authProviderX509CertUrl | N | If using explicit credentials, this field should contain the `auth_provider_x509_cert_url` field from the service account json | `https://www.googleapis.com/oauth2/v1/certs`
 | clientX509CertUrl | N | If using explicit credentials, this field should contain the `client_x509_cert_url` field from the service account json | `https://www.googleapis.com/robot/v1/metadata/x509/myserviceaccount%40myproject.iam.gserviceaccount.com`
 | disableEntityManagement | N | When set to `"true"`, topics and subscriptions do not get created automatically. Default: `"false"` | `"true"`, `"false"`
+| enableMessageOrdering | N | When set to `"true"`, subscribed messages will be received in order, depending on publishing and permissions configuration. | `"true"`, `"false"`
+
+{{% alert title="Warning" color="warning" %}}
+If `enableMessageOrdering` is set to "true", the roles/viewer or roles/pubsub.viewer role will be required on the service account in order to guarantee ordering in cases where order tokens are not embedded in the messages. If this role is not given, or the call to Subscription.Config() fails for any other reason, ordering by embedded order tokens will still function correctly.
+{{% /alert %}}
 
 ## Create a GCP Pub/Sub
 You can use either "explicit" or "implicit" credentials to configure access to your GCP pubsub instance. If using explicit, most fields are required. Implicit relies on dapr running under a Kubernetes service account (KSA) mapped to a Google service account (GSA) which has the necessary permissions to access pubsub. In implicit mode, only the `projectId` attribute is needed, all other are optional.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The new GCP Pub/Sub configuration value "enableMessageOrdering" is documented alongside all existing configuration for this service. Additionally, the new requirements for roles assigned to a service account to guarantee ordering under certain circumstances have been captured.

## Issue reference

This PR will close: #1742
