### PR TITLE
Match linkTitle case for HTTP

### DIFF
--- a/daprdocs/content/en/operations/configuration/increase-request-size.md
+++ b/daprdocs/content/en/operations/configuration/increase-request-size.md
@@ -1,7 +1,7 @@
 ---
 type: docs
 title: "How-To: Handle large http body requests"
-linkTitle: "Http request body size"
+linkTitle: "HTTP request body size"
 weight: 6000
 description: "Configure http requests that are bigger than 4 MB"
 ---


### PR DESCRIPTION
## Description

Consistency of HTTP and Http in link titles was incorrect. Fixing it to be HTTP

