### PR TITLE
Fix some minor config docs issues

### DIFF
--- a/daprdocs/content/en/concepts/configuration-concept.md
+++ b/daprdocs/content/en/concepts/configuration-concept.md
@@ -25,14 +25,14 @@ spec:
 
 This configuration configures tracing for metrics recording. It can be loaded in local self-hosted mode by editing the default configuration file called `config.yaml` file in your `.dapr` directory, or by applying it to your Kubernetes cluster with kubectl/helm.
 
-Here is an example of the Dapr control plane configuration in the `daprsystem` namespace.
+Here is an example of the Dapr control plane configuration called `daprsystem` in the `dapr-system` namespace.
 
 ```yaml
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
   name: daprsystem
-  namespace: default
+  namespace: dapr-system
 spec:
   mtls:
     enabled: true

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-management-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-management-overview.md
@@ -68,7 +68,7 @@ With the gRPC API, you can set content type by adding key/value pair `"contentTy
 
 ### Multiple operations
 
-Dapr supports two types of mult-read or multi-write operations: **bulk** or **transactional**. Read the [API reference]({{< ref state_api.md >}}) to learn how use bulk and multi options.
+Dapr supports two types of multi-read or multi-write operations: **bulk** or **transactional**. Read the [API reference]({{< ref state_api.md >}}) to learn how use bulk and multi options.
 
 #### Bulk read operations
 

--- a/daprdocs/content/en/operations/monitoring/metrics/metrics-overview.md
+++ b/daprdocs/content/en/operations/monitoring/metrics/metrics-overview.md
@@ -19,6 +19,8 @@ The default metrics port is `9090`. You can override this by passing the command
 
 You can also disable the metrics exporter for a specific application by setting the `dapr.io/enable-metrics: "false"` annotation to your application deployment. With the metrics exporter disabled, `daprd` will not open the metrics listening port.
 
+The follow example shows metrics are explicitly enabled with the port specified as "9090".
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -65,7 +67,7 @@ spec:
   tracing:
     samplingRate: "1"
   metrics:
-    enabled: true
+    enabled: false
 ```
 
 ## Metrics


### PR DESCRIPTION
The config sample yaml used the wrong namespace and while in there I decided to
mention the name of the config instead of just its namespace since the two
are so similar, I didn't want people to think one was a typo.

And the monitoring sample had a typo w.r.t. enable/disable.

The text before the metrics sample talked about disabling it, but then the example shows it being enabled - felt a bit odd. So I add a line before the same to say that the sample is "enabling" it so to not confuse people.

Adding a missing "i" on "mult-write" in the state store docs

Signed-off-by: Doug Davis <dug@microsoft.com>
