### PR TITLE
 Correct metadata key name in Azure Key Vault secret store 

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-secret-stores/azure-keyvault.md
+++ b/daprdocs/content/en/reference/components-reference/supported-secret-stores/azure-keyvault.md
@@ -25,13 +25,12 @@ spec:
   metadata:
   - name: vaultName
     value: [your_keyvault_name]
-  - name: spnTenantId
-    value: "[your_service_principal_tenant_id]"
-  - name: spnClientId
-    value: "[your_service_principal_app_id]"
-    value : "[pfx_certificate_contents]"
-  - name: spnCertificateFile
-    value : "[pfx_certificate_file_fully_qualified_local_path]"
+  - name: azureTenantId
+    value: "[your_tenant_id]"
+  - name: azureClientId
+    value: "[your_client_id]"
+  - name: azureClientSecret
+    value : "[your_client_secret]"
 ```
 
 {{% alert title="Warning" color="warning" %}}


### PR DESCRIPTION
`spn*` are legacy keys
Re-do of #1929 with a new base