### PR TITLE
Remove DaprCon card in main page

### DIFF
--- a/daprdocs/content/en/_index.md
+++ b/daprdocs/content/en/_index.md
@@ -2,23 +2,6 @@
 type: docs
 no_list: true
 ---
-
-<div class="card-deck">
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title">
-        <img src="/images/daprcon.png" alt="DaprCon logo" width=40>
-        <b> Watch DaprCon sessions on-demand!</b>
-      </h5>
-      <p class="card-text">
-        The first ever DaprCon took place October 19th-20th, 2021. Read this recap and find links to all on-demand content <br></br><i><b>Learn more >></b></i>
-      </p>
-      <a href="https://blog.dapr.io/posts/2021/10/21/thanks-for-a-great-first-daprcon/" class="stretched-link"></a>
-    </div>
-  </div>
-</div>
-
-<br></br>
 # <img src="/images/home-title.png" alt="Dapr Docs" width=400>
 
 Welcome to the Dapr documentation site!


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Removing the card with link to DaprCon content

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
