### PR TITLE
[quickstarts] add note about python vs python3

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/bindings-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/bindings-quickstart.md
@@ -88,6 +88,8 @@ Run the `batch-sdk` service alongside a Dapr sidecar.
 dapr run --app-id batch-sdk --app-port 50051 --components-path ../../../components -- python3 app.py
 ```
 
+> **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
+
 The code inside the `process_batch` function is executed every 10 seconds (defined in [`binding-cron.yaml`]({{< ref "#componentsbinding-cronyaml-component-file" >}}) in the `components` directory). The binding trigger looks for a route called via HTTP POST in your Flask application by the Dapr sidecar.
 
 ```python

--- a/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
@@ -59,6 +59,8 @@ Run the `order-processor` subscriber service alongside a Dapr sidecar.
 dapr run --app-id order-processor --components-path ../../../components/ --app-port 5001 -- python3 app.py
 ```
 
+> **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
+
 In the `order-processor` subscriber, we're subscribing to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. This enables your app code to talk to the Redis component instance through the Dapr sidecar.
 
 ```py
@@ -105,6 +107,8 @@ Run the `checkout` publisher service alongside a Dapr sidecar.
 ```bash
 dapr run --app-id checkout --components-path ../../../components/ -- python3 app.py
 ```
+
+> **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
 
 In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `order_pub_sub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:
 

--- a/daprdocs/content/en/getting-started/quickstarts/secrets-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/secrets-quickstart.md
@@ -55,6 +55,9 @@ Run the `order-processor` service alongside a Dapr sidecar.
 dapr run --app-id order-processor --components-path ../../../components/ -- python3 app.py
 ```
 
+> **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
+
+
 #### Behind the scenes
 
 **`order-processor` service**

--- a/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
@@ -59,6 +59,8 @@ Run the `order-processor` service alongside a Dapr sidecar.
 dapr run --app-port 7001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- python3 app.py
 ```
 
+> **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
+
 ```py
 @app.route('/orders', methods=['POST'])
 def getOrder():
@@ -91,6 +93,8 @@ Run the `checkout` service alongside a Dapr sidecar.
 ```bash
 dapr run --app-id checkout --app-protocol http --dapr-http-port 3500 -- python3 app.py
 ```
+
+> **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
 
 In the `checkout` service, you'll notice there's no need to rewrite your app code to use Dapr's service invocation. You can enable service invocation by simply adding the `dapr-app-id` header, which specifies the ID of the target service.
 

--- a/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
@@ -54,6 +54,8 @@ Run the `order-processor` service alongside a Dapr sidecar.
 dapr run --app-id order-processor --components-path ../../../components/ -- python3 app.py
 ```
 
+> **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
+
 The `order-processor` service writes, reads, and deletes an `orderId` key/value pair to the `statestore` instance [defined in the `statestore.yaml` component]({{< ref "#statestoreyaml-component-file" >}}). As soon as the service starts, it performs a loop.
 
 ```python


### PR DESCRIPTION
Signed-off-by: Hannah Hunter <hannahhunter@microsoft.com>

## Description

Add note suggesting using `python` instead of `python3` if using windows

## Issue reference

#2650 
