### PR TITLE
Added missing metadata option for Service Bus in 1.7

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
@@ -71,7 +71,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | Field              | Required | Details | Example |
 |--------------------|:--------:|---------|---------|
 | connectionString   | Y  | Shared access policy connection-string for the Service Bus  | "`Endpoint=sb://{ServiceBusNamespace}.servicebus.windows.net/;SharedAccessKeyName={PolicyName};SharedAccessKey={Key};EntityPath={ServiceBus}`"
-| consumerID         | N        | Consumer ID a.k.a consumer tag organizes one or more consumers into a group. Consumers with the same consumer ID work as one virtual consumer, i.e. a message is processed only once by one of the consumers in the group. If the consumer ID is not set, the dapr runtime will set it to the dapr application ID. |
+| consumerID         | N        | Consumer ID a.k.a consumer tag organizes one or more consumers into a group. Consumers with the same consumer ID work as one virtual consumer. In other words, a message is processed only once by one of the consumers in the group. If the consumer ID is not set, the Dapr runtime sets it to the Dapr application ID (appId). |
 | timeoutInSec       | N  | Timeout for sending messages and management operations. Default: `60` |`30`
 | handlerTimeoutInSec| N  |  Timeout for invoking app handler. # Optional. Default: `60` | `30`
 | disableEntityManagement | N  | When set to true, topics and subscriptions do not get created automatically. Default: `"false"` | `"true"`, `"false"`

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-servicebus.md
@@ -24,6 +24,8 @@ spec:
   metadata:
   - name: connectionString # Required when not using Azure Authentication.
     value: "Endpoint=sb://{ServiceBusNamespace}.servicebus.windows.net/;SharedAccessKeyName={PolicyName};SharedAccessKey={Key};EntityPath={ServiceBus}"
+  # - name: consumerID # Optional: defaults to the app's own ID
+  #   value: "{identifier}" 
   # - name: timeoutInSec # Optional
   #   value: 60
   # - name: handlerTimeoutInSec # Optional
@@ -69,6 +71,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | Field              | Required | Details | Example |
 |--------------------|:--------:|---------|---------|
 | connectionString   | Y  | Shared access policy connection-string for the Service Bus  | "`Endpoint=sb://{ServiceBusNamespace}.servicebus.windows.net/;SharedAccessKeyName={PolicyName};SharedAccessKey={Key};EntityPath={ServiceBus}`"
+| consumerID         | N        | Consumer ID a.k.a consumer tag organizes one or more consumers into a group. Consumers with the same consumer ID work as one virtual consumer, i.e. a message is processed only once by one of the consumers in the group. If the consumer ID is not set, the dapr runtime will set it to the dapr application ID. |
 | timeoutInSec       | N  | Timeout for sending messages and management operations. Default: `60` |`30`
 | handlerTimeoutInSec| N  |  Timeout for invoking app handler. # Optional. Default: `60` | `30`
 | disableEntityManagement | N  | When set to true, topics and subscriptions do not get created automatically. Default: `"false"` | `"true"`, `"false"`


### PR DESCRIPTION
This option was missing in the Azure Service Bus PubSub docs in 1.7