### PR TITLE
Guide users to generic mongo db component for azure cosmos db with mo…

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/_index.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/_index.md
@@ -76,7 +76,7 @@ Table captions:
 | Name | Input<br>Binding | Output<br>Binding | Status | Component version | Since |
 |------|:----------------:|:-----------------:|--------| --------- | ---------- |
 | [Azure Blob Storage]({{< ref blobstorage.md >}})            |    | ✅ | Beta | v1 | 1.0 |
-| [Azure CosmosDB]({{< ref cosmosdb.md >}})                   |    | ✅ | Beta | v1 | 1.0 |
+| [Azure CosmosDB (SQL API)]({{< ref cosmosdb.md >}})                   |    | ✅ | Beta | v1 | 1.0 |
 | [Azure CosmosDBGremlinAPI]({{< ref cosmosdbgremlinapi.md >}})              |    | ✅ | Alpha | v1 | 1.5 |
 | [Azure Event Grid]({{< ref eventgrid.md >}})                | ✅ | ✅ | Alpha | v1 | 1.0 |
 | [Azure Event Hubs]({{< ref eventhubs.md >}})                 | ✅ | ✅ | Beta | v1 | 1.0 |

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cosmosdb.md
@@ -1,8 +1,8 @@
 ---
 type: docs
-title: "Azure Cosmos DB binding spec"
-linkTitle: "Azure Cosmos DB"
-description: "Detailed documentation on the Azure Cosmos DB binding component"
+title: "Azure Cosmos DB (SQL API) binding spec"
+linkTitle: "Azure Cosmos DB (SQL API)"
+description: "Detailed documentation on the Azure Cosmos DB (SQL API) binding component"
 aliases:
   - "/operations/components/setup-bindings/supported-bindings/cosmosdb/"
 ---

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/_index.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/_index.md
@@ -60,7 +60,7 @@ The following stores are supported, at various levels, by the Dapr state managem
 | Name                                                             |CRUD|Transactional|ETag| [TTL]({{< ref state-store-ttl.md >}}) | [Actors]({{< ref howto-actors.md >}}) | [Query]({{< ref howto-state-query-api.md >}}) | Status | Component version | Since |
 |------------------------------------------------------------------|----|-------------|----|----|----|----|-------|----|-----|
 | [Azure Blob Storage]({{< ref setup-azure-blobstorage.md >}})     | ✅ | ❌           | ✅ | ❌ | ❌ | ❌ | Stable | v1 | 1.0 |
-| [Azure CosmosDB]({{< ref setup-azure-cosmosdb.md >}})            | ✅ | ✅           | ✅ | ✅ | ✅ | ✅ | Stable | v1 | 1.0 |
+| [Azure CosmosDB (SQL API)]({{< ref setup-azure-cosmosdb.md >}})            | ✅ | ✅           | ✅ | ✅ | ✅ | ✅ | Stable | v1 | 1.0 |
 | [Azure SQL Server]({{< ref setup-sqlserver.md >}})               | ✅ | ✅           | ✅ | ❌ | ✅ | ❌ | Stable | v1 | 1.5 |
 | [Azure Table Storage]({{< ref setup-azure-tablestorage.md >}})   | ✅ | ❌           | ✅ | ❌ | ❌ | ❌ | Alpha  | v1 | 1.0 |
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
@@ -59,6 +59,7 @@ The Azure Cosmos DB state store component supports authentication using all Azu
 You can read additional information for setting up Cosmos DB with Azure AD authentication in the [section below](#setting-up-cosmos-db-for-authenticating-with-azure-ad).
 
 ## Setup Azure Cosmos DB
+> Note: For an Azure Cosmos DB that uses the Mongo DB API, use the [Mongo DB state store component]({{< ref setup-mongodb.md >}}).
 
 [Follow the instructions](https://docs.microsoft.com/azure/cosmos-db/how-to-manage-database-account) from the Azure documentation on how to create an Azure Cosmos DB account.  The database and collection must be created in Cosmos DB before Dapr can use it.
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
@@ -1,8 +1,8 @@
 ---
 type: docs
-title: "Azure Cosmos DB"
-linkTitle: "Azure Cosmos DB"
-description: Detailed information on the Azure Cosmos DB state store component
+title: "Azure Cosmos DB (SQL API)"
+linkTitle: "Azure Cosmos DB (SQL API)"
+description: Detailed information on the Azure Cosmos DB (SQL API) state store component
 aliases:
   - "/operations/components/setup-state-store/supported-state-stores/setup-azure-cosmosdb/"
 ---
@@ -59,7 +59,6 @@ The Azure Cosmos DB state store component supports authentication using all Azu
 You can read additional information for setting up Cosmos DB with Azure AD authentication in the [section below](#setting-up-cosmos-db-for-authenticating-with-azure-ad).
 
 ## Setup Azure Cosmos DB
-> Note: For an Azure Cosmos DB that uses the Mongo DB API, use the [Mongo DB state store component]({{< ref setup-mongodb.md >}}).
 
 [Follow the instructions](https://docs.microsoft.com/azure/cosmos-db/how-to-manage-database-account) from the Azure documentation on how to create an Azure Cosmos DB account.  The database and collection must be created in Cosmos DB before Dapr can use it.
 


### PR DESCRIPTION
Added a sentence that instructs users using Azure Cosmos with Mongo API to use the generic Mongo component for a state store

## Issue reference
https://github.com/dapr/docs/issues/2189
