### PR TITLE
update endpoint in s3 binding doc

### DIFF
--- a/daprdocs/content/en/operations/monitoring/tracing/supported-tracing-backends/jaeger.md
+++ b/daprdocs/content/en/operations/monitoring/tracing/supported-tracing-backends/jaeger.md
@@ -83,7 +83,7 @@ spec:
 
 #### Production
 
-Jaeger uses Elasticsearch as the backend storage, and you can create a secret in k8s cluster to access Elasticsearch server with access control. See [Configuring and Deploying Jaeger](https://docs.openshift.com/container-platform/4.7/jaeger/jaeger_install/rhbjaeger-deploying.html)
+Jaeger uses Elasticsearch as the backend storage, and you can create a secret in k8s cluster to access Elasticsearch server with access control. See [Configuring and Deploying Jaeger](https://docs.openshift.com/container-platform/4.9/distr_tracing/distr_tracing_install/distr-tracing-deploying.html)
 
 ```shell
 kubectl create secret generic jaeger-secret --from-literal=ES_PASSWORD='xxx' --from-literal=ES_USERNAME='xxx' -n ${NAMESPACE}

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/s3.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/s3.md
@@ -27,6 +27,8 @@ spec:
     value: mybucket
   - name: region
     value: us-west-2
+  - name: endpoint
+    value: s3-us-west-2.amazonaws.com
   - name: accessKey
     value: *****************
   - name: secretKey
@@ -49,6 +51,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 |--------------------|:--------:|------------|-----|---------|
 | bucket | Y | Output | The name of the S3 bucket to write to | `"bucket"` |
 | region             | Y        | Output |  The specific AWS region | `"us-east-1"`       |
+| endpoint           | N        | Output |  The specific AWS endpoint | `"s3-us-west-2.amazonaws.com"` |
 | accessKey          | Y        | Output | The AWS Access Key to access this resource                              | `"key"`             |
 | secretKey          | Y        | Output | The AWS Secret Access Key to access this resource                       | `"secretAccessKey"` |
 | sessionToken       | N        | Output | The AWS session token to use                                            | `"sessionToken"`    |
@@ -136,6 +139,8 @@ spec:
     value: mybucket
   - name: region
     value: us-west-2
+  - name: endpoint
+    value: s3-us-west-2.amazonaws.com
   - name: accessKey
     value: *****************
   - name: secretKey

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/s3.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/s3.md
@@ -51,7 +51,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 |--------------------|:--------:|------------|-----|---------|
 | bucket | Y | Output | The name of the S3 bucket to write to | `"bucket"` |
 | region             | Y        | Output |  The specific AWS region | `"us-east-1"`       |
-| endpoint           | N        | Output |  The specific AWS endpoint | `"s3-us-west-2.amazonaws.com"` |
+| endpoint           | N        | Output |  The specific AWS endpoint | `"s3-us-east-1.amazonaws.com"` |
 | accessKey          | Y        | Output | The AWS Access Key to access this resource                              | `"key"`             |
 | secretKey          | Y        | Output | The AWS Secret Access Key to access this resource                       | `"secretAccessKey"` |
 | sessionToken       | N        | Output | The AWS session token to use                                            | `"sessionToken"`    |


### PR DESCRIPTION
Signed-off-by: lizzzcai <lizzzcai1@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
The [endpoint](https://github.com/dapr/components-contrib/blob/master/bindings/aws/s3/s3.go#L46) field in s3 binding is missing in the docs. 

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
https://github.com/dapr/docs/issues/2050
