### PR TITLE
Add component references to AAD authentication

### DIFF
--- a/daprdocs/content/en/developing-applications/integrations/Azure/azure-kubernetes-service-extension.md
+++ b/daprdocs/content/en/developing-applications/integrations/Azure/azure-kubernetes-service-extension.md
@@ -86,4 +86,4 @@ Once the k8-extension finishes provisioning, you can confirm that the Dapr contr
 kubectl get pods -n dapr-system
 ```
 
-For further information such as configuration options and targeting specific versions of Dapr, please see the official [AKS Dapr Extension Docs](https://docs.microsoft.com/azure/aks/dapr).
+For further information such as configuration options and targeting specific versions of Dapr, see the official [AKS Dapr Extension Docs](https://docs.microsoft.com/azure/aks/dapr).

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/blobstorage.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/blobstorage.md
@@ -50,6 +50,8 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | getBlobRetryCount | N | Output | Specifies the maximum number of HTTP GET requests that will be made while reading from a RetryReader Defaults to `10` | `1`, `2`
 | publicAccessLevel | N | Output | Specifies whether data in the container may be accessed publicly and the level of access (only used if the container is created by Dapr). Defaults to `none` | `blob`, `container`, `none` 
 
+### Azure Active Directory (AAD) authentication
+The Azure Blob Storage binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
 
 ## Binding support
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/blobstorage.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/blobstorage.md
@@ -51,7 +51,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | publicAccessLevel | N | Output | Specifies whether data in the container may be accessed publicly and the level of access (only used if the container is created by Dapr). Defaults to `none` | `blob`, `container`, `none` 
 
 ### Azure Active Directory (AAD) authentication
-The Azure Blob Storage binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+The Azure Blob Storage binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
 
 ## Binding support
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cosmosdb.md
@@ -51,7 +51,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 For more information see [Azure Cosmos DB resource model](https://docs.microsoft.com/azure/cosmos-db/account-databases-containers-items).
 
 ### Azure Active Directory (AAD) authentication
-The Azure Cosmos DB binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+The Azure Cosmos DB binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
 
 ## Binding support
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cosmosdb.md
@@ -50,6 +50,9 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 For more information see [Azure Cosmos DB resource model](https://docs.microsoft.com/azure/cosmos-db/account-databases-containers-items).
 
+### Azure Active Directory (AAD) authentication
+The Azure Cosmos DB binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+
 ## Binding support
 
 This component supports **output binding** with the following operations:

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/servicebusqueues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/servicebusqueues.md
@@ -44,7 +44,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | ttlInSeconds | N | Output | Parameter to set the default message [time to live](https://docs.microsoft.com/azure/service-bus-messaging/message-expiration). If this parameter is omitted, messages will expire after 14 days. See [also](#specifying-a-ttl-per-message) | `"60"` |
 
 ### Azure Active Directory (AAD) authentication
-The Azure Service Bus Queues binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+The Azure Service Bus Queues binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
 
 ## Binding support
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/servicebusqueues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/servicebusqueues.md
@@ -43,6 +43,9 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | queueName | Y | Input/Output | The Service Bus queue name. Queue names are case-insensitive and will always be forced to lowercase. | `"queuename"` |
 | ttlInSeconds | N | Output | Parameter to set the default message [time to live](https://docs.microsoft.com/azure/service-bus-messaging/message-expiration). If this parameter is omitted, messages will expire after 14 days. See [also](#specifying-a-ttl-per-message) | `"60"` |
 
+### Azure Active Directory (AAD) authentication
+The Azure Service Bus Queues binding component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+
 ## Binding support
 
 This component supports both **input and output** binding interfaces.

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -66,7 +66,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | messageRetentionInDays | N | Number of days to retain messages for in the newly created event hub. Used only when entity management is enabled. Default: `"1"` | `"90"`
 
 ### Azure Active Directory (AAD) authentication
-The Azure Event Hubs pubsub component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+The Azure Event Hubs pubsub component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
 
 ## Create an Azure Event Hub
 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -65,6 +65,8 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | partitionCount | N | Number of partitions for the new event hub. Only used when entity management is enabled. Default: `"1"` | `"2"`
 | messageRetentionInDays | N | Number of days to retain messages for in the newly created event hub. Used only when entity management is enabled. Default: `"1"` | `"90"`
 
+### Azure Active Directory (AAD) authentication
+The Azure Event Hubs pubsub component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
 
 ## Create an Azure Event Hub
 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
@@ -84,6 +84,9 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | publishMaxRetries | N  | The max number of retries for when Azure Service Bus responds with "too busy" in order to throttle messages. Defaults: `5` | `5`
 | publishInitialRetryInternalInMs | N  | Time in milliseconds for the initial exponential backoff when Azure Service Bus throttle messages. Defaults: `500` | `500`
 
+### Azure Active Directory (AAD) authentication
+The Azure Service Bus pubsub component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+
 ## Message metadata
 
 Azure Service Bus messages extend the Dapr message format with additional contextual metadata. Some metadata fields are set by Azure Service Bus itself (read-only) and others can be set by the client when publishing a message.

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
@@ -85,7 +85,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | publishInitialRetryInternalInMs | N  | Time in milliseconds for the initial exponential backoff when Azure Service Bus throttle messages. Defaults: `500` | `500`
 
 ### Azure Active Directory (AAD) authentication
-The Azure Service Bus pubsub component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+The Azure Service Bus pubsub component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
 
 ## Message metadata
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
@@ -53,7 +53,7 @@ If you wish to use CosmosDb as an actor store, append the following to the yaml.
 | actorStateStore    | N         | Consider this state store for actors. Defaults to `"false"` | `"true"`, `"false"`
 
 ### Azure Active Directory (AAD) authentication
-The Azure Cosmos DB state store component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+The Azure Cosmos DB state store component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
 
 ## Setup Azure Cosmos DB
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
@@ -52,6 +52,9 @@ If you wish to use CosmosDb as an actor store, append the following to the yaml.
 | collection         | Y        | The name of the collection | `"collection"`
 | actorStateStore    | N         | Consider this state store for actors. Defaults to `"false"` | `"true"`, `"false"`
 
+### Azure Active Directory (AAD) authentication
+The Azure Cosmos DB state store component supports authentication using all Azure Active Directory mechanisms. For further information and the relevant component metadata fields to provide depending on the choice of AAD authentication mechanism, please see the [docs for authenticating to Azure]({{< ref authenticating-azure.md >}}).
+
 ## Setup Azure Cosmos DB
 
 [Follow the instructions](https://docs.microsoft.com/azure/cosmos-db/how-to-manage-database-account) from the Azure documentation on how to create an Azure CosmosDB account.  The database and collection must be created in CosmosDB before Dapr can use it.


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

Azure components supporting AAD authentication were lacking information about AAD support. This PR fixes that.