### PR TITLE
Add mandatory `dapr init` step to Self-Hosted Mode in Container Docs

### DIFF
--- a/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
+++ b/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
@@ -67,6 +67,7 @@ RUN wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
 ARG DAPR_BUILD_DIR
 COPY $DAPR_BUILD_DIR /opt/dapr
 ENV PATH="/opt/dapr/:${PATH}"
+RUN dapr init --slim
 
 # Install your app
 WORKDIR /app


### PR DESCRIPTION
I followed the docs to ship Dapr together with an app inside the same container and came across the issue that `daprd` in the `ENTRYPOINT` was not available until i initialized dapr in slim mode.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
