### PR TITLE
Custom 404 page

### DIFF
--- a/daprdocs/staticwebapp.config.json
+++ b/daprdocs/staticwebapp.config.json
@@ -2,5 +2,10 @@
     "globalHeaders": {
       "X-Frame-Options": "DENY"
     }
+    "responseOverrides": {
+    "404": {
+      "rewrite": "/404.html",
+      "statusCode": 404
+    }
+  }  
 }
-

--- a/daprdocs/staticwebapp.config.json
+++ b/daprdocs/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
     "globalHeaders": {
         "X-Frame-Options": "DENY"
-    }
+    },
     "responseOverrides": {
         "404": {
             "rewrite": "/404.html",

--- a/daprdocs/staticwebapp.config.json
+++ b/daprdocs/staticwebapp.config.json
@@ -1,11 +1,11 @@
 {
     "globalHeaders": {
-      "X-Frame-Options": "DENY"
+        "X-Frame-Options": "DENY"
     }
     "responseOverrides": {
-    "404": {
-      "rewrite": "/404.html",
-      "statusCode": 404
+        "404": {
+            "rewrite": "/404.html",
+            "statusCode": 404
+        }
     }
-  }  
 }


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add Azure static web app configuration to use the hugo-generated default 404 page

## Issue reference
#2378 

