### PR TITLE
Add note to documentation to reference the podName attribute

### DIFF
--- a/daprdocs/content/en/operations/components/component-schema.md
+++ b/daprdocs/content/en/operations/components/component-schema.md
@@ -67,6 +67,9 @@ spec:
       value: "false"
 ```
 
+The consumerID metadata values can also contain a `{podName}` tag that is replaced with the Kubernetes POD's name when the Dapr sidecar starts up. This can be used to have a persisted behavior where the ConsumerID does not change on restart when using StatefulSets in Kubernetes.
+
+
 ## Further reading
 - [Components concept]({{< ref components-concept.md >}})
 - [Reference secrets in component definitions]({{< ref component-secrets.md >}})


### PR DESCRIPTION
Signed-off-by: CacheCoww <hmsmith2510@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
- Documentation describing the option to use {podName} as a consumerID for pub sub metadata

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->