### PR TITLE
Add docs to stop watching configuration updates

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
@@ -108,5 +108,23 @@ message SubscribeConfigurationRequest {
 
 Using this method, you can subscribe to changes in specific keys for a given configuration store. gRPC streaming varies widely based on language - see the [gRPC examples here](https://grpc.io/docs/languages/) for usage.
 
+### Stop watching configuration items
+
+After you have subscribed to watch configuration items, the gRPC-server stream starts. This stream thread does not close itself, and you have to do by explicitly call the `UnSubscribeConfigurationRequest` API. This method accepts the following request object:
+
+```proto
+// UnSubscribeConfigurationRequest is the message to stop watching the key-value configuration.
+message UnSubscribeConfigurationRequest {
+  // The name of configuration store.
+  string store_name = 1;
+  // Optional. The keys of the configuration item to stop watching.
+  // Store_name and keys should match previous SubscribeConfigurationRequest's keys and store_name.
+  // Once invoked, the subscription that is watching update for the key-value event is stopped
+  repeated string keys = 2;
+}
+```
+
+Using this unsubscribe method, you can stop watching configuration update events. Dapr locates the subscription stream based on the `store_name` and any optional keys supplied and closes it.
+
 ## Next steps
 * Read [configuration API overview]({{< ref configuration-api-overview.md >}})


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Add docs to stop watching configuration changes since no response in this thread: https://github.com/dapr/docs/pull/2010/files