### PR TITLE
Added a google analytics event for clicked tabs

### DIFF
--- a/daprdocs/layouts/shortcodes/tabs.html
+++ b/daprdocs/layouts/shortcodes/tabs.html
@@ -10,7 +10,7 @@
   <!-- Generate the IDs for the <a> and the <div> elements -->
   {{- $tabid := printf "%s-%s-tab" $guid $entry | anchorize -}}
   {{- $entryid := printf "%s-%s" $guid $entry | anchorize -}}
-  <a class="nav-link{{ if eq ($.Scratch.Get "first") true }} active{{ end }}"
+  <a onclick="ga('send', 'event', 'Tabs', 'Clicked', '{{ $.Page.Title }} - {{ $entryid }}');" class="nav-link{{ if eq ($.Scratch.Get "first") true }} active{{ end }}"
     id="{{ $tabid }}" data-toggle="tab" href="#{{ $entryid }}" role="tab"
     aria-controls="{{ $entryid }}" aria-selected="{{ $.Scratch.Get "first" }}">
     {{ . }}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added a google analytics event for clicked tabs to track which tabs are most clicked. 
