### PR TITLE
Added missing HTTP verb to the documentation dapr/dapr#4030

### DIFF
--- a/daprdocs/content/en/reference/api/service_invocation_api.md
+++ b/daprdocs/content/en/reference/api/service_invocation_api.md
@@ -16,7 +16,7 @@ This endpoint lets you invoke a method in another Dapr enabled app.
 ### HTTP Request
 
 ```
-POST/GET/PUT/DELETE http://localhost:<daprPort>/v1.0/invoke/<appId>/method/<method-name>
+PATCH/POST/GET/PUT/DELETE http://localhost:<daprPort>/v1.0/invoke/<appId>/method/<method-name>
 ```
 
 ### HTTP Response codes


### PR DESCRIPTION
**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added missing HTTP verb to dapr invoke REST documentation dapr/dapr#4030

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
