### PR TITLE
add rel attribute to remove association with previous page 

### DIFF
--- a/daprdocs/layouts/partials/navbar.html
+++ b/daprdocs/layouts/partials/navbar.html
@@ -14,7 +14,7 @@
 				{{ end }}
 				{{ $url := urls.Parse .URL }}
 				{{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
-				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" rel="nofollow noopener noreferrer"{{ end }}><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}

--- a/daprdocs/layouts/partials/page-meta-links.html
+++ b/daprdocs/layouts/partials/page-meta-links.html
@@ -21,8 +21,8 @@
 {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
 {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
 
-<a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
-<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+<a href="{{ $editURL }}" target="_blank" rel="nofollow noopener noreferrer"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+<a href="{{ $issuesURL }}" target="_blank" rel="nofollow noopener noreferrer"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 </div>
 {{ end }}
 {{ end }}

--- a/daprdocs/layouts/partials/version-banner.html
+++ b/daprdocs/layouts/partials/version-banner.html
@@ -8,7 +8,7 @@
     {{ with $current_version }}<p>The documentation you are viewing is for Dapr {{ . | markdownify }} 
       which is an older version of Dapr. 
       {{ with $latest_version }}For up-to-date documentation, see the 
-        <a href="{{ $latest_version | safeURL }}" target="_blank">latest version</a>.</p>
+        <a href="{{ $latest_version | safeURL }}" target="_blank" rel="nofollow noopener noreferrer">latest version</a>.</p>
       {{ end }}
     {{ end }}
   </div>


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This change addresses the security vulnerability that target = _blank creates for Tabnabbing

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
