### PR TITLE
Revert gRPC examples back for config how-to

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
@@ -156,6 +156,41 @@ dapr run --app-id orderprocessing --components-path ./components python3 OrderPr
 
 {{< /tabs >}}
 
+### Get configuration items using gRPC API
+
+Using your [favorite language](https://grpc.io/docs/languages/), create a Dapr gRPC client from the [Dapr proto](https://github.com/dapr/dapr/blob/master/dapr/proto/runtime/v1/dapr.proto). The following examples show Java, C#, Python and Javascript clients.
+
+{{< tabs Java Dotnet Python Javascript >}}
+
+{{% codetab %}}
+```java
+
+Dapr.ServiceBlockingStub stub = Dapr.newBlockingStub(channel);
+stub.GetConfigurationAlpha1(new GetConfigurationRequest{ StoreName = "redisconfigstore", Keys = new String[]{"myconfig"} });
+```
+{{% /codetab %}}
+
+{{% codetab %}}
+```csharp
+
+var call = client.GetConfigurationAlpha1(new GetConfigurationRequest { StoreName = "redisconfigstore", Keys = new String[]{"myconfig"} });
+```
+{{% /codetab %}}
+
+{{% codetab %}}
+```python
+response = stub.GetConfigurationAlpha1(request={ StoreName: 'redisconfigstore', Keys = ['myconfig'] })
+```
+{{% /codetab %}}
+
+{{% codetab %}}
+```javascript
+client.GetConfigurationAlpha1({ StoreName: 'redisconfigstore', Keys = ['myconfig'] })
+```
+{{% /codetab %}}
+
+{{< /tabs >}}
+
 ### Watch configuration items
 
 Create a Dapr gRPC client from the [Dapr proto](https://github.com/dapr/dapr/blob/master/dapr/proto/runtime/v1/dapr.proto) using your [preferred language](https://grpc.io/docs/languages/). Then use the proto method `SubscribeConfigurationAlpha1` on your client stub to start subscribing to events. The method accepts the following request object:

--- a/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
@@ -191,7 +191,7 @@ client.GetConfigurationAlpha1({ StoreName: 'redisconfigstore', Keys = ['myconfig
 
 {{< /tabs >}}
 
-### Watch configuration items
+##### Watch configuration items
 
 Create a Dapr gRPC client from the [Dapr proto](https://github.com/dapr/dapr/blob/master/dapr/proto/runtime/v1/dapr.proto) using your [preferred language](https://grpc.io/docs/languages/). Then use the proto method `SubscribeConfigurationAlpha1` on your client stub to start subscribing to events. The method accepts the following request object:
 
@@ -212,7 +212,7 @@ message SubscribeConfigurationRequest {
 
 Using this method, you can subscribe to changes in specific keys for a given configuration store. gRPC streaming varies widely based on language - see the [gRPC examples here](https://grpc.io/docs/languages/) for usage.
 
-### Stop watching configuration items
+##### Stop watching configuration items
 
 After you have subscribed to watch configuration items, the gRPC-server stream starts. This stream thread does not close itself, and you have to do by explicitly call the `UnSubscribeConfigurationRequest` API. This method accepts the following request object:
 


### PR DESCRIPTION

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Add grpc examples back to config howto
