### PR TITLE
removing pub/sub TTL capability from list

### DIFF
--- a/daprdocs/content/en/reference/api/metadata_api.md
+++ b/daprdocs/content/en/reference/api/metadata_api.md
@@ -10,12 +10,11 @@ Dapr has a metadata API that returns information about the sidecar allowing runt
 
 ## Components
 Each loaded component provides its name, type and version and also information about supported features in the form of component capabilities. 
-These features are available for the [state store]({{< ref supported-state-stores.md >}}), [pub/sub]({{< ref supported-pubsub.md >}}) and [binding]({{< ref supported-bindings.md >}}) component types. The table below shows the component type and the list of capabilities for a given version. This list might grow in future and only represents the capabilities of the loaded components.
+These features are available for the [state store]({{< ref supported-state-stores.md >}}) and [binding]({{< ref supported-bindings.md >}}) component types. The table below shows the component type and the list of capabilities for a given version. This list might grow in future and only represents the capabilities of the loaded components.
 
 Component type | Capabilites
 ---------------| ------------
 State Store    | ETAG, TRANSACTION, ACTOR, QUERY_API
-Pub/Sub        | TTL
 Binding        | INPUT_BINDING, OUTPUT_BINDING
 
 ## Attributes


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Removing Pub/Sub TTL from list of capabilities as TTL is supported by all components.

## Issue reference

Please reference the issue this PR will close: #2482 
