### PR TITLE
fixed typo in component yaml

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubernetes-binding.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubernetes-binding.md
@@ -25,7 +25,7 @@ spec:
   - name: namespace
     value: <NAMESPACE>
   - name: resyncPeriodInSec
-    vale: "<seconds>"
+    value: "<seconds>"
 ```
 
 ## Spec metadata fields


### PR DESCRIPTION
The attribute "value" was spelled "vale"

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The sample yaml for creating a Kubernetes Events Binding component had a typo that didnt pass validation when applyting via kubectl.  The key for "value" for the resyncPeriodInSec section was mispelled as "vale". 

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
