### PR TITLE
message for restarting the dapr-enabled pods

### DIFF
--- a/daprdocs/content/en/operations/security/mtls.md
+++ b/daprdocs/content/en/operations/security/mtls.md
@@ -178,12 +178,21 @@ dapr mtls renew-certificate -k --valid-until <days> --restart
 dapr mtls renew-certificate -k --private-key <private_key_file_path> --valid-until <days>
 ```
 #### Renew certificates by using provided custom certificates
-To update the provided certificates in the Kubernetes cluster, the CLI command below can be used.
+3. To update the provided certificates in the Kubernetes cluster, the CLI command below can be used.
 
 > **Note - It does not support `valid-until` flag to specify validity for new certificates.**
 
 ```bash
 dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-key <issuer.key> --issuer-public-certificate <issuer.crt> --restart
+```
+
+{{% alert title="Restart Dapr-enabled pods" color="warning" %}}
+Irrespective of which command was used to renew the certificates, you must restart all Dapr-enabled pods.
+You will experience potential downtime due to mismatching certificates until all deployments have successfully been restarted.
+{{% /alert %}}
+The recommended way to do this is to perform a rollout restart of your deployment:
+```
+kubectl rollout restart deploy/myapp
 ```
 
 ### Updating root or issuer certs using Kubectl

--- a/daprdocs/content/en/operations/security/mtls.md
+++ b/daprdocs/content/en/operations/security/mtls.md
@@ -178,7 +178,7 @@ dapr mtls renew-certificate -k --valid-until <days> --restart
 dapr mtls renew-certificate -k --private-key <private_key_file_path> --valid-until <days>
 ```
 #### Renew certificates by using provided custom certificates
-3. To update the provided certificates in the Kubernetes cluster, the CLI command below can be used.
+To update the provided certificates in the Kubernetes cluster, the CLI command below can be used.
 
 > **Note - It does not support `valid-until` flag to specify validity for new certificates.**
 
@@ -188,7 +188,7 @@ dapr mtls renew-certificate -k --ca-root-certificate <ca.crt> --issuer-private-k
 
 {{% alert title="Restart Dapr-enabled pods" color="warning" %}}
 Irrespective of which command was used to renew the certificates, you must restart all Dapr-enabled pods.
-You will experience potential downtime due to mismatching certificates until all deployments have successfully been restarted.
+Due to certificate mismatches, you might experience some downtime till all deployments have successfully been restarted.
 {{% /alert %}}
 The recommended way to do this is to perform a rollout restart of your deployment:
 ```


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added message for restarting the dapr application pods when cli commands are used to renew the certificates.

## Issue reference NA

<!--Please reference the issue this PR will close: #[issue number]-->
