### PR TITLE
Remove dash in "dapr-init"

### DIFF
--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -3,7 +3,7 @@ type: docs
 title: "Initialize Dapr in your local environment"
 linkTitle: "Init Dapr locally"
 weight: 20
-description: "Fetch the Dapr sidecar binaries and install them locally using `dapr-init`"
+description: "Fetch the Dapr sidecar binaries and install them locally using `dapr init`"
 aliases:
   - /getting-started/set-up-dapr/install-dapr/
 ---


### PR DESCRIPTION
I'm guessing it's a typo because the md file has the dash. But the command
itself doesn't

Signed-off-by: Doug Davis <dug@microsoft.com>
