### PR TITLE
Removing button from getting started note

### DIFF
--- a/daprdocs/content/en/getting-started/_index.md
+++ b/daprdocs/content/en/getting-started/_index.md
@@ -11,7 +11,6 @@ Welcome to the Dapr getting started guide!
 
 {{% alert title="Dapr Concepts" color="primary" %}}
 If you are looking for an introductory overview of Dapr and learn more about basic Dapr terminology, it is recommended to visit the [concepts section]({{<ref concepts>}}).
-{{< button text="Learn more" page="concepts" >}}
 {{% /alert %}}
 
 This guide will walk you through a series of steps to install, initialize and start using Dapr. The recommended way to get started with Dapr is to setup a local development environment (also referred to as [_self-hosted_ mode]({{< ref self-hosted >}})) which includes the Dapr CLI, Dapr sidecar binaries, and some default components that can help you start using Dapr quickly.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
<!--Please explain the changes you've made-->
This PR removes the button leading to the concepts section from the note at the top of the getting started page. This page is a critical part of the user journey and needs to optimize for moving visitors along the getting started experience. Buttons are emphasized links that implicitly tell users where to go first. Since the goal is to get people to the "Step 1" page that should be the only button in the page. (In addition we should consider moving the note to the bottom of the page altogether)


## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
N/A
