### PR TITLE
Remove app-protocol from gRPC proxying

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-services-grpc.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-services-grpc.md
@@ -90,7 +90,7 @@ spec:
 Run the sidecar and the Go server:
 
 ```bash
-dapr run --app-id server --app-protocol grpc --app-port 50051 --config config.yaml -- go run main.go
+dapr run --app-id server --app-port 50051 --config config.yaml -- go run main.go
 ```
 
 Using the Dapr CLI, we're assigning a unique id to the app, `server`, using the `--app-id` flag.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Remove app-protocol from gRPC proxying

## Issue reference
https://github.com/dapr/docs/issues/2048
