### PR TITLE
add ForcePathStyle support for s3 binding

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/s3.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/s3.md
@@ -37,6 +37,8 @@ spec:
     value: <bool>
   - name: encodeBase64
     value: <bool>
+  - name: forcePathStyle
+    value: <bool>
 ```
 
 {{% alert title="Warning" color="warning" %}}
@@ -52,6 +54,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | accessKey          | Y        | Output | The AWS Access Key to access this resource                              | `"key"`             |
 | secretKey          | Y        | Output | The AWS Secret Access Key to access this resource                       | `"secretAccessKey"` |
 | sessionToken       | N        | Output | The AWS session token to use                                            | `"sessionToken"`    |
+| forcePathStyle     | N        | Output | Currently Amazon S3 SDK supports virtual hosted-style and path-style access. `true` is path-style format like `https://<endpoint>/<your bucket>/<key>`. `false` is hosted-style format like `https://<your bucket>.<endpoint>/<key>`. Defaults to `false` | `true`, `false` |
 | decodeBase64 | N | Output | Configuration to decode base64 file content before saving to bucket storage. (In case of saving a file with binary content). `true` is the only allowed positive value. Other positive variations like `"True", "1"` are not acceptable. Defaults to `false` | `true`, `false` |
 | encodeBase64 | N | Output | Configuration to encode base64 file content before return the content. (In case of opening a file with binary content). `true` is the only allowed positive value. Other positive variations like `"True", "1"` are not acceptable. Defaults to `false` | `true`, `false` |
 
@@ -143,6 +146,8 @@ spec:
   - name: sessionToken
     value: mysession
   - name: decodeBase64
+    value: <bool>
+  - name: forcePathStyle
     value: <bool>
 ```
 


### PR DESCRIPTION
Signed-off-by: rainfd <rainfd@live.cn>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add S3ForcePathStyle field  for s3 binding.

## Issue reference

#2022 
dapr/components-contrib#1360
