### PR TITLE
Remove alert saying Codespaces is in Beta

### DIFF
--- a/daprdocs/content/en/contributing/codespaces.md
+++ b/daprdocs/content/en/contributing/codespaces.md
@@ -10,10 +10,6 @@ aliases:
 
 [GitHub Codespaces](https://github.com/features/codespaces) are the easiest way to get up and running for contributing to a Dapr repo. In as little as a single click, you can have an environment with all of the prerequisites ready to go in your browser.
 
-{{% alert title="Private Beta" color="warning" %}}
-GitHub Codespaces is currently in a private beta. Sign up [here](https://github.com/features/codespaces/signup).
-{{% /alert %}}
-
 ## Features
 
 - **Click and Run**: Get a dedicated and sandboxed environment with all of the required frameworks and packages ready to go.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Remove the alert saying Codespaces is in Private Beta. Codespaces is now GA.

## Issue reference
https://github.com/dapr/docs/issues/1768

