### PR TITLE
Fix curl example

### DIFF
--- a/daprdocs/content/en/reference/api/actors_api.md
+++ b/daprdocs/content/en/reference/api/actors_api.md
@@ -53,7 +53,7 @@ You can provide the method parameters and values in the body of the request, for
 
 ```shell
 curl -X POST http://localhost:3500/v1.0/actors/x-wing/33/method/fly \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
   -d '{
         "destination": "Hoth"
       }'
@@ -63,7 +63,7 @@ or
 
 ```shell
 curl -X POST http://localhost:3500/v1.0/actors/x-wing/33/method/fly \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
   -d "{\"destination\":\"Hoth\"}"
 ```
 
@@ -103,7 +103,7 @@ Parameter | Description
 
 ```shell
 curl -X POST http://localhost:3500/v1.0/actors/stormtrooper/50/state \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
   -d '[
        {
          "operation": "upsert",
@@ -242,7 +242,7 @@ Parameter | Description
 
 ```shell
 curl http://localhost:3500/v1.0/actors/stormtrooper/50/reminders/checkRebels \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
 -d '{
       "data": "someData",
       "dueTime": "1m",
@@ -383,7 +383,7 @@ Parameter | Description
 
 ```shell
 curl http://localhost:3500/v1.0/actors/stormtrooper/50/timers/checkRebels \
-    -H "Content-Type: application/json"
+    -H "Content-Type: application/json" \
 -d '{
       "data": "someData",
       "dueTime": "1m",


### PR DESCRIPTION
`\` is missing for some curl examples.



**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
The request body is missing due to the absence of the `\` character.
<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
