### PR TITLE
Fix navbar for v1.7 branch

### DIFF
--- a/daprdocs/config.toml
+++ b/daprdocs/config.toml
@@ -173,7 +173,7 @@ url_latest_version = "https://docs.dapr.io"
   url = "#"
 [[params.versions]]
   version = "v1.6 (latest)"
-  url = "https://v1-6.docs.dapr.io"
+  url = "https://docs.dapr.io"
 [[params.versions]]
   version = "v1.5"
   url = "https://v1-5.docs.dapr.io"

--- a/daprdocs/config.toml
+++ b/daprdocs/config.toml
@@ -163,17 +163,17 @@ github_subdir = "daprdocs"
 github_branch = "v1.7"
 
 # Versioning
-version_menu = "v1.6 (latest)"
-version = "v1.6"
+version_menu = "v1.7 (preview)"
+version = "v1.7"
 archived_version = false
 url_latest_version = "https://docs.dapr.io"
 
 [[params.versions]]
   version = "v1.7 (preview)"
-  url = "https://v1-7.docs.dapr.io"
+  url = "#"
 [[params.versions]]
   version = "v1.6 (latest)"
-  url = "#"
+  url = "https://v1-6.docs.dapr.io"
 [[params.versions]]
   version = "v1.5"
   url = "https://v1-5.docs.dapr.io"


### PR DESCRIPTION
Signed-off-by: Nick Greenfield <nigreenf@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fix navbar for v1.7 branch so it shows v1.7 and not v1.6
