### PR TITLE
Add a missing back-tick

### DIFF
--- a/daprdocs/content/en/getting-started/configure-state-pubsub.md
+++ b/daprdocs/content/en/getting-started/configure-state-pubsub.md
@@ -138,7 +138,7 @@ If using a state store other than Redis, refer to the [supported state stores]({
 
 ### Create Pub/sub message broker component
 
-Create a file called redis-pubsub.yaml, and paste the following:
+Create a file called `redis-pubsub.yaml`, and paste the following:
 
 ```yaml
 apiVersion: dapr.io/v1alpha1


### PR DESCRIPTION
Adding a missing back-tick around the filename to match what's done in other spots in the file.

Signed-off-by: Doug Davis <dug@microsoft.com>