### PR TITLE
Update autoDeleteOnIdleInSec field description

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
@@ -45,7 +45,7 @@ spec:
   # - name: defaultMessageTimeToLiveInSec # Optional
   #   value: 10
   # - name: autoDeleteOnIdleInSec # Optional
-  #   value: 10
+  #   value: 3600
   # - name: maxReconnectionAttempts # Optional
   #   value: 30
   # - name: connectionRecoveryInSec # Optional
@@ -78,7 +78,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | maxConcurrentHandlers | N  |Defines the maximum number of concurrent message handlers  | `10`
 | prefetchCount         | N  |Defines the number of prefetched messages (use for high throughput / low latency scenarios)| `5`
 | defaultMessageTimeToLiveInSec | N  |Default message time to live. | `10`
-| autoDeleteOnIdleInSec | N  |Time in seconds to wait before auto deleting messages. | `10`
+| autoDeleteOnIdleInSec | N  |Time in seconds to wait before auto deleting idle subscriptions. | `3600`
 | maxReconnectionAttempts | N  |Defines the maximum number of reconnect attempts. Default: `30` | `30`
 | connectionRecoveryInSec | N  |Time in seconds to wait between connection recovery attempts. Defaults: `2` | `2`
 | publishMaxRetries | N  | The max number of retries for when Azure Service Bus responds with "too busy" in order to throttle messages. Defaults: `5` | `5`


### PR DESCRIPTION
Signed-off-by: Richard Laos <richard.laos@quest.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated the description of the autoDeleteOnIdleInSec field behavior when using Azure Service Bus pub/sub. The fields configures the auto deletion of topic subscriptions. Also updated the example value to reflect a better real world use case value.

## Issue reference

#2171
