### PR TITLE
Add docs on oracle database state store component

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/_index.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/_index.md
@@ -36,6 +36,7 @@ The following stores are supported, at various levels, by the Dapr state managem
 | [Memcached]({{< ref setup-memcached.md >}})        | ✅ | ❌          | ❌  | ✅ | ❌ | ❌ | Alpha  | v1 | 1.0 |
 | [MongoDB]({{< ref setup-mongodb.md >}})            | ✅ | ✅          | ✅  | ❌ | ✅ | ✅ | Stable | v1 | 1.0 |
 | [MySQL]({{< ref setup-mysql.md >}})                | ✅ | ✅          | ✅  | ❌ | ✅ | ❌ | Alpha  | v1 | 1.0 |
+| [Oracle Database]({{< ref setup-oracledatabase.md >}})      | ✅ | ✅          | ✅  | ✅ | ✅ | ❌ | Alpha  | v1 | 1.7 |
 | [PostgreSQL]({{< ref setup-postgresql.md >}})      | ✅ | ✅          | ✅  | ❌ | ✅ | ❌ | Alpha  | v1 | 1.0 |
 | [Redis]({{< ref setup-redis.md >}})                | ✅ | ✅          | ✅  | ✅ | ✅ | ❌ | Stable | v1 | 1.0 |
 | [RethinkDB]({{< ref setup-rethinkdb.md >}})        | ✅ | ✅          | ✅  | ❌ | ✅ | ❌ | Alpha  | v1 | 1.0 |

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/_index.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/_index.md
@@ -66,4 +66,5 @@ The following stores are supported, at various levels, by the Dapr state managem
 
 | Name                                                             |CRUD|Transactional|ETag| [TTL]({{< ref state-store-ttl.md >}}) | [Actors]({{< ref howto-actors.md >}}) | [Query]({{< ref howto-state-query-api.md >}}) | Status | Component version | Since |
 |------------------------------------------------------------------|----|-------------|----|----|----|----|-------|----|-----|
-| [OCI Object Storage]({{< ref setup-oci-objectstorage.md >}})     | ✅ | ❌           | ✅ | ✅ | ❌ | ❌ | Alpha | v1 | 1.6 |
+| [Autonomous Database (ATP and ADW)]({{< ref setup-oracledatabase.md >}})      | ✅ | ✅          | ✅  | ✅ | ✅ | ❌ | Alpha  | v1 | 1.7 |
+| [Object Storage]({{< ref setup-oci-objectstorage.md >}})     | ✅ | ❌           | ✅ | ✅ | ❌ | ❌ | Alpha | v1 | 1.6 |

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-oci-objectstorage.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-oci-objectstorage.md
@@ -26,7 +26,7 @@ spec:
  - name: configFileAuthentication
    value: <"true" or "false">  # Optional. default: "false" . Not used when instancePrincipalAuthentication == "true" 
  - name: configFilePath
-   value: <REPLACE-WITH-FULL-QUALIFIED-PATH-OF-CONFIG-FILE>  # Optional. default: the operating system specific default location for the OCI config file; on Linux: "~/.oci/config" . Only used when configFileAuthentication == "true" 
+   value: <REPLACE-WITH-FULL-QUALIFIED-PATH-OF-CONFIG-FILE>  # Optional. No default. Only used when configFileAuthentication == "true" 
  - name: configFileProfile
    value: <REPLACE-WITH-NAME-OF-PROFILE-IN-CONFIG-FILE>  # Optional. default: "DEFAULT" . Only used when configFileAuthentication == "true" 
  - name: tenancyOCID
@@ -59,7 +59,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 |--------------------|:--------:|---------|---------|
 | instancePrincipalAuthentication        | N        | Boolean to indicate whether instance principal based authentication is used. Default: `"false"`  | `"true"` or  `"false"` .
 | configFileAuthentication        | N        | Boolean to indicate whether identity credential details are provided through a configuration file. Default: `"false"` Not required nor used when instancePrincipalAuthentication is true.  | `"true"` or  `"false"` .
