### PR TITLE
Add missing upgrade step for 1.7

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-upgrade.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-upgrade.md
@@ -61,6 +61,7 @@ From version 1.0.0 onwards, upgrading Dapr using Helm is no longer a disruptive 
    kubectl replace -f https://raw.githubusercontent.com/dapr/dapr/v{{% dapr-latest-version long="true" %}}/charts/dapr/crds/components.yaml
    kubectl replace -f https://raw.githubusercontent.com/dapr/dapr/v{{% dapr-latest-version long="true" %}}/charts/dapr/crds/configuration.yaml
    kubectl replace -f https://raw.githubusercontent.com/dapr/dapr/v{{% dapr-latest-version long="true" %}}/charts/dapr/crds/subscription.yaml
+   kubectl apply -f https://raw.githubusercontent.com/dapr/dapr/v{{% dapr-latest-version long="true" %}}/charts/dapr/crds/resiliency.yaml
    ```
 
    ```bash


### PR DESCRIPTION
Without this extra step, an upgrade to 1.7 is incomplete and users can't apply Resiliency policies.
