### PR TITLE
Correction to global ha configuration using yaml

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
@@ -87,8 +87,9 @@ helm search repo dapr --devel --versions
 # create a values file to store variables
 touch values.yml
 cat << EOF >> values.yml
-global.ha.enabled: true
-
+global:
+  ha:
+    enabled: true
 EOF
 
 # run install/upgrade


### PR DESCRIPTION
The global configuration to enable ha was not correct, it was in the same format as the command line, but it's a yaml file and it should be in a nested format.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