-| configFilePath        | N        | Full path name to the OCI configuration file. Default: the default location on your operating system for the OCI confile file, for example `"~/.oci/config"` on Linux. Not used when instancePrincipalAuthentication is true.  | `"/home/apps/configuration-files/myOCIConfig.txt"`.
+| configFilePath        | N        | Full path name to the OCI configuration file. No default value exists. Not used when instancePrincipalAuthentication is true. Note: the ~/ prefix is not supported. | `"/home/apps/configuration-files/myOCIConfig.txt"`.
 | configFileProfile        | N        | Name of profile in configuration file to use. Default: `"DEFAULT"` Not used when instancePrincipalAuthentication is true.  | `"DEFAULT"` or  `"PRODUCTION"` .
 | tenancyOCID        | Y        | The OCI tenancy identifier. Not required nor used when instancePrincipalAuthentication is true. | `"ocid1.tenancy.oc1..aaaaaaaag7c7sljhsdjhsdyuwe723"`.
 | userOCID           | Y        | The OCID for an OCI account (this account requires permissions to access OCI Object Storage). Not required nor used when instancePrincipalAuthentication is true.| `"ocid1.user.oc1..aaaaaaaaby4oyyyuqwy7623yuwe76"`
@@ -76,7 +76,7 @@ Dapr-applications running on Oracle Cloud Infrastructure - in a compute instance
 
 Identity based authentication interacts with OCI through an OCI account that has permissions to create, read and delete objects through OCI Object Storage in the indicated bucket and that is allowed to create a bucket in the specified compartment if the bucket is not created beforehand. The OCI documentation [describes how to create an OCI Account](https://docs.oracle.com/en-us/iaas/Content/GSG/Tasks/addingusers.htm#Adding_Users). The interaction by the state store is performed using the public key's fingerprint and a private key from an RSA Key Pair generated for the OCI account. The [instructions for generating the key pair and getting hold of the required information](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm) are available in the OCI documentation. 
 
-Details for the identity and identity's credentials to be used for interaction with OCI can be provided directly in the Dapr component properties file - using the properties tenancyOCID, userOCID, fingerPrint, privateKey and region - or can be provided from a configuration file as is common for many OCI related tools (such as CLI and Terraform) and SDKs. In the latter case, a default configuration file can be assumed (such as ~/.oci/config on Linux) or the exact file name and path can be provided through property configFilePath. A configuration file can contain multiple profiles; the desired profile can be specified through property configFileProfile. If no value is provided, DEFAULT is used as the name for the profile to be used. Note: if the indicated profile is not found, then the DEFAULT profile (if it exists) is used instead. The OCI SDK documentation gives [details about the definition of the configuration file](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm).  
+Details for the identity and identity's credentials to be used for interaction with OCI can be provided directly in the Dapr component properties file - using the properties tenancyOCID, userOCID, fingerPrint, privateKey and region - or can be provided from a configuration file as is common for many OCI related tools (such as CLI and Terraform) and SDKs. In the latter case the exact file name and full path has to be provided through property configFilePath. Note: the ~/ prefix is not supported in the path. A configuration file can contain multiple profiles; the desired profile can be specified through property configFileProfile. If no value is provided, DEFAULT is used as the name for the profile to be used. Note: if the indicated profile is not found, then the DEFAULT profile (if it exists) is used instead. The OCI SDK documentation gives [details about the definition of the configuration file](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm).  
 
 If you wish to create the bucket for Dapr to use, you can do so beforehand. However, Object Storage state provider will create one - in the specified compartment - for you automatically if it doesn't exist.
 
@@ -170,7 +170,6 @@ creates the following object:
 | as specified with **bucketName** in components.yaml | -  | nihilus | darth | category: dapr-state-store , expiry-time-from-ttl: 2022-01-06T08:34:32 
 
 The exact value of the expiry-time-from-ttl depends of course on the time at which the state was created and will be 120 seconds later than that moment.
-
 
 Note that expired state is not removed from the state store by this component. An application operator may decide to run a periodic job that does a form of garbage collection in order to explicitly remove all state that has an  **expiry-time-from-ttl** label with a timestamp in the past.
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-oracledatabase.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-oracledatabase.md
@@ -1,0 +1,165 @@
+---
+type: docs
+title: "Oracle Database"
+linkTitle: "Oracle Database"
+description: Detailed information on the Oracle Database state store component
+aliases:
+  - "/operations/components/setup-state-store/supported-state-stores/setup-oracledatabase/"
+---
+
+## Create a Dapr component
+
+Create a component properties yaml file, for example called `oracle.yaml` (but it could be named anything ), paste the following and replace the `<CONNECTION STRING>` value with your connection string. The connection string is a standard Oracle Database connection string, composed as: `"oracle://user/password@host:port/servicename"` for example `"oracle://demo:demo@localhost:1521/xe"`. In case you connect to the database using an Oracle Wallet, you should specify a value for the `oracleWalletLocation` property, for example: `"/home/app/state/Wallet_daprDB/"`; this should refer to the local file system directory that contains the file `cwallet.sso` that is extracted from the Oracle Wallet archive file.
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: <NAME>
+  namespace: <NAMESPACE>
+spec:
+  type: state.oracledatabase
+  version: v1
+  metadata:
+  - name: connectionString
+    value: "<CONNECTION STRING>"
+  - name: oracleWalletLocation
+    value: "<FULL PATH TO DIRECTORY WITH ORACLE WALLET CONTENTS >"  # Optional, no default
+  - name: tableName
+    value: "<NAME OF DATABASE TABLE TO STORE STATE IN >" # Optional, defaults to STATE
+```
+{{% alert title="Warning" color="warning" %}}
+The above example uses secrets as plain strings. It is recommended to use a secret store for the secrets as described [here]({{< ref component-secrets.md >}}).
+{{% /alert %}}
+
+## Spec metadata fields
+
+| Field              | Required | Details | Example |
+|--------------------|:--------:|---------|---------|
+| connectionString   | Y        | The connection string for Oracle Database | `"oracle://user/password@host:port/servicename"` for example `"oracle://demo:demo@localhost:1521/xe"` or for Autonomous Database `"oracle://states_schema:State12345pw@adb.us-ashburn-1.oraclecloud.com:1522/k8j2agsqjsw_daprdb_low.adb.oraclecloud.com"`
+| oracleWalletLocation    | N         | Location of the contents of an Oracle Wallet file (required to connect to Autonomous Database on OCI)| `"/home/app/state/Wallet_daprDB/"`
+| tableName    | N         | Name of the database table in which this instance of the state store records the data default `"STATE"`| `"MY_APP_STATE_STORE"`
+
+## What Happens at Runtime?
+When the state store component initializes, it connects to the Oracle Database and it checks if a table with the name specified with `tableName` already exists. If it does not, it will create this table (with columns Key, Value, Binary_YN, ETag, Creation_Time, Update_Time, Expiration_time). 
+
+Every state entry is represented by a record in the database table. The `key` property provided in the requests to the Dapr API to determine the name of the object is stored literally in the KEY column. The `value` is stored as the (literal) content of the object. Binary content is stored as Base64 encoded text. Each object is assigned a unique ETag value - whenever it is created or updated (aka overwritten). 
+
+For example, the following operation 
+
+```shell
+curl -X POST http://localhost:3500/v1.0/state \
+  -H "Content-Type: application/json"
+  -d '[
+        {
+          "key": "nihilus",
+          "value": "darth"
+        }
+      ]'
+```
+
+creates the following records in table STATE:
+
+| KEY | VALUE | CREATION_TIME  | BINARY_YN | ETAG |
+| ------------ | ------- | ----- | ----- | ---- |
+| nihilus | darth | 2022-02-14T22:11:00 | N | 79dfb504-5b27-43f6-950f-d55d5ae0894f |
+
+
+Dapr uses a fixed key scheme with *composite keys* to partition state across applications. For general states, the key format is:
+`App-ID||state key`. The Oracle Database state store maps this key in its entirety to the KEY column. 
+
+You can easily inspect all state stored with SQL queries against the STATE table. 
+
+
+## Time To Live and State Expiration
+The state store components supports Dapr's Time To Live logic that ensures that state cannot be retrieved after it has expired. See [this How To on Setting State Time To Live]({{< ref "state-store-ttl.md" >}}) for details.
+
+The Oracle Database does not have native support for a Time To Live setting. The implementation in this component uses a column called `EXPIRATION_TIME` to hold the time after which the record is considered *expired*. The values in this column is set only when a TTL was specified in Set request. It is calculated as the current UTC timestamp with the TTL period added to it. When state is retrieved through a call to Get, this component checks if it has the `EXPIRATION_TIME` set and if so it checks whether it is in the past. In that case, no state is returned. 
+
+The following operation therefore: 
+
+```shell
+curl -X POST http://localhost:3500/v1.0/state \
+  -H "Content-Type: application/json"
+  -d '[
+        {
+          "key": "temporary",
+          "value": "ephemeral",
+          "metadata": {"ttlInSeconds": "120"}}
+        }
+      ]'
+```
+
+creates the following object:
+
+| KEY | VALUE | CREATION_TIME  |EXPIRATION_TIME  | BINARY_YN | ETAG |
+| ------------ | ------- | ----- | ----- | ---- |---- |
+| temporary | ephemeral | 2022-03-31T22:11:00 |2022-03-31T22:13:00 | N | 79dfb504-5b27-43f6-950f-d55d5ae0894f |
+
+with the EXPIRATION_TIME set to a timestamp 2 minutes (120 seconds) (later than the CREATION_TIME) 
+
+Note that expired state is not removed from the state store by this component. An application operator may decide to run a periodic job that does a form of garbage collection in order to explicitly remove all state records with an EXPIRATION_TIME in the past.
+
+## Concurrency
+
+Concurrency in the Oracle Database state store is achieved by using `ETag`s. Each piece of state recorded in the Oracle Database State Store is assigned a unique ETag - a generated, unique string stored in the column ETag - when it is created or updated (aka replaced). Note: the column UPDATE_TIME is also updated whenever a Set operation is performed on an existing record. When the `Set` and `Delete` requests for this state store specify the FirstWrite concurrency policy, then the request need to provide the actual ETag value for the state to be written or removed for the request to be successful. 
+
+## Consistency
+
+Oracle Database state store supports Transactions. Multiple Set and Delete commands can be combined a single request that is processed as a single, atomic transaction. Note: simple Set and Delete operations are a transaction on their own; when a Set or Delete requests returns an HTTP-20X result, the database transaction has been committed successfully. 
+
+## Query
+
+Oracle Database state store does not currently support the Query API.
+
+
+
+## Create Oracle Database and User Schema
+
+{{< tabs "Self-Hosted" "Autonomous Database on OCI">}}
+
+{{% codetab %}}
+
+1. Run an instance of Oracle Database. You can run a local instance of Oracle Database in Docker CE with the following command:
+
+     This example does not describe a production configuration because it sets the password for users `SYS` and `SYSTEM` in plain text.
+
+     ```bash
+     docker run -d -p 1521:1521 -e ORACLE_PASSWORD=TheSuperSecret1509! gvenzl/oracle-xe
+     ```
+
+2. Create a schema for state data.
+Create a new user schema for storing state data. Grant this user (schema) privileges for creating a table and storing data in the associated tablespace.
+
+    To create a new user schema in Oracle Database, run the following SQL command:
+
+    ```SQL
+    create user dapr_state identified by DaprState4239 default tablespace users quota unlimited on users;
+    grant create session, create table to dapr_state;
+    ```
+{{% /codetab %}}
+
+{{% codetab %}}
+
+1. Create a free (or paid for) Autonomous Transaction Processing (ATP) or ADW (Autonomous Data Warehouse) instance on Oracle Cloud Infrastructure, as described in the [OCI documentation for the always free autonomous database](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/autonomous-always-free.html#GUID-03F9F3E8-8A98-4792-AB9C-F0BACF02DC3E).
+
+You need to provide the password for user ADMIN. You use this account (initially at least) for database administration activities. You can work both in the web based SQL Developer tool, from its desktop counterpart or from any of a plethora of database development tools.  
+
+2. Create a schema for state data.
+Create a new user schema for storing state data - for example using the ADMIN account. Grant this new user (schema) privileges for creating a table and storing data in the associated tablespace.
+
+    To create a new user schema in Oracle Database, run the following SQL command:
+
+    ```SQL
+    create user dapr_state identified by DaprState4239 default tablespace users quota unlimited on users;
+    grant create session, create table to dapr_state;
+    ```
+{{% /codetab %}}
+
+
+{{% /tabs %}}
+
+## Related links
+- [Basic schema for a Dapr component]({{< ref component-schema >}})
+- Read [this guide]({{< ref "howto-get-save-state.md#step-2-save-and-retrieve-a-single-state" >}}) for instructions on configuring state store components
+- [State management building block]({{< ref state-management >}})


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
provide new documentation on the Oracle Database state store component (introduced in PR https://github.com/dapr/components-contrib/pull/1454 )

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->  #2109
https://github.com/dapr/docs/issues/2109