### PR TITLE
Add DCO check to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 Thank you for helping make the Dapr documentation better!
 
 **Please follow this checklist before submitting:**
-
+- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
 - [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
 - [ ] Commands include options for Linux, MacOS, and Windows within codetabs
 - [ ] New file and folder names are globally unique


### PR DESCRIPTION
Signed-off-by: Nick Greenfield <nigreenf@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add DCO check to PR template so contributors will see the reminder that their commits need to be signed. 

## Issue reference

https://github.com/dapr/docs/issues/2039
