### PR TITLE
Display value instead of a object

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
@@ -195,7 +195,7 @@ while True:
         #Using Dapr SDK to save and get state
         client.save_state(DAPR_STORE_NAME, "order_1", str(orderId)) 
         result = client.get_state(DAPR_STORE_NAME, "order_1")
-        logging.info('Result after get: ' + str(result))
+        logging.info('Result after get: ' + result.data.decode('utf-8'))
 ```
 
 Navigate to the directory containing the above code, then run the following command to launch a Dapr sidecar and run the application:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Before:

```
== APP == INFO:root:Result after get: <dapr.clients.grpc._response.StateResponse object at 0x7f3f1ef42b00>
```

After:

```
== APP == INFO:root:Result after get: 910
```

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
