### PR TITLE
Bump runtime version references to 1.4.3 and supported versions table

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-aks.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-aks.md
@@ -12,7 +12,7 @@ description: >
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/install/)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 
 ## Deploy an Azure Kubernetes Service cluster

--- a/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-gke.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-gke.md
@@ -8,7 +8,7 @@ description: "Setup a Google Kubernetes Engine cluster"
 
 ### Prerequisites
 
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Google Cloud SDK](https://cloud.google.com/sdk)
 
 ## Create a new cluster

--- a/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-minikube.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-minikube.md
@@ -12,7 +12,7 @@ description: >
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/install/)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Minikube](https://minikube.sigs.k8s.io/docs/start/)
 
 > Note: For Windows, enable Virtualization in BIOS and [install Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v)

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -15,7 +15,7 @@ For more information on what is deployed to your Kubernetes cluster read the [Ku
 ## Prerequisites
 
 - Install [Dapr CLI]({{< ref install-dapr-cli.md >}})
-- Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- Install [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - Kubernetes cluster (see below if needed)
 
 ### Create cluster

--- a/daprdocs/content/en/operations/monitoring/logging/fluentd.md
+++ b/daprdocs/content/en/operations/monitoring/logging/fluentd.md
@@ -9,7 +9,7 @@ description: "How to install Fluentd, Elastic Search, and Kibana to search logs 
 ## Prerequisites
 
 - Kubernetes (> 1.14)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Helm 3](https://helm.sh/)
 
 ## Install Elastic search and Kibana

--- a/daprdocs/content/en/operations/monitoring/metrics/azure-monitor.md
+++ b/daprdocs/content/en/operations/monitoring/metrics/azure-monitor.md
@@ -10,7 +10,7 @@ description: "Enable Dapr metrics and logs with Azure Monitor for Azure Kubernet
 
 - [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/)
 - [Enable Azure Monitor For containers in AKS](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-overview)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Helm 3](https://helm.sh/)
 
 ## Enable Prometheus metric scrape using config map

--- a/daprdocs/content/en/operations/monitoring/metrics/prometheus.md
+++ b/daprdocs/content/en/operations/monitoring/metrics/prometheus.md
@@ -67,7 +67,7 @@ Once Prometheus is running, you'll be able to visit its dashboard by visiting `h
 ### Prerequisites
 
 - Kubernetes (> 1.14)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Helm 3](https://helm.sh/)
 
 ### Install Prometheus

--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -78,8 +78,11 @@ General guidance on upgrading can be found for [self hosted mode]({{<ref self-ho
 |                          |                 1.4.1 |                    1.4.2 |
 |                          |                 1.4.2 |                    1.4.3 |
 | 1.4.0                    |                   N/A |                    1.4.1 |
-| 1.4.1                    |                 1.4.2 |                    1.4.3 |
-| 1.4.2                    |                   N/A |                    1.4.3 |
+|                          |                 1.4.1 |                    1.4.2 |
+|                          |                 1.4.2 |                    1.4.3 |
+| 1.4.1                    |                   N/A |                    1.4.2 |
+|                          |                 1.4.2 |                    1.4.3 |
+| 1.4.2                    |                  N/A  |                    1.4.3 |
 
 ## Feature and deprecations
 There is a process for announcing feature deprecations.  Deprecations are applied two (2) releases after the release in which they were announced. For example Feature X is announced to be deprecated in the 1.0.0 release notes and will then be removed in 1.2.0.

--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -58,31 +58,16 @@ General guidance on upgrading can be found for [self hosted mode]({{<ref self-ho
 | 1.0.0 or 1.0.1           |                   N/A |                    1.1.2 |
 |                          |                 1.1.2 |                    1.2.2 |
 |                          |                 1.2.2 |                    1.3.1 |
-|                          |                 1.3.1 |                    1.4.1 |
-|                          |                 1.4.1 |                    1.4.2 |
-|                          |                 1.4.2 |                    1.4.3 |
+|                          |                 1.3.1 |                    1.4.3 |
 | 1.1.0 to 1.1.2           |                   N/A |                    1.2.2 |
 |                          |                 1.2.2 |                    1.3.1 |
-|                          |                 1.3.1 |                    1.4.1 |
-|                          |                 1.4.1 |                    1.4.2 |
-|                          |                 1.4.2 |                    1.4.3 |
+|                          |                 1.3.1 |                    1.4.3 |
 | 1.2.0 to 1.2.2           |                   N/A |                    1.3.1 |
-|                          |                 1.3.1 |                    1.4.1 |
-|                          |                 1.4.1 |                    1.4.2 |
-|                          |                 1.4.2 |                    1.4.3 |
+|                          |                 1.3.1 |                    1.4.3 |
 | 1.3.0                    |                   N/A |                    1.3.1 |
-|                          |                 1.3.1 |                    1.4.1 |
-|                          |                 1.4.1 |                    1.4.2 |
-|                          |                 1.4.2 |                    1.4.3 |
-| 1.3.1                    |                   N/A |                    1.4.1 |
-|                          |                 1.4.1 |                    1.4.2 |
-|                          |                 1.4.2 |                    1.4.3 |
-| 1.4.0                    |                   N/A |                    1.4.1 |
-|                          |                 1.4.1 |                    1.4.2 |
-|                          |                 1.4.2 |                    1.4.3 |
-| 1.4.1                    |                   N/A |                    1.4.2 |
-|                          |                 1.4.2 |                    1.4.3 |
-| 1.4.2                    |                  N/A  |                    1.4.3 |
+|                          |                 1.3.1 |                    1.4.3 |
+| 1.3.1                    |                   N/A |                    1.4.3 |
+| 1.4.0 to 1.4.2           |                   N/A |                    1.4.3 |
 
 ## Feature and deprecations
 There is a process for announcing feature deprecations.  Deprecations are applied two (2) releases after the release in which they were announced. For example Feature X is announced to be deprecated in the 1.0.0 release notes and will then be removed in 1.2.0.

--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -42,7 +42,9 @@ The table below shows the versions of Dapr releases that have been tested togeth
 | Jul 26th 2021 | 1.3</br>   | 1.3.0 | Java 1.2.0 </br>Go 1.2.0 </br>PHP 1.1.0 </br>Python 1.2.0 </br>.NET 1.3.0 | 0.7.0 | Supported           |
 | Sep 14th 2021 | 1.3.1</br> | 1.3.0 | Java 1.2.0 </br>Go 1.2.0 </br>PHP 1.1.0 </br>Python 1.2.0 </br>.NET 1.3.0 | 0.7.0 | Supported           |
 | Sep 15th 2021 | 1.4</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported           |
-| Sep 22nd 2021 | 1.4.1</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported (current) |
+| Sep 22nd 2021 | 1.4.1</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported
+| Sep 15th 2021 | 1.4.2</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported           |
+| Sep 22nd 2021 | 1.4.3</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported (current) |
 
 ## Upgrade paths
 After the 1.0 release of the runtime there may be situations where it is necessary to explicitly upgrade through an additional release to reach the desired target. For example an upgrade from v1.0 to v1.2 may need go pass through v1.1
@@ -66,6 +68,8 @@ General guidance on upgrading can be found for [self hosted mode]({{<ref self-ho
 |                          |                 1.3.1 |                    1.4.1 |
 | 1.3.1                    |                   N/A |                    1.4.1 |
 | 1.4.0                    |                   N/A |                    1.4.1 |
+| 1.4.1                    |                 1.4.2 |                    1.4.3 |
+| 1.4.2                    |                   N/A |                    1.4.3 |
 
 ## Feature and deprecations
 There is a process for announcing feature deprecations.  Deprecations are applied two (2) releases after the release in which they were announced. For example Feature X is announced to be deprecated in the 1.0.0 release notes and will then be removed in 1.2.0.

--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -43,8 +43,8 @@ The table below shows the versions of Dapr releases that have been tested togeth
 | Sep 14th 2021 | 1.3.1</br> | 1.3.0 | Java 1.2.0 </br>Go 1.2.0 </br>PHP 1.1.0 </br>Python 1.2.0 </br>.NET 1.3.0 | 0.7.0 | Supported           |
 | Sep 15th 2021 | 1.4</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported           |
 | Sep 22nd 2021 | 1.4.1</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported
-| Sep 15th 2021 | 1.4.2</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported           |
-| Sep 22nd 2021 | 1.4.3</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported (current) |
+| Sep 24th 2021 | 1.4.2</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported           |
+| Oct 7th 2021  | 1.4.3</br>   | 1.4.0 | Java 1.3.0 </br>Go 1.3.0 </br>PHP 1.2.0 </br>Python 1.3.0 </br>.NET 1.4.0 | 0.8.0 | Supported (current) |
 
 ## Upgrade paths
 After the 1.0 release of the runtime there may be situations where it is necessary to explicitly upgrade through an additional release to reach the desired target. For example an upgrade from v1.0 to v1.2 may need go pass through v1.1
@@ -59,14 +59,24 @@ General guidance on upgrading can be found for [self hosted mode]({{<ref self-ho
 |                          |                 1.1.2 |                    1.2.2 |
 |                          |                 1.2.2 |                    1.3.1 |
 |                          |                 1.3.1 |                    1.4.1 |
+|                          |                 1.4.1 |                    1.4.2 |
+|                          |                 1.4.2 |                    1.4.3 |
 | 1.1.0 to 1.1.2           |                   N/A |                    1.2.2 |
 |                          |                 1.2.2 |                    1.3.1 |
 |                          |                 1.3.1 |                    1.4.1 |
+|                          |                 1.4.1 |                    1.4.2 |
+|                          |                 1.4.2 |                    1.4.3 |
 | 1.2.0 to 1.2.2           |                   N/A |                    1.3.1 |
 |                          |                 1.3.1 |                    1.4.1 |
+|                          |                 1.4.1 |                    1.4.2 |
+|                          |                 1.4.2 |                    1.4.3 |
 | 1.3.0                    |                   N/A |                    1.3.1 |
 |                          |                 1.3.1 |                    1.4.1 |
+|                          |                 1.4.1 |                    1.4.2 |
+|                          |                 1.4.2 |                    1.4.3 |
 | 1.3.1                    |                   N/A |                    1.4.1 |
+|                          |                 1.4.1 |                    1.4.2 |
+|                          |                 1.4.2 |                    1.4.3 |
 | 1.4.0                    |                   N/A |                    1.4.1 |
 | 1.4.1                    |                 1.4.2 |                    1.4.3 |
 | 1.4.2                    |                   N/A |                    1.4.3 |

--- a/daprdocs/layouts/shortcodes/dapr-latest-version.html
+++ b/daprdocs/layouts/shortcodes/dapr-latest-version.html
@@ -1,1 +1,1 @@
-{{- if .Get "short" }}1.4{{ else if .Get "long" }}1.4.1{{ else if .Get "cli" }}1.4.0{{ else }}1.4.1{{ end -}}
+{{- if .Get "short" }}1.4{{ else if .Get "long" }}1.4.3{{ else if .Get "cli" }}1.4.0{{ else }}1.4.3{{ end -}}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Update supported versions table to 1.4.3 and bumped runtime version references to 1.4.3
