### PR TITLE
Fix spec metadata table for Kafka binding docs

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kafka.md
@@ -37,6 +37,8 @@ spec:
     secretKeyRef:
       name: kafka-secrets
       key: saslPasswordSecret
+  - name: initialOffset # Optional. Used for input bindings.
+    value: "newest"
   - name: maxMessageBytes # Optional.
     value: 1024
   - name: version # Optional.
@@ -54,9 +56,9 @@ spec:
 | authRequired | Y | Input/Output | Enable [SASL](https://en.wikipedia.org/wiki/Simple_Authentication_and_Security_Layer) authentication with the Kafka brokers. | `"true"`, `"false"` |
 | saslUsername | N | Input/Output | The SASL username used for authentication. Only required if `authRequired` is set to `"true"`. | `"adminuser"` |
 | saslPassword | N | Input/Output | The SASL password used for authentication. Can be `secretKeyRef` to use a [secret reference]({{< ref component-secrets.md >}}). Only required if `authRequired` is set to `"true"`. | `""`, `"KeFg23!"` |
-| initialOffset   | N | The initial offset to use if no offset was previously committed. Should be "newest" or "oldest". Defaults to "newest". | `"oldest"` |
+| initialOffset   | N | Input | The initial offset to use if no offset was previously committed. Should be "newest" or "oldest". Defaults to "newest". | `"oldest"` |
 | maxMessageBytes | N | Input/Output | The maximum size in bytes allowed for a single Kafka message. Defaults to 1024. | `2048` |
-| version | N | Kafka cluster version. Defaults to 1.0.0 | `1.0.0`
+| version | N | Input/Output | Kafka cluster version. Defaults to 1.0.0 | `1.0.0`
 
 ## Binding support
 
@@ -87,6 +89,10 @@ curl -X POST http://localhost:3500/v1.0/bindings/myKafka \
         "operation": "create"
       }'
 ```
+
+### Response
+
+An HTTP 204 (No Content) and empty body will be returned if successful.
 
 ## Related links
 


### PR DESCRIPTION
Signed-off-by: Sarthak Sharma <t-sartsharma@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Fix missing data in spec metadata table for Kafka binding and add output response for operation.
## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
