### PR TITLE
Update button shortcode so links open in new tab

### DIFF
--- a/daprdocs/content/en/contributing/contributing-docs.md
+++ b/daprdocs/content/en/contributing/contributing-docs.md
@@ -334,6 +334,8 @@ The shortcode would be:
 
 To create a button in a webpage, use the `button` shortcode.
 
+An optional "newtab" parameter will indicate if the page should open in a new tab. Options are "true" or "false". Default is "false", where the page will open in the same tab.
+
 #### Link to an external page
 
 ```
@@ -346,10 +348,10 @@ To create a button in a webpage, use the `button` shortcode.
 
 You can also reference pages in your button as well:
 ```
-{{</* button text="My Button" page="contributing" */>}}
+{{</* button text="My Button" page="contributing" newtab="true" */>}}
 ```
 
-{{< button text="My Button" page="contributing" >}}
+{{< button text="My Button" page="contributing" newtab="true" >}}
 
 #### Button colors
 

--- a/daprdocs/layouts/shortcodes/button.html
+++ b/daprdocs/layouts/shortcodes/button.html
@@ -5,4 +5,4 @@
 
 {{- if $page -}}{{- $link = ref . $page -}}{{- end -}}
 
-<a class="btn btn-{{ $color }}" href="{{ $link }}" role="button">{{ $text }}</a>
+<a class="btn btn-{{ $color }}" href="{{ $link }}" role="button" target="_blank">{{ $text }}</a>

--- a/daprdocs/layouts/shortcodes/button.html
+++ b/daprdocs/layouts/shortcodes/button.html
@@ -2,7 +2,8 @@
 {{ $page := .Get "page" }}
 {{ $link := .Get "link" | default "#" }}
 {{ $text := .Get "text" }}
+{{ $opentab := .Get "newtab" | default False }}
 
 {{- if $page -}}{{- $link = ref . $page -}}{{- end -}}
 
-<a class="btn btn-{{ $color }}" href="{{ $link }}" role="button" target="_blank">{{ $text }}</a>
+<a class="btn btn-{{ $color }}" href="{{ $link }}" role="button" {{- if $opentab -}}target="_blank"{{- end -}}>{{ $text }}</a>

--- a/daprdocs/layouts/shortcodes/button.html
+++ b/daprdocs/layouts/shortcodes/button.html
@@ -2,8 +2,8 @@
 {{ $page := .Get "page" }}
 {{ $link := .Get "link" | default "#" }}
 {{ $text := .Get "text" }}
-{{ $opentab := .Get "newtab" | default False }}
+{{ $newtab := .Get "newtab" | default "false" }}
 
 {{- if $page -}}{{- $link = ref . $page -}}{{- end -}}
 
-<a class="btn btn-{{ $color }}" href="{{ $link }}" role="button" {{- if $opentab -}}target="_blank"{{- end -}}>{{ $text }}</a>
+<a class="btn btn-{{ $color }}" href="{{ $link }}" role="button" {{- if eq $newtab "true" -}}target="_blank"{{- end -}}>{{ $text }}</a>


### PR DESCRIPTION
Setting a target of _blank will tell the browser to open the page in a new tab

Adding a configuration parameter that is opt-in that opens the link in a new tab