### PR TITLE
Remove sentence about a pict since pict isn't there

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/service-invocation-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/service-invocation-overview.md
@@ -45,7 +45,7 @@ Applications can be scoped to namespaces for deployment and security, and you ca
 
 ### Service-to-service security
 
-All calls between Dapr applications can be made secure with mutual (mTLS) authentication on hosted platforms, including automatic certificate rollover, via the Dapr Sentry service. The diagram below shows this for self hosted applications.
+All calls between Dapr applications can be made secure with mutual (mTLS) authentication on hosted platforms, including automatic certificate rollover, via the Dapr Sentry service.
 
 For more information read the [service-to-service security]({{< ref "security-concept.md#sidecar-to-sidecar-communication" >}}) article.
 


### PR DESCRIPTION
See #2229 for more info. Let me know if I should open this against v1.7 instead.

Fixes #2229

Signed-off-by: Doug Davis <dug@microsoft.com>