### PR TITLE
Update docker compose example to load components correctly

### DIFF
--- a/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
+++ b/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
@@ -120,12 +120,13 @@ services:
     image: "daprio/daprd:edge"
     command: [
       "./daprd",
-     "-app-id", "nodeapp",
-     "-app-port", "3000",
-     "-placement-host-address", "placement:50006" # Dapr's placement service can be reach via the docker DNS entry
+     "--app-id", "nodeapp",
+     "--app-port", "3000",
+     "--placement-host-address", "placement:50006", # Dapr's placement service can be reach via the docker DNS entry
+     "--components-path", "./components"
      ]
     volumes:
-        - "./components/:/components" # Mount our components folder for the runtime to use
+        - "./components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --components-path argument.
     depends_on:
       - nodeapp
     network_mode: "service:nodeapp" # Attach the nodeapp-dapr service to the nodeapp network namespace
@@ -134,7 +135,7 @@ services:
 
   placement:
     image: "daprio/dapr"
-    command: ["./placement", "-port", "50006"]
+    command: ["./placement", "--port", "50006"]
     ports:
       - "50006:50006"
   


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

Thank you for helping make the Dapr documentation better!



**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Adds a matching Dapr components path argument to the Docker Compose example so that mounted components are actually loaded.