### PR TITLE
Include protocol response headers when checking the healthz output

### DIFF
--- a/daprdocs/content/en/reference/api/health_api.md
+++ b/daprdocs/content/en/reference/api/health_api.md
@@ -34,6 +34,6 @@ daprPort | The Dapr port.
 ### Examples
 
 ```shell
-curl http://localhost:3500/v1.0/healthz
+curl -i http://localhost:3500/v1.0/healthz
 ```
 


### PR DESCRIPTION
Signed-off-by: Bilgin Ibryam <bibryam@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The example curl command doesn't produce any output. Adding the option to show protocol heads show clearly 204 status code as documented.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
