### PR TITLE
moving middleware to samples

### DIFF
--- a/daprdocs/content/en/developing-applications/middleware.md
+++ b/daprdocs/content/en/developing-applications/middleware.md
@@ -74,4 +74,4 @@ After the components-contrib change has been accepted, submit another pull reque
 
 * [Component schema]({{< ref component-schema.md >}})
 * [Configuration overview]({{< ref configuration-overview.md >}})
-* [Middleware quickstart](https://github.com/dapr/quickstarts/tree/master/middleware)
+* [Middleware sample](https://github.com/dapr/samples/tree/master/middleware)

--- a/daprdocs/content/en/developing-applications/middleware.md
+++ b/daprdocs/content/en/developing-applications/middleware.md
@@ -74,4 +74,4 @@ After the components-contrib change has been accepted, submit another pull reque
 
 * [Component schema]({{< ref component-schema.md >}})
 * [Configuration overview]({{< ref configuration-overview.md >}})
-* [Middleware sample](https://github.com/dapr/samples/tree/master/middleware)
+* [Middleware sample](https://github.com/dapr/samples/tree/master/middleware-oauth-google)

--- a/daprdocs/content/en/getting-started/quickstarts.md
+++ b/daprdocs/content/en/getting-started/quickstarts.md
@@ -22,7 +22,6 @@ The [Dapr Quickstarts](https://github.com/dapr/quickstarts/tree/v1.5.0) are a co
 | [Distributed Calculator](https://github.com/dapr/quickstarts/tree/v1.5.0/distributed-calculator) | Demonstrates a distributed calculator application that uses Dapr services to power a React web app. Highlights polyglot (multi-language) programming, service invocation and state management. |
 | [Pub/Sub](https://github.com/dapr/quickstarts/tree/v1.5.0/pub-sub)                | Demonstrates how to use Dapr to enable pub-sub applications. Uses Redis as a pub-sub component.                                                                                          |
 | [Bindings](https://github.com/dapr/quickstarts/tree/v1.5.0/bindings)            | Demonstrates how to use Dapr to create input and output bindings to other components. Uses bindings to Kafka.                                                                            |
-| [Middleware](https://github.com/dapr/quickstarts/tree/v1.5.0/middleware) | Demonstrates use of Dapr middleware to enable OAuth 2.0 authorization. |
 | [Observability](https://github.com/dapr/quickstarts/tree/v1.5.0/observability) | Demonstrates Dapr tracing capabilities. Uses Zipkin as a tracing component. |
 | [Secret Store](https://github.com/dapr/quickstarts/tree/v1.5.0/secretstore) | Demonstrates the use of Dapr Secrets API to access secret stores. |
 


### PR DESCRIPTION
Signed-off-by: Paul Yuknewicz <paulyuk@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Middleware has been moved from Quickstarts to Samples.  This is the corresponding doc changes.  

## Issue reference

Fixes https://github.com/dapr/quickstarts/issues/512 

Waiting on
https://github.com/dapr/quickstarts/pull/513
https://github.com/dapr/samples/pull/94

