### PR TITLE
how to set content type in state store

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-management-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-management-overview.md
@@ -55,6 +55,17 @@ When strong consistency is used, Dapr waits for all replicas (or designated quor
 
 Read the [API reference]({{< ref state_api.md >}}) to learn how to set consistency options.
 
+### Setting content type
+
+Some state store components might have different ways of maintaining and manipulating data, depending on its type.
+Dapr supports passing content type in [State management API](#state-management-api) as part of request metadata.
+
+Setting the content type is optional, and it is up to the component to make use of it. Dapr only provides the means of passing this information to the component.
+
+With the HTTP API, you can set content type via URL query parameter `metadata.contentType`. For example, `http://localhost:3500/v1.0/state/store?metadata.contentType=application/json`
+
+With the gRPC API, you can set content type by adding key/value pair `"contentType" : <content type>` to the request metadata.
+
 ### Bulk operations
 
 Dapr supports two types of bulk operations: **bulk** or **multi**. You can group several requests of the same type into a bulk (or a batch). Dapr submits requests in bulk operations as individual requests to the underlying data store. In other words, bulk operations are not transactional. On the other hand, you can group requests of different types into a multi-operation, which is then handled as an atomic transaction.

--- a/daprdocs/content/en/reference/api/state_api.md
+++ b/daprdocs/content/en/reference/api/state_api.md
@@ -28,11 +28,7 @@ spec:
 
 The ```metadata.name``` is the name of the state store.
 
-the ```spec/metadata``` section is an open key value pair metadata that allows a binding to define connection properties.
-
-Starting with 0.4.0 release, support for multiple state stores was added. This is a breaking change from previous releases as the state APIs were changed to support this new scenario.
-
-Please refer https://github.com/dapr/dapr/blob/master/docs/decision_records/api/API-008-multi-state-store-api-design.md for more details.
+The ```spec/metadata``` section is an open key value pair metadata that allows a binding to define connection properties.
 
 ## Key scheme
 
@@ -64,6 +60,11 @@ Parameter | Description
 --------- | -----------
 daprPort | the Dapr port
 storename | ```metadata.name``` field in the user configured state store component yaml. Please refer Dapr State Store configuration structure mentioned above.
+
+The optional request metadata is passed via URL query parameters. For example,
+```
+POST http://localhost:3500/v1.0/state/myStore?metadata.contentType=application/json
+```
 
 > Note, all URL parameters are case-sensitive.
 
@@ -98,7 +99,7 @@ None.
 ### Example
 
 ```shell
-curl -X POST http://localhost:3500/v1.0/state/starwars \
+curl -X POST http://localhost:3500/v1.0/state/starwars?metadata.contentType=application/json \
   -H "Content-Type: application/json" \
   -d '[
         {
@@ -135,6 +136,11 @@ key | the key of the desired state
 consistency | (optional) read consistency mode, see [state operation options](#optional-behaviors)
 metadata | (optional) metadata as query parameters to the state store
 
+The optional request metadata is passed via URL query parameters. For example,
+```
+GET http://localhost:3500/v1.0/state/myStore/myKey?metadata.contentType=application/json
+```
+
 > Note, all URL parameters are case-sensitive.
 
 ### HTTP Response
@@ -160,8 +166,7 @@ JSON-encoded value
 ### Example
 
 ```shell
-curl http://localhost:3500/v1.0/state/starwars/planet \
-  -H "Content-Type: application/json"
+curl http://localhost:3500/v1.0/state/starwars/planet?metadata.contentType=application/json
 ```
 
 > The above command returns the state:
@@ -175,7 +180,7 @@ curl http://localhost:3500/v1.0/state/starwars/planet \
 To pass metadata as query parammeter:
 
 ```
-GET http://localhost:3500/v1.0/state/starwars/planet?metadata.partitionKey=mypartitionKey
+GET http://localhost:3500/v1.0/state/starwars/planet?metadata.partitionKey=mypartitionKey&metadata.contentType=application/json
 ```
 
 ## Get bulk state
@@ -195,6 +200,11 @@ Parameter | Description
 daprPort | the Dapr port
 storename | ```metadata.name``` field in the user configured state store component yaml. Please refer Dapr State Store configuration structure mentioned above.
 metadata | (optional) metadata as query parameters to the state store
+
+The optional request metadata is passed via URL query parameters. For example,
+```
+POST/PUT http://localhost:3500/v1.0/state/myStore/bulk?metadata.partitionKey=mypartitionKey
+```
 
 > Note, all URL parameters are case-sensitive.
 
@@ -238,12 +248,6 @@ curl http://localhost:3500/v1.0/state/myRedisStore/bulk \
   }
 ]
 ```
-To pass metadata as query parammeter:
-
-```
-POST http://localhost:3500/v1.0/state/myRedisStore/bulk?metadata.partitionKey=mypartitionKey
-```
-
 
 ## Delete state
 
@@ -264,6 +268,11 @@ storename | ```metadata.name``` field in the user configured state store compone
 key | the key of the desired state
 concurrency | (optional) either *first-write* or *last-write*, see [state operation options](#optional-behaviors)
 consistency | (optional) either *strong* or *eventual*, see [state operation options](#optional-behaviors)
+
+The optional request metadata is passed via URL query parameters. For example,
+```
+DELETE http://localhost:3500/v1.0/state/myStore/myKey?metadata.contentType=application/json
+```
 
 > Note, all URL parameters are case-sensitive.
 
@@ -314,6 +323,11 @@ daprPort | the Dapr port
 storename | ```metadata.name``` field in the user configured state store component yaml. Refer to the Dapr state store configuration structure mentioned above.
 metadata | (optional) metadata as query parameters to the state store
 
+The optional request metadata is passed via URL query parameters. For example,
+```
+POST http://localhost:3500/v1.0-alpha1/state/myStore/query?metadata.contentType=application/json
+```
+
 > Note, all URL parameters are case-sensitive.
 
 #### Response Codes
@@ -330,7 +344,7 @@ An array of JSON-encoded values
 ### Example
 
 ```shell
-curl -X POST http://localhost:3500/v1.0-alpha1/state/myStore/query \
+curl -X POST http://localhost:3500/v1.0-alpha1/state/myStore/query?metadata.contentType=application/json \
   -H "Content-Type: application/json" \
   -d '{
         "filter": {
@@ -410,11 +424,6 @@ curl -X POST http://localhost:3500/v1.0-alpha1/state/myStore/query \
   "token": "3"
 }
 ```
-To pass metadata as query parammeter:
-
-```
-POST http://localhost:3500/v1.0-alpha1/state/myStore/query?metadata.partitionKey=mypartitionKey
-```
 
 ## State transactions
 
@@ -450,6 +459,11 @@ Parameter | Description
 --------- | -----------
 daprPort | the Dapr port
 storename | ```metadata.name``` field in the user configured state store component yaml. Please refer Dapr State Store configuration structure mentioned above.
+
+The optional request metadata is passed via URL query parameters. For example,
+```
+POST http://localhost:3500/v1.0/state/myStore/transaction?metadata.contentType=application/json
+```
 
 > Note, all URL parameters are case-sensitive.
 


### PR DESCRIPTION

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added info on how to set content type in state store

## Issue reference

#2186 
