### PR TITLE
Added notes for EKS users to watch out for hostnework issue

### DIFF
--- a/daprdocs/content/en/operations/troubleshooting/common_issues.md
+++ b/daprdocs/content/en/operations/troubleshooting/common_issues.md
@@ -64,6 +64,32 @@ In order to further diagnose any issue, check the logs of the Dapr sidecar injec
 
 *Note: If you installed Dapr to a different namespace, replace dapr-system above with the desired namespace*
 
+If you are deploying Dapr on Amazon EKS and using an overlay network such as Calico, you will need to set `hostNetwork` parameter to true, this is a limitation of EKS with such CNIs.
+
+You can set this parameter using Helm `values.yaml` file:
+
+```
+helm upgrade --install dapr dapr/dapr \
+  --namespace dapr-system \
+  --create-namespace \
+  --values values.yaml
+```
+
+`values.yaml`
+```yaml
+dapr_sidecar_injector:
+  hostNetwork: true
+```
+
+or using command line:
+
+```
+helm upgrade --install dapr dapr/dapr \
+  --namespace dapr-system \
+  --create-namespace \
+  --set dapr_sidecar_injector.hostNetwork=true
+```
+
 ## My pod is in CrashLoopBackoff or another failed state due to the daprd sidecar
 
 If the Dapr sidecar (`daprd`) is taking too long to initialize, this might be surfaced as a failing health check by Kubernetes.


### PR DESCRIPTION
Signed-off-by: Abel Perez Martinez <abelperezok@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added notes for EKS users to watch out for hostnework issue

## Issue reference

This is a follow up from issue https://github.com/dapr/dapr/issues/4074 on dapr main repo
