### PR TITLE
Fix: "last modified" on every page shows the same date and commit

### DIFF
--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Setup Docsy
         run: cd daprdocs && git submodule update --init --recursive && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli
       - name: Build And Deploy

--- a/.github/workflows/website-v1-7.yml
+++ b/.github/workflows/website-v1-7.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          fetch-depth: 0          
       - name: Setup Docsy
         run: cd daprdocs && git submodule update --init --recursive && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli
       - name: Build And Deploy


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [N/A] Commands include options for Linux, MacOS, and Windows within codetabs
- [N/A] New file and folder names are globally unique
- [N/A] Page references use shortcodes instead of markdown or URL links
- [N/A ] Images use HTML style and have alternative text
- [N/A] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

As described in https://github.com/dapr/docs/issues/2597, currently "last modified" on every page on Dapr docs shows the same date and commit. This PR should fix it by having the checkout GitHub Action fetch all git history instead of the default of 1 commit, as noted [here](https://discourse.gohugo.io/t/problems-with-gitinfo-in-ci/22480/2). I've tried this in a Docsy site hosted on Azure Static Web Apps I have, works great.

## Issue reference

https://github.com/dapr/docs/issues/2597
