### PR TITLE
Fixes state-store-ttl Python example

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-raw.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-raw.md
@@ -48,7 +48,7 @@ with DaprClient() as d:
     # Create a typed message with content type and body
     resp = d.publish_event(
         pubsub_name='pubsub',
-        topic='TOPIC_A',
+        topic_name='TOPIC_A',
         data=json.dumps(req_data),
         publish_metadata={'rawPayload': 'true'}
     )

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
@@ -46,7 +46,7 @@ DAPR_STORE_NAME = "statestore"
 
 with DaprClient() as client:
         client.save_state(DAPR_STORE_NAME, "order_1", str(orderId), metadata=(
-            ('ttlInSeconds', '120')
+            ('ttlInSeconds', '120'),
         )) 
 
 ```


### PR DESCRIPTION
Add comma so the metadata value is a tuple of tuple, otherwise Python collapses it to just being an ordinary tuple.

All renamed `pubsub` to `pubsub_name` in another sample

Fixes #1803