### PR TITLE
Fixes wrong working directory for dotnet state management sample

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
@@ -414,7 +414,7 @@ Install the dependencies:
 mvn clean install
 ```
 
-Run the `order-processor` publisher service alongside a Dapr sidecar.
+Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
 dapr run --app-id order-processor --components-path ../../../components -- java -jar target/order-processor-0.0.1-SNAPSHOT.jar

--- a/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
@@ -285,7 +285,7 @@ git clone https://github.com/dapr/quickstarts.git
 In a terminal window, navigate to the `order-processor` directory.
 
 ```bash
-cd pub_sub/csharp/sdk/order-processor
+cd state_management/csharp/sdk/order-processor
 ```
 
 Recall NuGet packages:


### PR DESCRIPTION
The working directory for .NET is pointing to `pub_sub` but it should be `state_management`.

Signed-off-by: Stephane Lapointe <stephane.lap@outlook.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The working directory for .NET is pointing to `pub_sub` but it should be `state_management`.

## Issue reference

N/A
