### PR TITLE
Link Validation: Microsoft Docs links must not be localized

### DIFF
--- a/.github/workflows/link_validation.yaml
+++ b/.github/workflows/link_validation.yaml
@@ -27,3 +27,11 @@ jobs:
       - name: Check Markdown Files
         run: |
           for name in `find . -name "*.md"`; do echo -e "------\n$name" ; mm.py -l $name || exit 1 ;done
+      - name: Check Microsoft URLs do not pin localized versions
+        run: |
+          localized=$(find . -name '*.md' | xargs grep -ol "\.microsoft\.com/[[:alpha:]]\{2\}-[[:alnum:]]\{2\}/")
+          if [[ $(echo $localized) ]]; then
+            echo "The following files contain links to Microsoft Docs that pin a localized version:"
+            echo $localized
+            exit 1
+          fi

--- a/.github/workflows/link_validation.yaml
+++ b/.github/workflows/link_validation.yaml
@@ -16,6 +16,16 @@ jobs:
       PYTHON_VER: 3.7
     steps:
       - uses: actions/checkout@v2
+      - name: Check Microsoft URLs do not pin localized versions
+        run: |
+          localized=$(find . -name '*.md' | xargs grep -ol "\.microsoft\.com/[[:alpha:]]\{2\}-[[:alpha:]]\{2\}/") || true
+          if [ -z "$localized" ]; then
+            echo "All Microsoft Docs links ok."
+          else
+            echo "The following files contain links to Microsoft Docs that pin a localized version:"
+            echo $localized
+            exit 1
+          fi
       - name: Set up Python ${{ env.PYTHON_VER }}
         uses: actions/setup-python@v2
         with:
@@ -27,11 +37,4 @@ jobs:
       - name: Check Markdown Files
         run: |
           for name in `find . -name "*.md"`; do echo -e "------\n$name" ; mm.py -l $name || exit 1 ;done
-      - name: Check Microsoft URLs do not pin localized versions
-        run: |
-          localized=$(find . -name '*.md' | xargs grep -ol "\.microsoft\.com/[[:alpha:]]\{2\}-[[:alpha:]]\{2\}/")
-          if [[ $(echo $localized) ]]; then
-            echo "The following files contain links to Microsoft Docs that pin a localized version:"
-            echo $localized
-            exit 1
-          fi
+

--- a/.github/workflows/link_validation.yaml
+++ b/.github/workflows/link_validation.yaml
@@ -29,7 +29,7 @@ jobs:
           for name in `find . -name "*.md"`; do echo -e "------\n$name" ; mm.py -l $name || exit 1 ;done
       - name: Check Microsoft URLs do not pin localized versions
         run: |
-          localized=$(find . -name '*.md' | xargs grep -ol "\.microsoft\.com/[[:alpha:]]\{2\}-[[:alnum:]]\{2\}/")
+          localized=$(find . -name '*.md' | xargs grep -ol "\.microsoft\.com/[[:alpha:]]\{2\}-[[:alpha:]]\{2\}/")
           if [[ $(echo $localized) ]]; then
             echo "The following files contain links to Microsoft Docs that pin a localized version:"
             echo $localized


### PR DESCRIPTION
Updates the link validation to also prohibit pinning of Microsoft Docs links to localized versions