### PR TITLE
Added in-memory spec.metadata to example and note

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-inmemory.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-inmemory.md
@@ -20,7 +20,10 @@ metadata:
 spec:
   type: pubsub.in-memory
   version: v1
+  metadata: []
 ```
+
+> Note: in-memory does not require any specific metadata for the component to work, however spec.metadata is a required field.
 
 ## Related links
 - [Basic schema for a Dapr component]({{< ref component-schema >}}) in the Related links section


### PR DESCRIPTION
Signed-off-by: Tyson Lawrie <tlawrie@users.noreply.github.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated the in-memory reference example to include the necessary `spec.metadata` field as well as adding a note to the documentation to explain why its empty.

## Issue reference

Closes: https://github.com/dapr/dapr/issues/4740
