### PR TITLE
Added DCO sign-off guidance for contributing to Dapr

### DIFF
--- a/daprdocs/content/en/contributing/contributing-overview.md
+++ b/daprdocs/content/en/contributing/contributing-overview.md
@@ -54,8 +54,48 @@ All contributions come through pull requests. To submit a proposed change, follo
     - Code changes require tests
 1. Update relevant documentation for the change
 1. Commit and open a PR
-1. Wait for the CI process to finish and make sure all checks are green
-1. A maintainer of the project will be assigned, and you can expect a review within a few days
+
+    - Developer Certificate of Origin: Signing your work
+    
+        The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full [text of the DCO](https://developercertificate.org/), reformatted for readability:
+        ```
+        By making a contribution to this project, I certify that:
+        
+         a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+        
+         b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+        
+        c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+        
+        d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+        ```
+
+        Contributors _sign-off_ that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
+        ```bash
+        This is my commit message
+
+        Signed-off-by: Random J Developer <random@developer.example.org>
+        ```
+
+        Git even has a `-s` command line option to append this automatically to your commit message:
+
+        ```bash
+        $ git commit -s -m 'This is my commit message'
+        ```
+
+        Once commits have been signed and a PR has been open, wait for the CI process to finish and make sure all checks are green. A maintainer of the project will be assigned, and you can expect a review within a few days
+
+    - I didn't sign my commit, what do I do now?
+
+        You can easily replay your changes, sign them and force push them!
+
+        ```bash
+        git checkout <branch-name>
+        git reset $(git merge-base main <branch-name>)
+        git add -A
+        git commit -sm "one commit on <branch-name>"
+        git push --force
+        ```
 
 #### Use work-in-progress PRs for early feedback
 

--- a/daprdocs/content/en/contributing/contributing-overview.md
+++ b/daprdocs/content/en/contributing/contributing-overview.md
@@ -43,6 +43,7 @@ Before you submit an issue, make sure you've checked the following:
     - Many changes to the Dapr runtime may require changes to the API. In that case, the best place to discuss the potential feature is the main [Dapr repo](https://github.com/dapr/dapr).
     - Other examples could include bindings, state stores or entirely new components.
 
+
 ## Pull Requests
 
 All contributions come through pull requests. To submit a proposed change, follow this workflow:
@@ -53,57 +54,54 @@ All contributions come through pull requests. To submit a proposed change, follo
 1. Create your change
     - Code changes require tests
 1. Update relevant documentation for the change
-1. Commit and open a PR
+1. Commit with [DCO sign-off]({{< ref "contributing-overview.md#developer-certificate-of-origin-signing-your-work" >}}) and open a PR
+1. Wait for the CI process to finish and make sure all checks are green
+1. A maintainer of the project will be assigned, and you can expect a review within a few days
 
-    - Developer Certificate of Origin: Signing your work
-    
-        The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full [text of the DCO](https://developercertificate.org/), reformatted for readability:
-        ```
-        By making a contribution to this project, I certify that:
-        
-         a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
-        
-         b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
-        
-        c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
-        
-        d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
-        ```
-
-        Contributors _sign-off_ that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
-        ```bash
-        This is my commit message
-
-        Signed-off-by: Random J Developer <random@developer.example.org>
-        ```
-
-        Git even has a `-s` command line option to append this automatically to your commit message:
-
-        ```bash
-        $ git commit -s -m 'This is my commit message'
-        ```
-
-        Once commits have been signed and a PR has been open, wait for the CI process to finish and make sure all checks are green. A maintainer of the project will be assigned, and you can expect a review within a few days
-
-    - I didn't sign my commit, what do I do now?
-
-        You can easily replay your changes, sign them and force push them!
-
-        ```bash
-        git checkout <branch-name>
-        git reset $(git merge-base main <branch-name>)
-        git add -A
-        git commit -sm "one commit on <branch-name>"
-        git push --force
-        ```
 
 #### Use work-in-progress PRs for early feedback
 
 A good way to communicate before investing too much time is to create a "Work-in-progress" PR and share it with your reviewers. The standard way of doing this is to add a "[WIP]" prefix in your PR's title and assign the **do-not-merge** label. This will let people looking at your PR know that it is not well baked yet.
 
-### Use of Third-party code
+## Use of Third-party code
 
 - Third-party code must include licenses.
+
+## Developer Certificate of Origin: Signing your work
+#### Every commit needs to be signed
+
+The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the [DCO](https://developercertificate.org/), reformatted for readability:
+```
+By making a contribution to this project, I certify that:
+    (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+    (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+    (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+    (d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+```
+Contributors sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
+
+```
+This is my commit message
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+Git even has a `-s` command line option to append this automatically to your commit message:
+```
+$ git commit -s -m 'This is my commit message'
+```
+
+Each Pull Request is checked  whether or not commits in a Pull Request do contain a valid Signed-off-by line.
+
+#### I didn't sign my commit, now what?!
+
+No worries - You can easily replay your changes, sign them and force push them!
+
+```
+git checkout <branch-name>
+git reset $(git merge-base main <branch-name>)
+git add -A
+git commit -s -m "one commit on <branch-name>"
+git push --force
+```
 
 ## Code of Conduct
 


### PR DESCRIPTION
Signed-off-by: Nick Greenfield <nigreenf@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added DCO sign-off guidance for contributing to Dapr
## Issue reference
https://github.com/dapr/docs/issues/2039
