### PR TITLE
Minor tweaks to the service invocation quickstart

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
@@ -20,7 +20,7 @@ Select your preferred language-specific Dapr SDK before proceeding with the Quic
  <!-- Python -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -30,7 +30,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -38,7 +38,7 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Subscribe to topics
+### Step 3: Subscribe to topics
 
 In a terminal window, from the root of the Quickstarts clone directory
 navigate to the `order-processor` directory.
@@ -86,7 +86,7 @@ def orders_subscriber():
 app.run(port=5001)
 ```
 
-### Publish a topic
+### Step 4: Publish a topic
 
 In a new terminal window, navigate to the `checkout` directory.
 
@@ -119,7 +119,7 @@ with DaprClient() as client:
     )
 ```
 
-### View the Pub/sub outputs
+### Step 5: View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a random number to the Dapr sidecar while the subscriber receives it.
 
@@ -190,7 +190,7 @@ In the YAML file:
  <!-- JavaScript -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -200,7 +200,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -208,7 +208,7 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Subscribe to topics
+### Step 3: Subscribe to topics
 
 In a terminal window, from the root of the Quickstarts clone directory
 navigate to the `order-processor` directory.
@@ -240,7 +240,7 @@ In the `order-processor` subscriber, we're subscribing to the Redis instance cal
 server.pubsub.subscribe("order_pub_sub", "orders", (data) => console.log("Subscriber received: " + JSON.stringify(data)));
 ```
 
-### Publish a topic
+### Step 4: Publish a topic
 
 In a new terminal window, from the root of the Quickstarts clone directory,
 navigate to the `checkout` directory.
@@ -266,7 +266,7 @@ Run the `checkout` publisher service alongside a Dapr sidecar.
 dapr run --app-id checkout --app-protocol http --dapr-http-port 3500 --components-path ../../../components -- npm run start
 ```
 
-In the `checkout` publisher service, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:  
+In the `checkout` publisher service, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:
 
 ```js
 const client = new DaprClient(DAPR_HOST, DAPR_HTTP_PORT);
@@ -275,7 +275,7 @@ await client.pubsub.publish(PUBSUB_NAME, PUBSUB_TOPIC, order);
    console.log("Published data: " + JSON.stringify(order));
 ```
 
-### View the Pub/sub outputs
+### Step 5: View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a random number to the Dapr sidecar while the subscriber receives it.
 
@@ -348,7 +348,7 @@ In the YAML file:
  <!-- .NET -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -358,7 +358,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -366,7 +366,7 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Subscribe to topics
+### Step 3: Subscribe to topics
 
 In a terminal window, from the root of the Quickstarts clone directory
 navigate to the `order-processor` directory.
