### PR TITLE
Add hint on OPTIONS request for input bindings

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
@@ -96,7 +96,7 @@ spec:
 
 ## Listen for incoming events (input binding)
 
-Configure your application to receive incoming events. If using HTTP, you need to listen on a `POST` endpoint with the name of the binding, as specified in `metadata.name` in the `binding.yaml` file. 
+Configure your application to receive incoming events. If using HTTP, you need to listen on a `POST` endpoint with the name of the binding, as specified in `metadata.name` in the `binding.yaml` file. Additionally make sure that your application allows dapr to make an `OPTIONS` request for this endpoint.
 
 Below are code examples that leverage Dapr SDKs to demonstrate an output binding.
 


### PR DESCRIPTION
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

## Description

When creating an input binding dapr makes an `OPTIONS` call on the specified endpoint. If the request fails, the subscription is dropped and input wont be handled. 
