### PR TITLE
Fixed typo in security concept doc

### DIFF
--- a/daprdocs/content/en/concepts/security-concept.md
+++ b/daprdocs/content/en/concepts/security-concept.md
@@ -138,7 +138,7 @@ By default Dapr doesn't transform the state data from applications. This means D
 
 However application state often needs to get encrypted at rest to provide stronger security in enterprise workloads or regulated environments and Dapr does provide automatic client side state encryption based on AES256. Read [How-To: Encrypt application state]({{< ref howto-encrypt-state.md >}}) for more details.
 
-## Dapr Runtrime state
+## Dapr Runtime state
 Importantly the Dapr runtime does not store any data at rest, meaning that Dapr runtime has no dependency on any state stores for its operation and can be considered stateless.
 
 # Using security capabilies in an example application


### PR DESCRIPTION
Signed-off-by: moreyhat <moreyhat@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Fixed typo in security concept doc (Dapr Runtrime state -> Dapr Runtime state)

## Issue reference
#2373 
