### PR TITLE
fix alpha1 typo for query state api ref

### DIFF
--- a/daprdocs/content/en/reference/api/state_api.md
+++ b/daprdocs/content/en/reference/api/state_api.md
@@ -303,7 +303,7 @@ This API is in alpha stage.
 ### HTTP Request
 
 ```
-POST/PUT http://localhost:<daprPort>/v1.0-alpha/state/<storename>/query
+POST/PUT http://localhost:<daprPort>/v1.0-alpha1/state/<storename>/query
 ```
 
 #### URL Parameters
@@ -330,7 +330,7 @@ An array of JSON-encoded values
 ### Example
 
 ```shell
-curl http://localhost:3500/v1.0-alpha/state/myStore/query \
+curl http://localhost:3500/v1.0-alpha1/state/myStore/query \
   -H "Content-Type: application/json" \
   -d '{
         "query": {
@@ -415,7 +415,7 @@ curl http://localhost:3500/v1.0-alpha/state/myStore/query \
 To pass metadata as query parammeter:
 
 ```
-POST http://localhost:3500/v1.0-alpha/state/myStore/query?metadata.partitionKey=mypartitionKey
+POST http://localhost:3500/v1.0-alpha1/state/myStore/query?metadata.partitionKey=mypartitionKey
 ```
 
 ## State transactions


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

fix alpha1 typo for query state api ref
in other places in docs it is v1.0-alpha1

also in http API it is defined as https://github.com/dapr/dapr/blob/master/pkg/http/api.go#L93

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
