### PR TITLE
Fixing middleware samples link in component-reference

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-oauth2.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-oauth2.md
@@ -74,7 +74,7 @@ spec:
 ## Related links
 
 - [Configure API authorization with OAuth]({{< ref oauth >}})
-- [Middleware OAuth quickstart](https://github.com/dapr/quickstarts/tree/master/middleware)
+- [Middleware OAuth sample (interactive)](https://github.com/dapr/samples/tree/master/middleware-oauth-google)
 - [Middleware]({{< ref middleware.md >}})
 - [Configuration concept]({{< ref configuration-concept.md >}})
 - [Configuration overview]({{< ref configuration-overview.md >}})


### PR DESCRIPTION
… samples repo

Signed-off-by: Paul Yuknewicz <paulyuk@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Tests fail and link is broken after the move of middleware from quickstarts to samples.  Changing the broken link here:

./daprdocs/content/en/reference/components-reference/supported-middleware/middleware-oauth2.md

from:
https://github.com/dapr/quickstarts/tree/master/middleware 

to:
https://github.com/dapr/samples/tree/master/middleware-oauth-google

## Issue reference

fixes #512
