### PR TITLE
Add example for nats jetstream with nkey based authentication

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-jetstream.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-jetstream.md
@@ -26,9 +26,9 @@ spec:
   - name: natsURL
     value: "nats://localhost:4222"
   - name: jwt
-    value: "eyJhbGciOiJ...6yJV_adQssw5c" # Optional. Used for decentralized JWT Authentication
+    value: "eyJhbGciOiJ...6yJV_adQssw5c" # Optional. Used for decentralized JWT authentication
   - name: seedKey
-    value: "SUACS34K232O...5Z3POU7BNIL4Y" # Optional. Used for decentralized JWT Authentication
+    value: "SUACS34K232O...5Z3POU7BNIL4Y" # Optional. Used for decentralized JWT authentication
   - name: name
     value: "connection name"
   - name: durableName
@@ -50,8 +50,8 @@ spec:
 | Field          | Required | Details | Example |
 |----------------|:--------:|---------|---------|
 | natsURL        |        Y | NATS server address URL   | "`nats://localhost:4222`"|
-| jwt            |        N | NATS decentralized Authentication JWT | "`eyJhbGciOiJ...6yJV_adQssw5c`"|
-| seedKey        |        N | NATS decentralized Authentication seed key | "`SUACS34K232O...5Z3POU7BNIL4Y`"|
+| jwt            |        N | NATS decentralized authentication JWT | "`eyJhbGciOiJ...6yJV_adQssw5c`"|
+| seedKey        |        N | NATS decentralized authentication seed key | "`SUACS34K232O...5Z3POU7BNIL4Y`"|
 | name           |        N | NATS connection name | `"my-conn-name"`|
 | durableName    |        N | [Durable name] | `"my-durable"` |
 | queueGroupName |        N | Queue group name | `"my-queue"` |
@@ -101,3 +101,4 @@ with NATS, find the service with: `kubectl get svc my-nats`.
 [Start Time]: https://docs.nats.io/jetstream/concepts/consumers#deliverbystarttime
 [Replay Policy]: https://docs.nats.io/jetstream/concepts/consumers#replaypolicy
 [Flow Control]: https://docs.nats.io/jetstream/concepts/consumers#flowcontrol
+[Decentralized JWT Authentication/Authorization]: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-jetstream.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-jetstream.md
@@ -25,6 +25,10 @@ spec:
   metadata:
   - name: natsURL
     value: "nats://localhost:4222"
+  - name: jwt
+    value: "eyJhbGciOiJ...6yJV_adQssw5c" # Optional. Used for decentralized JWT Authentication
+  - name: seedKey
+    value: "SUACS34K232O...5Z3POU7BNIL4Y" # Optional. Used for decentralized JWT Authentication
   - name: name
     value: "connection name"
   - name: durableName
@@ -46,6 +50,8 @@ spec:
 | Field          | Required | Details | Example |
 |----------------|:--------:|---------|---------|
 | natsURL        |        Y | NATS server address URL   | "`nats://localhost:4222`"|
+| jwt            |        N | NATS decentralized Authentication JWT | "`eyJhbGciOiJ...6yJV_adQssw5c`"|
+| seedKey        |        N | NATS decentralized Authentication seed key | "`SUACS34K232O...5Z3POU7BNIL4Y`"|
 | name           |        N | NATS connection name | `"my-conn-name"`|
 | durableName    |        N | [Durable name] | `"my-durable"` |
 | queueGroupName |        N | Queue group name | `"my-queue"` |


### PR DESCRIPTION
Signed-off-by: Tim Burkert <burkert.tim@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x]  Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated nats jetstream pub-sub components reference with new metadata fields for decentralized JWT Authentication

