### PR TITLE
Fixing the main link to JS-SDK docs

### DIFF
--- a/daprdocs/content/en/developing-applications/sdks/_index.md
+++ b/daprdocs/content/en/developing-applications/sdks/_index.md
@@ -36,7 +36,7 @@ The Dapr SDKs are the easiest way for you to get Dapr into your application. Cho
 | [Java]({{< ref java >}}) | Stable | ✔ | Spring Boot | ✔ |
 | [Go]({{< ref go >}}) | Stable | ✔ | ✔ | ✔ |
 | [PHP]({{< ref php >}}) | Stable | ✔ | ✔ | ✔ |
-| [Javascript](https://github.com/dapr/js-sdk) | Stable| ✔ | | ✔ |
+| [Javascript]({{< ref js >}}) | Stable| ✔ | | ✔ |
 | [C++](https://github.com/dapr/cpp-sdk) | In development | ✔ | |
 | [Rust](https://github.com/dapr/rust-sdk) | In development | ✔ | |  |
 


### PR DESCRIPTION
Signed-off-by: Paul Yuknewicz <paulyuk@microsoft.com>

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The main JS-SDK link points to the github repo instead of the SDK-docs.  This reduces the user experience.

## Issue reference

#2142 
