### PR TITLE
Mark Azure blob storage binding Stable (was stable in 1.7)

### DIFF
--- a/daprdocs/data/components/bindings/azure.yaml
+++ b/daprdocs/data/components/bindings/azure.yaml
@@ -24,7 +24,7 @@
     output: true
 - component: Azure Blob Storage
   link: blobstorage
-  state: Beta
+  state: Stable
   version: v1
   since: "1.0"
   features:


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

Thank you for helping make the Dapr documentation better!

Mark blob storage binding Stable (was stable in 1.7)