### PR TITLE
fix: Getting started / Init Dapr locally has wrong quickstarts link

### DIFF
--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -125,5 +125,5 @@ explorer "%USERPROFILE%\.dapr\"
 
 <br>
 
-{{< button text="Next step: Use the Dapr API >>" "getting-started/get-started-api.md" >}}
+{{< button text="Next step: Use the Dapr API >>" page="getting-started/get-started-api.md" >}}
 

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -125,4 +125,4 @@ explorer "%USERPROFILE%\.dapr\"
 
 <br>
 
-{{< button text="Next step: Try Dapr quickstarts >>" page="getting-started/_index.md" >}}
+{{< button text="Next step: Try Dapr quickstarts >>" page="getting-started/quickstarts" >}}

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -125,4 +125,4 @@ explorer "%USERPROFILE%\.dapr\"
 
 <br>
 
-{{< button text="Next step: Try Dapr quickstarts >>" page="getting-started/quickstarts" >}}
+{{< button text="Next step: Use the Dapr API >>" "getting-started/get-started-api.md" >}}


### PR DESCRIPTION
Signed-off-by: Yauri <me@yauri.io>

## Description

“Try Dapr quickstarts"  link in this [page](https://docs.dapr.io/getting-started/install-dapr-selfhost/)  goes back to first page of [Getting started](https://docs.dapr.io/getting-started/).
This PR change the incorrect link to [Dapr Quickstarts](https://docs.dapr.io/getting-started/quickstarts/)

## Issue reference
<img width="905" alt="Screen Shot 2022-03-23 at 12 42 52 PM" src="https://user-images.githubusercontent.com/30032724/159627977-3468f7a4-e23a-4ffe-87be-e8704b641959.png">

