### PR TITLE
Target of dapr annotations (pod) described more clearly

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-overview.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-overview.md
@@ -22,7 +22,7 @@ Read [this guide]({{< ref kubernetes-deploy.md >}}) to learn how to deploy Dapr 
 
 ## Adding Dapr to a Kubernetes deployment
 
-Deploying and running a Dapr enabled application into your Kubernetes cluster is as simple as adding a few annotations to the deployment schemes. To give your service an `id` and `port` known to Dapr, turn on tracing through configuration and launch the Dapr sidecar container, you annotate your Kubernetes deployment like this. For more information check  [dapr annotations]({{< ref arguments-annotations-overview.md >}})
+Deploying and running a Dapr enabled application into your Kubernetes cluster is as simple as adding a few annotations to the pods schema. To give your service an `id` and `port` known to Dapr, turn on tracing through configuration and launch the Dapr sidecar container, you annotate your Kubernetes pod like this. For more information check  [dapr annotations]({{< ref arguments-annotations-overview.md >}})
 
 ```yml
   annotations:


### PR DESCRIPTION
Signed-off-by: Thorsten Hans <thorsten.hans@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Kubernetes overview was a bit misleading. It mentioned that annotations should be added to the Kubernetes deployment. However the annotations must be provided on the `Pod`. So I updated the corresponding parts

## Issue reference

No issue
