### PR TITLE
Add example for HTTPS binding

### DIFF
--- a/daprdocs/content/en/operations/configuration/install-certificates.md
+++ b/daprdocs/content/en/operations/configuration/install-certificates.md
@@ -80,17 +80,18 @@ spec:
 ...
 ```
 
-{{% alert title="Note" color="primary" %}}
-When using Windows containers, the sidecar container is started with admin privileges, which is required to install the certificates. This does not apply to Linux containers.
-{{% /alert %}}
+**Note**: When using Windows containers, the sidecar container is started with admin privileges, which is required to install the certificates. This does not apply to Linux containers.
 
 {{% /codetab %}}
 
-Note, all the certificates in the directory pointed by `SSL_CERT_DIR` are installed. 
+{{< /tabs >}}
+
+<hr/>
+
+All the certificates in the directory pointed by `SSL_CERT_DIR` are installed.
+
 1. On Linux containers, all the certificate extensions supported by OpenSSL are supported. For more information, see https://www.openssl.org/docs/man1.1.1/man1/openssl-rehash.html
 1. On Windows container, all the certificate extensions supported by certoc.exe are supported. For more information, see certoc.exe present in [Windows Server Core](https://hub.docker.com/_/microsoft-windows-servercore)
-
-{{< /tabs >}}
 
 ## Related links
 - [(Kubernetes) How-to: Mount Pod volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})

--- a/daprdocs/content/en/operations/configuration/install-certificates.md
+++ b/daprdocs/content/en/operations/configuration/install-certificates.md
@@ -93,6 +93,16 @@ All the certificates in the directory pointed by `SSL_CERT_DIR` are installed.
 1. On Linux containers, all the certificate extensions supported by OpenSSL are supported. For more information, see https://www.openssl.org/docs/man1.1.1/man1/openssl-rehash.html
 1. On Windows container, all the certificate extensions supported by certoc.exe are supported. For more information, see certoc.exe present in [Windows Server Core](https://hub.docker.com/_/microsoft-windows-servercore)
 
+## Example
+
+Watch the demo on using installing SSL certificates and securely using the HTTP binding in community call 64:
+
+<div class="embed-responsive embed-responsive-16by9">
+<iframe width="560" height="315" src="https://www.youtube.com/embed/M0VM7GlphAU?start=800" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+
 ## Related links
+- [HTTP binding spec]({{< ref http.md >}})
 - [(Kubernetes) How-to: Mount Pod volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
 - [Dapr Kubernetes pod annotations spec]({{< ref arguments-annotations-overview.md >}})

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
@@ -236,7 +236,7 @@ The sidecar can read the SSL certificate from a variety of sources. See [How-to:
 kubectl create secret generic myapp-cert --from-file /tmp/ssl/cert.pem
 ```
 
-The YAML below is an example of the kubernetes deployment that mounts the above secret to the sidecar and sets `SSL_CERT_DIR` to install the certificates.
+The YAML below is an example of the Kubernetes deployment that mounts the above secret to the sidecar and sets `SSL_CERT_DIR` to install the certificates.
 
 ```yaml
 apiVersion: apps/v1

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
@@ -173,8 +173,125 @@ curl -d '{ "operation": "post", "data": "YOUR_BASE_64_CONTENT", "metadata": { "p
 
 The HTTP binding can also be used with HTTPS endpoints by configuring the Dapr sidecar to trust the server's SSL certificate.
 
-1. Update the binding component's YAML to use `https` instead of `http`
+
+1. Update the binding URL to use `https` instead of `http`.
 1. Refer [How-To: Install certificates in the Dapr sidecar]({{< ref install-certificates >}}), to install the SSL certificate in the sidecar.
+
+### Example
+
+#### Update the binding component
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: <NAME>
+  namespace: <NAMESPACE>
+spec:
+  type: bindings.http
+  version: v1
+  metadata:
+  - name: url
+    value: https://my-secured-website.com # Use HTTPS
+```
+
+#### Install the SSL certificate in the sidecar
+
+
+{{< tabs Self-Hosted Kubernetes >}}
+
+{{% codetab %}}
+When the sidecar is not running inside a container, the SSL certificate can be directly installed on the host operating system.
+
+Below is an example when the sidecar is running as a container. The SSL certificate is located on the host computer at `/tmp/ssl/cert.pem`.
+
+```yaml
+version: '3'
+services:
+  my-app:
+    # ...
+  dapr-sidecar:
+    image: "daprio/daprd:1.8.0"
+    command: [
+      "./daprd",
+     "-app-id", "myapp",
+     "-app-port", "3000",
+     ]
+    volumes:
+        - "./components/:/components"
+        - "/tmp/ssl/:/certificates" # Mount the certificates folder to the sidecar container at /certificates
+    environment:
+      - "SSL_CERT_DIR=/certificates" # Set the environment variable to the path of the certificates folder
+    depends_on:
+      - my-app
+```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+
+The sidecar can read the SSL certificate from a variety of sources. See [How-to: Mount Pod volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts >}}) for more. In this example, we store the SSL certificate as a Kubernetes secret.
+
+```bash
+kubectl create secret generic myapp-cert --from-file /tmp/ssl/cert.pem
+```
+
+The YAML below is an example of the kubernetes deployment that mounts the above secret to the sidecar and sets `SSL_CERT_DIR` to install the certificates.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+  namespace: default
+  labels:
+    app: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "myapp"
+        dapr.io/app-port: "8000"
+        dapr.io/volume-mounts: "cert-vol:/certificates" # Mount the certificates folder to the sidecar container at /certificates
+        dapr.io/env: "SSL_CERT_DIR=/certificates" # Set the environment variable to the path of the certificates folder
+    spec:
+      volumes:
+        - name: cert-vol
+          secret:
+            secretName: myapp-cert
+...
+```
+
+{{% /codetab %}}
+
+{{< /tabs >}}
+
+#### Invoke the binding securely
+
+{{< tabs Windows Linux >}}
+
+{{% codetab %}}
+```bash
+curl -d "{ \"operation\": \"get\" }" \
+      https://localhost:<dapr-port>/v1.0/bindings/<binding-name>
+```
+{{% /codetab %}}
+
+{{% codetab %}}
+```bash
+curl -d '{ "operation": "get" }' \
+      https://localhost:<dapr-port>/v1.0/bindings/<binding-name>
+```
+{{% /codetab %}}
+
+{{< /tabs >}}
 
 
 ## Related links


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This PR adds an example for HTTPS binding and fixes a minor formatting issue with install-certs.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
