### PR TITLE
Fixed indentation of RabbitMQ binding spec

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/rabbitmq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/rabbitmq.md
@@ -38,7 +38,7 @@ spec:
     value: false
   - name: maxPriority
     value: 5
-- name: contentType
+  - name: contentType
     value: "text/plain"
 ```
 


### PR DESCRIPTION
This is my commit message
Signed-off-by: Malte Götz <maltegoetz@users.noreply.github.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

There was a mistake with the indentation of the RabbitMQ binding spec leading to an invalid yaml syntax.
