### PR TITLE
Docs tweak for #1408 / #1409: Kafka PubSub using metadata as headers

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -138,10 +138,10 @@ curl -X POST http://localhost:3500/v1.0/publish/myKafka/myTopic?metadata.partiti
 
 ### Message headers
 
-All other metadata key/value pairs (that are not `partitionKey`) are set as headers in the Kafka message. For example, here is an example setting a `correlationId` for the message.
+All other metadata key/value pairs (that are not `partitionKey`) are set as headers in the Kafka message. Here is an example setting a `correlationId` for the message.
 
 ```shell
-curl -X POST http://localhost:3500/v1.0/publish/myKafka/myTopic?metadata.correlationId=myCorrelationID \
+curl -X POST http://localhost:3500/v1.0/publish/myKafka/myTopic?metadata.correlationId=myCorrelationID&metadata.partitionKey=key1 \
   -H "Content-Type: application/json" \
   -d '{
         "data": {

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -136,6 +136,20 @@ curl -X POST http://localhost:3500/v1.0/publish/myKafka/myTopic?metadata.partiti
       }'
 ```
 
+### Message headers
+
+All other metadata key/value pairs (that are not `partitionKey`) are set as headers in the Kafka message. For example, here is an example setting a `correlationId` for the message.
+
+```shell
+curl -X POST http://localhost:3500/v1.0/publish/myKafka/myTopic?metadata.correlationId=myCorrelationID \
+  -H "Content-Type: application/json" \
+  -d '{
+        "data": {
+          "message": "Hi"
+        }
+      }'
+```
+
 ## Create a Kafka instance
 
 {{< tabs "Self-Hosted" "Kubernetes">}}


### PR DESCRIPTION
## Description

Documentation for using metadata as Kafka message headers.

## Issue reference

Issue: dapr/components-contrib#1408
PR: dapr/components-contrib#1409