@@ -400,7 +400,7 @@ app.MapPost("/orders", [Topic("order_pub_sub", "orders")] (Order order) => {
 public record Order([property: JsonPropertyName("orderId")] int OrderId);
 ```
 
-### Publish a topic
+### Step 4: Publish a topic
 
 In a new terminal window, from the root of the Quickstarts clone directory,
 navigate to the `checkout` directory.
@@ -430,7 +430,7 @@ await client.PublishEventAsync("order_pub_sub", "orders", order);
 Console.WriteLine("Published data: " + order);
 ```
 
-### View the Pub/sub outputs
+### Step 5: View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a random number to the Dapr sidecar while the subscriber receives it.
 
@@ -501,7 +501,7 @@ In the YAML file:
  <!-- Java -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -514,7 +514,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -522,7 +522,7 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Subscribe to topics
+### Step 3: Subscribe to topics
 
 In a terminal window, from the root of the Quickstarts clone directory
 navigate to the `order-processor` directory.
@@ -560,7 +560,7 @@ public Mono<ResponseEntity> getCheckout(@RequestBody(required = false) CloudEven
 }
 ```
 
-### Publish a topic
+### Step 4: Publish a topic
 
 In a new terminal window, from the root of the Quickstarts clone directory,
 navigate to the `checkout` directory.
@@ -592,7 +592,7 @@ client.publishEvent(
 logger.info("Published data: " + order.getOrderId());
 ```
 
-### View the Pub/sub outputs
+### Step 5: View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a random number to the Dapr sidecar while the subscriber receives it.
 
@@ -666,7 +666,7 @@ In the YAML file:
  <!-- Go -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -676,7 +676,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -684,7 +684,7 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Subscribe to topics
+### Step 3: Subscribe to topics
 
 In a terminal window, from the root of the Quickstarts clone directory
 navigate to the `order-processor` directory.
@@ -714,7 +714,7 @@ func eventHandler(ctx context.Context, e *common.TopicEvent) (retry bool, err er
 }
 ```
 
-### Publish a topic
+### Step 4: Publish a topic
 
 In a new terminal window, from the root of the Quickstarts clone directory,
 navigate to the `checkout` directory.
@@ -747,7 +747,7 @@ if err := client.PublishEvent(ctx, PUBSUB_NAME, PUBSUB_TOPIC, []byte(order)); er
 fmt.Sprintf("Published data: ", order)
 ```
 
-### View the Pub/sub outputs
+### Step 5: View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a numbered message to the Dapr sidecar while the subscriber receives it.
 

--- a/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
@@ -30,7 +30,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -38,42 +38,9 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Step 2: Publish a topic
+### Subscribe to topics
 
-In a terminal window, navigate to the `checkout` directory.
-
-```bash
-cd pub_sub/python/sdk/checkout
-```
-
-Install the dependencies:
-
-```bash
-pip3 install -r requirements.txt
-```
-
-Run the `checkout` publisher service alongside a Dapr sidecar.
-
-```bash
-dapr run --app-id checkout --components-path ../../../components/ -- python3 app.py
-```
-
-In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:
-
-```python
-with DaprClient() as client:
-    # Publish an event/message using Dapr PubSub
-    result = client.publish_event(
-        pubsub_name='order_pub_sub',
-        topic_name='orders',
-        data=json.dumps(order),
-        data_content_type='application/json',
-    )
-```
-
-### Step 3: Subscribe to topics
-
-In a new terminal window, from the root of the Quickstarts clone directory,
+In a terminal window, from the root of the Quickstarts clone directory
 navigate to the `order-processor` directory.
 
 ```bash
@@ -119,7 +86,40 @@ def orders_subscriber():
 app.run(port=5001)
 ```
 
-### Step 4: View the Pub/sub outputs
+### Publish a topic
+
+In a new terminal window, navigate to the `checkout` directory.
+
+```bash
+cd pub_sub/python/sdk/checkout
+```
+
+Install the dependencies:
+
+```bash
+pip3 install -r requirements.txt
+```
+
+Run the `checkout` publisher service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-id checkout --components-path ../../../components/ -- python3 app.py
+```
+
+In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:
+
+```python
+with DaprClient() as client:
+    # Publish an event/message using Dapr PubSub
+    result = client.publish_event(
+        pubsub_name='order_pub_sub',
+        topic_name='orders',
+        data=json.dumps(order),
+        data_content_type='application/json',
+    )
+```
+
+### View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a random number to the Dapr sidecar while the subscriber receives it.
 
@@ -200,7 +200,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -208,9 +208,42 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Step 2: Publish a topic
+### Subscribe to topics
 
-In a terminal window, navigate to the `checkout` directory.
+In a terminal window, from the root of the Quickstarts clone directory
+navigate to the `order-processor` directory.
+
+```bash
+cd pub_sub/javascript/sdk/order-processor
+```
+
+Install dependencies, which will include the `dapr-client` package from the JavaScript SDK:
+
+```bash
+npm install
+```
+
+Verify you have the following files included in the service directory:
+
+- `package.json`
+- `package-lock.json`
+
+Run the `order-processor` subscriber service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-port 5001 --app-id order-processing --app-protocol http --dapr-http-port 3501 --components-path ../../../components -- npm run start
+```
+
+In the `order-processor` subscriber, we're subscribing to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. This enables your app code to talk to the Redis component instance through the Dapr sidecar.
+
+```js
+server.pubsub.subscribe("order_pub_sub", "orders", (data) => console.log("Subscriber received: " + JSON.stringify(data)));
+```
+
+### Publish a topic
+
+In a new terminal window, from the root of the Quickstarts clone directory,
+navigate to the `checkout` directory.
 
 ```bash
 cd pub_sub/javascript/sdk/checkout
@@ -242,39 +275,7 @@ await client.pubsub.publish(PUBSUB_NAME, PUBSUB_TOPIC, order);
    console.log("Published data: " + JSON.stringify(order));
 ```
 
-### Step 3: Subscribe to topics
-
-In a new terminal window, from the root of the Quickstarts clone directory,
-navigate to the `order-processor` directory.
-
-```bash
-cd pub_sub/javascript/sdk/order-processor
-```
-
-Install dependencies, which will include the `dapr-client` package from the JavaScript SDK:
-
-```bash
-npm install
-```
-
-Verify you have the following files included in the service directory:
-
-- `package.json`
-- `package-lock.json`
-
-Run the `order-processor` subscriber service alongside a Dapr sidecar.
-
-```bash
-dapr run --app-port 5001 --app-id order-processing --app-protocol http --dapr-http-port 3501 --components-path ../../../components -- npm run start
-```
-
-In the `order-processor` subscriber, we're subscribing to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. This enables your app code to talk to the Redis component instance through the Dapr sidecar.
-
-```js
-server.pubsub.subscribe("order_pub_sub", "orders", (data) => console.log("Subscriber received: " + JSON.stringify(data)));
-```
-
-### Step 4: View the Pub/sub outputs
+### View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a random number to the Dapr sidecar while the subscriber receives it.
 
@@ -357,7 +358,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -365,38 +366,9 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Step 2: Publish a topic
+### Subscribe to topics
 
-In a terminal window, navigate to the `checkout` directory.
-
-```bash
-cd pub_sub/csharp/sdk/checkout
-```
-
-Recall NuGet packages:
-
-```bash
-dotnet restore
-dotnet build
-```
-
-Run the `checkout` publisher service alongside a Dapr sidecar.
-
-```bash
-dapr run --app-id checkout --components-path ../../../components -- dotnet run
-```
-
-In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:
-
-```cs
-using var client = new DaprClientBuilder().Build();
-await client.PublishEventAsync("order_pub_sub", "orders", order);
-Console.WriteLine("Published data: " + order);
-```
-
-### Step 3: Subscribe to topics
-
-In a new terminal window, from the root of the Quickstarts clone directory,
+In a terminal window, from the root of the Quickstarts clone directory
 navigate to the `order-processor` directory.
 
 ```bash
@@ -428,7 +400,37 @@ app.MapPost("/orders", [Topic("order_pub_sub", "orders")] (Order order) => {
 public record Order([property: JsonPropertyName("orderId")] int OrderId);
 ```
 
-### Step 4: View the Pub/sub outputs
+### Publish a topic
+
+In a new terminal window, from the root of the Quickstarts clone directory,
+navigate to the `checkout` directory.
+
+```bash
+cd pub_sub/csharp/sdk/checkout
+```
+
+Recall NuGet packages:
+
+```bash
+dotnet restore
+dotnet build
+```
+
+Run the `checkout` publisher service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-id checkout --components-path ../../../components -- dotnet run
+```
+
+In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:
+
+```cs
+using var client = new DaprClientBuilder().Build();
+await client.PublishEventAsync("order_pub_sub", "orders", order);
+Console.WriteLine("Published data: " + order);
+```
+
+### View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a random number to the Dapr sidecar while the subscriber receives it.
 
@@ -512,7 +514,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -520,40 +522,9 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Step 2: Publish a topic
+### Subscribe to topics
 
-In a terminal window, navigate to the `checkout` directory.
-
-```bash
-cd pub_sub/java/sdk/checkout
-```
-
-Install the dependencies:
-
-```bash
-mvn clean install
-```
-
-Run the `checkout` publisher service alongside a Dapr sidecar.
-
-```bash
-dapr run --app-id checkout --components-path ../../../components -- java -jar target/CheckoutService-0.0.1-SNAPSHOT.jar
-```
-
-In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:
-
-```java
-DaprClient client = new DaprClientBuilder().build();
-client.publishEvent(
-		PUBSUB_NAME,
-		TOPIC_NAME,
-		order).block();
-logger.info("Published data: " + order.getOrderId());
-```
-
-### Step 3: Subscribe to topics
-
-In a new terminal window, from the root of the Quickstarts clone directory,
+In a terminal window, from the root of the Quickstarts clone directory
 navigate to the `order-processor` directory.
 
 ```bash
@@ -589,7 +560,39 @@ public Mono<ResponseEntity> getCheckout(@RequestBody(required = false) CloudEven
 }
 ```
 
-### Step 4: View the Pub/sub outputs
+### Publish a topic
+
+In a new terminal window, from the root of the Quickstarts clone directory,
+navigate to the `checkout` directory.
+
+```bash
+cd pub_sub/java/sdk/checkout
+```
+
+Install the dependencies:
+
+```bash
+mvn clean install
+```
+
+Run the `checkout` publisher service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-id checkout --components-path ../../../components -- java -jar target/CheckoutService-0.0.1-SNAPSHOT.jar
+```
+
+In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:
+
+```java
+DaprClient client = new DaprClientBuilder().build();
+client.publishEvent(
+		PUBSUB_NAME,
+		TOPIC_NAME,
+		order).block();
+logger.info("Published data: " + order.getOrderId());
+```
+
+### View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a random number to the Dapr sidecar while the subscriber receives it.
 
@@ -673,7 +676,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/pub_sub).
 
@@ -681,9 +684,40 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Step 2: Publish a topic
+### Subscribe to topics
 
-In a terminal window, navigate to the `checkout` directory.
+In a terminal window, from the root of the Quickstarts clone directory
+navigate to the `order-processor` directory.
+
+```bash
+cd pub_sub/go/sdk/order-processor
+```
+
+Install the dependencies and build the application:
+
+```bash
+go build app.go
+```
+
+Run the `order-processor` subscriber service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-port 6001 --app-id order-processor --app-protocol http --dapr-http-port 3501 --components-path ../../../components -- go run app.go
+```
+
+In the `order-processor` subscriber, we're subscribing to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. This enables your app code to talk to the Redis component instance through the Dapr sidecar.
+
+```go
+func eventHandler(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
+	fmt.Println("Subscriber received: ", e.Data)
+	return false, nil
+}
+```
+
+### Publish a topic
+
+In a new terminal window, from the root of the Quickstarts clone directory,
+navigate to the `checkout` directory.
 
 ```bash
 cd pub_sub/go/sdk/checkout
@@ -713,37 +747,7 @@ if err := client.PublishEvent(ctx, PUBSUB_NAME, PUBSUB_TOPIC, []byte(order)); er
 fmt.Sprintf("Published data: ", order)
 ```
 
-### Step 3: Subscribe to topics
-
-In a new terminal window, from the root of the Quickstart clone directory,
-navigate to the `order-processor` directory.
-
-```bash
-cd pub_sub/go/sdk/order-processor
-```
-
-Install the dependencies and build the application:
-
-```bash
-go build app.go
-```
-
-Run the `order-processor` subscriber service alongside a Dapr sidecar.
-
-```bash
-dapr run --app-port 6001 --app-id order-processor --app-protocol http --dapr-http-port 3501 --components-path ../../../components -- go run app.go
-```
-
-In the `order-processor` subscriber, we're subscribing to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. This enables your app code to talk to the Redis component instance through the Dapr sidecar.
-
-```go
-func eventHandler(ctx context.Context, e *common.TopicEvent) (retry bool, err error) {
-	fmt.Println("Subscriber received: ", e.Data)
-	return false, nil
-}
-```
-
-### Step 4: View the Pub/sub outputs
+### View the Pub/sub outputs
 
 Notice, as specified in the code above, the publisher pushes a numbered message to the Dapr sidecar while the subscriber receives it.
 

--- a/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
@@ -20,7 +20,7 @@ Select your preferred language before proceeding with the Quickstart.
  <!-- Python -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -30,7 +30,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -38,9 +38,9 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Run `order-processor` service
+### Step 3: Run `order-processor` service
 
-In a terminal window, from the root of the quickstart clone directory
+In a terminal window, from the root of the Quickstart clone directory
 navigate to `order-processor` directory.
 
 ```bash
@@ -71,9 +71,9 @@ def getOrder():
 app.run(port=7001)
 ```
 
-### Run `checkout` service
+### Step 4: Run `checkout` service
 
-In a new terminal window, from the root of the quickstart clone directory
+In a new terminal window, from the root of the Quickstart clone directory
 navigate to the `checkout` directory.
 
 ```bash
@@ -103,7 +103,7 @@ result = requests.post(
     headers=headers
 )
 ```
-### View the Service Invocation outputs
+### Step 5: View the Service Invocation outputs
 
 Dapr invokes an application on any Dapr instance. In the code, the sidecar programming model encourages each application to talk to its own instance of Dapr. The Dapr instances then discover and communicate with one another.
 
@@ -142,7 +142,7 @@ Dapr invokes an application on any Dapr instance. In the code, the sidecar progr
  <!-- JavaScript -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -152,7 +152,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -160,9 +160,9 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Run `order-processor` service
+### Step 3: Run `order-processor` service
 
-In a terminal window, from the root of the quickstart clone directory
+In a terminal window, from the root of the Quickstart clone directory
 navigate to `order-processor` directory.
 
 ```bash
@@ -188,9 +188,9 @@ app.post('/orders', (req, res) => {
 });
 ```
 
-### Run `checkout` service
+### Step 4: Run `checkout` service
 
-In a new terminal window, from the root of the quickstart clone directory
+In a new terminal window, from the root of the Quickstart clone directory
 navigate to the `checkout` directory.
 
 ```bash
@@ -221,7 +221,7 @@ let axiosConfig = {
   console.log("Order passed: " + res.config.data);
 ```
 
-### View the Service Invocation outputs
+### Step 5: View the Service Invocation outputs
 
 Dapr invokes an application on any Dapr instance. In the code, the sidecar programming model encourages each application to talk to its own instance of Dapr. The Dapr instances then discover and communicate with one another.
 
@@ -260,7 +260,7 @@ Dapr invokes an application on any Dapr instance. In the code, the sidecar progr
  <!-- .NET -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -270,7 +270,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -278,9 +278,9 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Run `order-processor` service
+### Step 3: Run `order-processor` service
 
-In a terminal window, from the root of the quickstart clone directory
+In a terminal window, from the root of the Quickstart clone directory
 navigate to `order-processor` directory.
 
 ```bash
@@ -308,9 +308,9 @@ app.MapPost("/orders", async context => {
 });
 ```
 
-### Run `checkout` service
+### Step 4: Run `checkout` service
 
-In a new terminal window, from the root of the quickstart clone directory
+In a new terminal window, from the root of the Quickstart clone directory
 navigate to the `checkout` directory.
 
 ```bash
@@ -342,7 +342,7 @@ var response = await client.PostAsync($"{baseURL}/orders", content);
     Console.WriteLine("Order passed: " + order);
 ```
 
-### View the Service Invocation outputs
+### Step 5: View the Service Invocation outputs
 
 Dapr invokes an application on any Dapr instance. In the code, the sidecar programming model encourages each application to talk to its own instance of Dapr. The Dapr instances then discover and communicate with one another.
 
@@ -381,7 +381,7 @@ Dapr invokes an application on any Dapr instance. In the code, the sidecar progr
  <!-- Java -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -394,7 +394,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -402,9 +402,9 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Run `order-processor` service
+### Step 3: Run `order-processor` service
 
-In a terminal window, from the root of the quickstart clone directory
+In a terminal window, from the root of the Quickstart clone directory
 navigate to `order-processor` directory.
 
 ```bash
@@ -430,9 +430,9 @@ public String processOrders(@RequestBody Order body) {
     }
 ```
 
-### Run `checkout` service
+### Step 4: Run `checkout` service
 
-In a new terminal window, from the root of the quickstart clone directory
+In a new terminal window, from the root of the Quickstart clone directory
 navigate to the `checkout` directory.
 
 ```bash
@@ -461,7 +461,7 @@ HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandle
 System.out.println("Order passed: "+ orderId)
 ```
 
-### View the Service Invocation outputs
+### Step 5: View the Service Invocation outputs
 
 Dapr invokes an application on any Dapr instance. In the code, the sidecar programming model encourages each application to talk to its own instance of Dapr. The Dapr instances then discover and communicate with one another.
 
@@ -500,7 +500,7 @@ Dapr invokes an application on any Dapr instance. In the code, the sidecar progr
  <!-- Go -->
 {{% codetab %}}
 
-### Pre-requisites
+### Step 1: Pre-requisites
 
 For this example, you will need:
 
@@ -510,7 +510,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Set up the environment
+### Step 2: Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -519,9 +519,9 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Run `order-processor` service
+### Step 3: Run `order-processor` service
 
-In a terminal window, from the root of the quickstart clone directory
+In a terminal window, from the root of the Quickstart clone directory
 navigate to `order-processor` directory.
 
 ```bash
@@ -552,9 +552,9 @@ func getOrder(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Order received : %s", string(data))
 ```
 
-### Run `checkout` service
+### Step 4: Run `checkout` service
 
-In a new terminal window, from the root of the quickstart clone directory
+In a new terminal window, from the root of the Quickstart clone directory
 navigate to the `checkout` directory.
 
 ```bash
@@ -581,7 +581,7 @@ req.Header.Add("dapr-app-id", "order-processor")
 response, err := client.Do(req)
 ```
 
-### View the Service Invocation outputs
+### Step 5: View the Service Invocation outputs
 
 Dapr invokes an application on any Dapr instance. In the code, the sidecar programming model encourages each application to talk to its own instance of Dapr. The Dapr instances then discover and communicate with one another.
 

--- a/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
@@ -38,47 +38,16 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Run `checkout` service
-
-In a terminal window, navigate to the `checkout` directory.
-
-```bash
-cd service_invocation/python/http/checkout
-```
-
-Install the dependencies:
-
-```bash
-pip3 install -r requirements.txt 
-```
-
-Run the `checkout` service alongside a Dapr sidecar.
-
-```bash
-dapr run  --app-id checkout --app-protocol http --dapr-http-port 3500 -- python3 app.py
-```
-
-In the `checkout` service, you'll notice there's no need to rewrite your app code to use Dapr's service invocation. You can enable service invocation by simply adding the `dapr-app-id` header, which specifies the ID of the target service.
-
-```python
-headers = {'dapr-app-id': 'order-processor'}
-
-result = requests.post(
-    url='%s/orders' % (base_url),
-    data=json.dumps(order),
-    headers=headers
-)
-```
-
 ### Run `order-processor` service
 
-In a new terminal window, navigate to `order-processor` directory.
+In a terminal window, from the root of the quickstart clone directory
+navigate to `order-processor` directory.
 
 ```bash
 cd service_invocation/python/http/order-processor
 ```
 
-Install the dependencies:
+Install the dependencies and build the application:
 
 ```bash
 pip3 install -r requirements.txt 
@@ -102,6 +71,38 @@ def getOrder():
 app.run(port=7001)
 ```
 
+### Run `checkout` service
+
+In a new terminal window, from the root of the quickstart clone directory
+navigate to the `checkout` directory.
+
+```bash
+cd service_invocation/python/http/checkout
+```
+
+Install the dependencies and build the application:
+
+```bash
+pip3 install -r requirements.txt 
+```
+
+Run the `checkout` service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-id checkout --app-protocol http --dapr-http-port 3500 -- python3 app.py
+```
+
+In the `checkout` service, you'll notice there's no need to rewrite your app code to use Dapr's service invocation. You can enable service invocation by simply adding the `dapr-app-id` header, which specifies the ID of the target service.
+
+```python
+headers = {'dapr-app-id': 'order-processor'}
+
+result = requests.post(
+    url='%s/orders' % (base_url),
+    data=json.dumps(order),
+    headers=headers
+)
+```
 ### View the Service Invocation outputs
 
 Dapr invokes an application on any Dapr instance. In the code, the sidecar programming model encourages each application to talk to its own instance of Dapr. The Dapr instances then discover and communicate with one another.
@@ -159,41 +160,10 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Run `checkout` service
-
-In a terminal window, navigate to the `checkout` directory.
-
-```bash
-cd service_invocation/javascript/http/checkout
-```
-
-Install the dependencies:
-
-```bash
-npm install
-```
-
-Run the `checkout` service alongside a Dapr sidecar.
-
-```bash
-dapr run  --app-id checkout --app-protocol http --dapr-http-port 3500 -- npm start
-```
-
-In the `checkout` service, you'll notice there's no need to rewrite your app code to use Dapr's service invocation. You can enable service invocation by simply adding the `dapr-app-id` header, which specifies the ID of the target service.
-
-```javascript
-let axiosConfig = {
-  headers: {
-      "dapr-app-id": "order-processor"
-  }
-};
-  const res = await axios.post(`${DAPR_HOST}:${DAPR_HTTP_PORT}/orders`, order , axiosConfig);
-  console.log("Order passed: " + res.config.data);
-```
-
 ### Run `order-processor` service
 
-In a new terminal window, navigate to `order-processor` directory.
+In a terminal window, from the root of the quickstart clone directory
+navigate to `order-processor` directory.
 
 ```bash
 cd service_invocation/javascript/http/order-processor
@@ -208,7 +178,7 @@ npm install
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-port 5001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- npm start
+dapr run --app-port 6001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- npm start
 ```
 
 ```javascript
@@ -216,6 +186,39 @@ app.post('/orders', (req, res) => {
     console.log("Order received:", req.body);
     res.sendStatus(200);
 });
+```
+
+### Run `checkout` service
+
+In a new terminal window, from the root of the quickstart clone directory
+navigate to the `checkout` directory.
+
+```bash
+cd service_invocation/javascript/http/checkout
+```
+
+Install the dependencies:
+
+```bash
+npm install
+```
+
+Run the `checkout` service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-id checkout --app-protocol http --dapr-http-port 3500 -- npm start
+```
+
+In the `checkout` service, you'll notice there's no need to rewrite your app code to use Dapr's service invocation. You can enable service invocation by simply adding the `dapr-app-id` header, which specifies the ID of the target service.
+
+```javascript
+let axiosConfig = {
+  headers: {
+      "dapr-app-id": "order-processor"
+  }
+};
+  const res = await axios.post(`${DAPR_HOST}:${DAPR_HTTP_PORT}/orders`, order , axiosConfig);
+  console.log("Order passed: " + res.config.data);
 ```
 
 ### View the Service Invocation outputs
@@ -275,9 +278,40 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
+### Run `order-processor` service
+
+In a terminal window, from the root of the quickstart clone directory
+navigate to `order-processor` directory.
+
+```bash
+cd service_invocation/csharp/http/order-processor
+```
+
+Install the dependencies:
+
+```bash
+dotnet restore
+dotnet build
+```
+
+Run the `order-processor` service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-port 7001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- dotnet run
+```
+
+```csharp
+app.MapPost("/orders", async context => {
+    var data = await context.Request.ReadFromJsonAsync<Order>();
+    Console.WriteLine("Order received : " + data);
+    await context.Response.WriteAsync(data.ToString());
+});
+```
+
 ### Run `checkout` service
 
-In a terminal window, navigate to the `checkout` directory.
+In a new terminal window, from the root of the quickstart clone directory
+navigate to the `checkout` directory.
 
 ```bash
 cd service_invocation/csharp/http/checkout
@@ -306,35 +340,6 @@ client.DefaultRequestHeaders.Add("dapr-app-id", "order-processor");
 
 var response = await client.PostAsync($"{baseURL}/orders", content);
     Console.WriteLine("Order passed: " + order);
-```
-
-### Run `order-processor` service
-
-In a new terminal window, navigate to `order-processor` directory.
-
-```bash
-cd service_invocation/csharp/http/order-processor
-```
-
-Install the dependencies:
-
-```bash
-dotnet restore
-dotnet build
-```
-
-Run the `order-processor` service alongside a Dapr sidecar.
-
-```bash
-dapr run --app-port 7001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- dotnet run
-```
-
-```csharp
-app.MapPost("/orders", async context => {
-    var data = await context.Request.ReadFromJsonAsync<Order>();
-    Console.WriteLine("Order received : " + data);
-    await context.Response.WriteAsync(data.ToString());
-});
 ```
 
 ### View the Service Invocation outputs
@@ -397,9 +402,38 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
+### Run `order-processor` service
+
+In a terminal window, from the root of the quickstart clone directory
+navigate to `order-processor` directory.
+
+```bash
+cd service_invocation/java/http/order-processor
+```
+
+Install the dependencies:
+
+```bash
+mvn clean install
+```
+
+Run the `order-processor` service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-id order-processor --app-port 6001 --app-protocol http --dapr-http-port 3501 -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
+```
+
+```java
+public String processOrders(@RequestBody Order body) {
+        System.out.println("Order received: "+ body.getOrderId());
+        return "CID" + body.getOrderId();
+    }
+```
+
 ### Run `checkout` service
 
-In a terminal window, navigate to the `checkout` directory.
+In a new terminal window, from the root of the quickstart clone directory
+navigate to the `checkout` directory.
 
 ```bash
 cd service_invocation/java/http/checkout
@@ -425,33 +459,6 @@ In the `checkout` service, you'll notice there's no need to rewrite your app cod
 
 HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 System.out.println("Order passed: "+ orderId)
-```
-
-### Run `order-processor` service
-
-In a new terminal window, navigate to `order-processor` directory.
-
-```bash
-cd service_invocation/java/http/order-processor
-```
-
-Install the dependencies:
-
-```bash
-mvn clean install
-```
-
-Run the `order-processor` service alongside a Dapr sidecar.
-
-```bash
-dapr run --app-id order-processor --app-port 6001 --app-protocol http --dapr-http-port 3501 -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
-```
-
-```java
-public String processOrders(@RequestBody Order body) {
-        System.out.println("Order received: "+ body.getOrderId());
-        return "CID" + body.getOrderId();
-    }
 ```
 
 ### View the Service Invocation outputs
@@ -512,49 +519,10 @@ Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quic
 git clone https://github.com/dapr/quickstarts.git
 ```
 
-### Run `checkout` service
-
-In a terminal window, navigate to the `checkout` directory.
-
-```bash
-cd service_invocation/go/http/checkout
-```
-
-Install the dependencies:
-
-```bash
-go build app.go
-```
-
-Run the `checkout` service alongside a Dapr sidecar.
-
-```bash
-dapr run  --app-id checkout --app-protocol http --dapr-http-port 3500 -- go run app.go
-```
-
-In the `checkout` service, you'll notice there's no need to rewrite your app code to use Dapr's service invocation. You can enable service invocation by simply adding the `dapr-app-id` header, which specifies the ID of the target service.
-
-```go
-req.Header.Add("dapr-app-id", "order-processor")
-
-response, err := client.Do(req)
-
-if err != nil {
-			fmt.Print(err.Error())
-			os.Exit(1)
-		}
-
-		result, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		log.Println("Order passed: ", string(result))
-```
-
 ### Run `order-processor` service
 
-In a new terminal window, navigate to `order-processor` directory.
+In a terminal window, from the root of the quickstart clone directory
+navigate to `order-processor` directory.
 
 ```bash
 cd service_invocation/go/http/order-processor
@@ -569,8 +537,11 @@ go build app.go
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-port 6001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- go run app.go
+dapr run --app-port 5001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- go run app.go
 ```
+
+Each order is received via an HTTP POST request and processed by the
+`getOrder` function.
 
 ```go
 func getOrder(w http.ResponseWriter, r *http.Request) {
@@ -581,6 +552,35 @@ func getOrder(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Order received : %s", string(data))
 ```
 
+### Run `checkout` service
+
+In a new terminal window, from the root of the quickstart clone directory
+navigate to the `checkout` directory.
+
+```bash
+cd service_invocation/go/http/checkout
+```
+
+Install the dependencies:
+
+```bash
+go build app.go
+```
+
+Run the `checkout` service alongside a Dapr sidecar.
+
+```bash
+dapr run --app-id checkout --app-protocol http --dapr-http-port 3500 -- go run app.go
+```
+
+In the `checkout` service, you'll notice there's no need to rewrite your app code to use Dapr's service invocation. You can enable service invocation by simply adding the `dapr-app-id` header, which specifies the ID of the target service.
+
+```go
+req.Header.Add("dapr-app-id", "order-processor")
+
+response, err := client.Do(req)
+```
+
 ### View the Service Invocation outputs
 
 Dapr invokes an application on any Dapr instance. In the code, the sidecar programming model encourages each application to talk to its own instance of Dapr. The Dapr instances then discover and communicate with one another.
@@ -588,16 +588,16 @@ Dapr invokes an application on any Dapr instance. In the code, the sidecar progr
 `checkout` service output:
 
 ```
-== APP == Order passed:  "{\"orderId\":1}"
-== APP == Order passed:  "{\"orderId\":2}"
-== APP == Order passed:  "{\"orderId\":3}"
-== APP == Order passed:  "{\"orderId\":4}"
-== APP == Order passed:  "{\"orderId\":5}"
-== APP == Order passed:  "{\"orderId\":6}"
-== APP == Order passed:  "{\"orderId\":7}"
-== APP == Order passed:  "{\"orderId\":8}"
-== APP == Order passed:  "{\"orderId\":9}"
-== APP == Order passed:  "{\"orderId\":10}"
+== APP == Order passed:  {"orderId":1}
+== APP == Order passed:  {"orderId":2}
+== APP == Order passed:  {"orderId":3}
+== APP == Order passed:  {"orderId":4}
+== APP == Order passed:  {"orderId":5}
+== APP == Order passed:  {"orderId":6}
+== APP == Order passed:  {"orderId":7}
+== APP == Order passed:  {"orderId":8}
+== APP == Order passed:  {"orderId":9}
+== APP == Order passed:  {"orderId":10}
 ```
 
 `order-processor` service output:

--- a/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
@@ -30,7 +30,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -152,7 +152,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -270,7 +270,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -394,7 +394,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 
@@ -510,7 +510,7 @@ For this example, you will need:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 <!-- END_IGNORE -->
 
-### Step 1: Set up the environment
+### Set up the environment
 
 Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/service_invocation).
 


### PR DESCRIPTION
Minor tweaks to the service invocation quickstart
- run the consumer before the sender, otherwise things will fail
- be clear about where to run the 'cd' cmd from
- in the golang sender sample code I removed the extra "if" statement
  because it wasn't relevant to the point being made... adding a header
- remove quotes from sender's json output to go along with
  https://github.com/dapr/quickstarts/pull/621
- ~~remove "Step" from the "###" headers~~
- reordered the pub-sub sample too so we start-up the receiver first

Signed-off-by: Doug Davis <dug@microsoft.com>
