### PR TITLE
[secrets mgmt] typo in go section

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/observability/w3c-tracing/w3c-tracing-howto.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/observability/w3c-tracing/w3c-tracing-howto.md
@@ -135,7 +135,7 @@ You can create a trace context using the recommended OpenCensus SDKs. OpenCensus
 | Language | SDK |
 |:-------:|:----:|
 | Go | [Link](https://pkg.go.dev/go.opencensus.io?tab=overview)
-| Java | [Link](https://www.javadoc.io/doc/io.opencensus/opencensus-api)
+| Java | [Link](https://github.com/census-instrumentation/opencensus-java)
 | C# | [Link](https://github.com/census-instrumentation/opencensus-csharp/)
 | C++ | [Link](https://github.com/census-instrumentation/opencensus-cpp)
 | Node.js | [Link](https://github.com/census-instrumentation/opencensus-node)

--- a/daprdocs/content/en/developing-applications/building-blocks/observability/w3c-tracing/w3c-tracing-howto.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/observability/w3c-tracing/w3c-tracing-howto.md
@@ -135,7 +135,7 @@ You can create a trace context using the recommended OpenCensus SDKs. OpenCensus
 | Language | SDK |
 |:-------:|:----:|
 | Go | [Link](https://pkg.go.dev/go.opencensus.io?tab=overview)
-| Java | [Link](https://www.javadoc.io/doc/io.opencensus/opencensus-api/latest/index.html)
+| Java | [Link](https://www.javadoc.io/doc/io.opencensus/opencensus-api)
 | C# | [Link](https://github.com/census-instrumentation/opencensus-csharp/)
 | C++ | [Link](https://github.com/census-instrumentation/opencensus-cpp)
 | Node.js | [Link](https://github.com/census-instrumentation/opencensus-node)

--- a/daprdocs/content/en/getting-started/quickstarts/secrets-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/secrets-quickstart.md
@@ -482,7 +482,7 @@ cd secrets_management/go/sdk/order-processor
 Install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+go build app.go
 ```
 
 Run the `order-processor` service alongside a Dapr sidecar.


### PR DESCRIPTION
Signed-off-by: Hannah Hunter <hannahhunter@microsoft.com>

## Description

Remove 'pip3' reference in Go section and replace with 'go build'

## Issue reference

PR will close: #2528 
