### PR TITLE
Deny iFrame embeds

### DIFF
--- a/daprdocs/staticwebapp.config.json
+++ b/daprdocs/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+    "globalHeaders": {
+      "X-Frame-Options": "DENY"
+    }
+}
+


### PR DESCRIPTION
This adds the X-Frame-Options: DENY header to every page hosted on Azure Static Web Apps

per:
https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#global-headers