### PR TITLE
concurrency mode

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-aws-snssqs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-aws-snssqs.md
@@ -82,7 +82,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | disableEntityManagement | N  | When set to true, SNS topics, SQS queues and the SQS subscriptions to SNS do not get created automatically. Default: `"false"` | `"true"`, `"false"`
 | disableDeleteOnRetryLimit | N  | When set to true, after retrying and failing of `messageRetryLimit` times processing a message, reset the message visibility timeout so that other consumers can try processing, instead of deleting the message from SQS (the default behvior). Default: `"false"` | `"true"`, `"false"`
 | assetsManagementTimeoutSeconds | N  | Amount of time in seconds, for an AWS asset management operation, before it times out and cancelled. Asset management operations are any operations performed on STS, SNS and SQS, except message publish and consume operations that implement the default Dapr component retry behavior. The value can be set to any non-negative float/integer. Default: `5` | `0.5`, `10`
-| concurrencyMode | N  | When a bulk of messages is pulled from SQS, call the subscriber sequencially (“single” message at a time), or concurrently (in “parallel”). Default: `"parallel"` | `"single"`, `"parallel"`
+| concurrencyMode | N  | When messages are received in bulk from SQS, call the subscriber sequentially (“single” message at a time), or concurrently (in “parallel”). Default: `"parallel"` | `"single"`, `"parallel"`
 
 
 * Dapr created SNS topic and SQS queue names conform with [AWS specifications](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html). By default, Dapr creates an SQS queue name based on the consumer `app-id`, therefore Dapr might perform name standardization to meet with AWS specifications.

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-aws-snssqs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-aws-snssqs.md
@@ -52,7 +52,8 @@ spec:
     #   value: "false"
     # - name: assetsManagementTimeoutSeconds # Optional
     #   value: 5
-
+    # - name: concurrencyMode # Optional
+    #   value: "single"
 
 
 ```
@@ -81,6 +82,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | disableEntityManagement | N  | When set to true, SNS topics, SQS queues and the SQS subscriptions to SNS do not get created automatically. Default: `"false"` | `"true"`, `"false"`
 | disableDeleteOnRetryLimit | N  | When set to true, after retrying and failing of `messageRetryLimit` times processing a message, reset the message visibility timeout so that other consumers can try processing, instead of deleting the message from SQS (the default behvior). Default: `"false"` | `"true"`, `"false"`
 | assetsManagementTimeoutSeconds | N  | Amount of time in seconds, for an AWS asset management operation, before it times out and cancelled. Asset management operations are any operations performed on STS, SNS and SQS, except message publish and consume operations that implement the default Dapr component retry behavior. The value can be set to any non-negative float/integer. Default: `5` | `0.5`, `10`
+| concurrencyMode | N  | When a bulk of messages is pulled from SQS, call the subscriber sequencially (“single” message at a time), or concurrently (in “parallel”). Default: `"parallel"` | `"single"`, `"parallel"`
 
 
 * Dapr created SNS topic and SQS queue names conform with [AWS specifications](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html). By default, Dapr creates an SQS queue name based on the consumer `app-id`, therefore Dapr might perform name standardization to meet with AWS specifications.

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-aws-snssqs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-aws-snssqs.md
@@ -88,7 +88,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 * Dapr created SNS topic and SQS queue names conform with [AWS specifications](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html). By default, Dapr creates an SQS queue name based on the consumer `app-id`, therefore Dapr might perform name standardization to meet with AWS specifications.
 * Using SQS FIFO (`fifo` metadata field set to `"true"`), per AWS specifications, provides message ordering and deduplication, but incurs a lower SQS processing throughput, among other caveats
 * Be aware that specifying `fifoMessageGroupID` limits the number of concurrent consumers of the FIFO queue used to only one but guarantees global ordering of messages published by the app's Dapr sidecars. See [this](https://aws.amazon.com/blogs/compute/solving-complex-ordering-challenges-with-amazon-sqs-fifo-queues/) post to better understand the topic of Message Group IDs and FIFO queues.
-
+* Since v1.8.0, the component supports the `"parallel"` `concurrencyMode` as its default mode. In prior versions, the component default behavior was calling the subscriber a single message at a time and waiting for its response. 
 
 
 ## Create an SNS/SQS instance


### PR DESCRIPTION
Signed-off-by: Amit Mor <amitm@at-bay.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
AWS Pub/Sub SNS/SQS component: add documentation about a new metadata field named `concurrencyMode` allowing the user to select either "parallel" or "single" publishing mode. As defined by this new field, upon receiving a bulk of message from SQS, the sidecar would publish the messages to the client with default mode of "parallel", i.e. concurrently, otherwise, publishing would be sequential, one message at a time.

## Issue reference

#2354 
