### PR TITLE
Update dapr CLI publish documentation 

### DIFF
--- a/daprdocs/content/en/reference/cli/dapr-publish.md
+++ b/daprdocs/content/en/reference/cli/dapr-publish.md
@@ -21,19 +21,27 @@ dapr publish [flags]
 
 ### Flags
 
-| Name                     | Environment Variable | Default                                                      | Description                                           |
-| ------------------------ | -------------------- | ------------------------------------------------------------ | ----------------------------------------------------- |
-| `--publish-app-id`, `-i` |                      | The ID that represents the app from which you are publishing |
-| `--pubsub`, `-p`         |                      | The name of the pub/sub component                            |
-| `--topic`, `-t`          |                      |                                                              | The topic to be published to                          |
-| `--data`, `-d`           |                      |                                                              | The JSON serialized string (optional)                 |
-| `--data-file`, `-f`      |                      |                                                              | A file containing the JSON serialized data (optional) |
-| `--help`, `-h`           |                      |                                                              | Print this help message                               |
+| Name                         | Environment Variable | Default                                                      | Description                                           |
+| ---------------------------- | -------------------- | ------------------------------------------------------------ | ----------------------------------------------------- |
+| `--publish-app-id`, `-i`     |                      | The ID that represents the app from which you are publishing |
+| `--pubsub`, `-p`             |                      | The name of the pub/sub component                            |
+| `--topic`, `-t`              |                      |                                                              | The topic to be published to                          |
+| `--data`, `-d`               |                      |                                                              | The JSON serialized string (optional)                 |
+| `--data-file`, `-f`          |                      |                                                              | A file containing the JSON serialized data (optional) |
+| `--help`, `-h`               |                      |                                                              | Print this help message                               |
+| `--metadata`, `-m`           |                      |                                                              | A JSON serialized publish metadata (optional)         |
+| `--unix-domain-socket`, `-u` |                      |                                                              | The path to the unix domain socket (optional)         |
 
 
 ### Examples
 
 ```bash
-# Publish to sample topic in target pubsub
+# Publish to sample topic in target pubsub via a publishing app
 dapr publish --publish-app-id appId --topic sample --pubsub target --data '{"key":"value"}'
+
+# Publish to sample topic in target pubsub via a publishing app using Unix domain socket
+dapr publish --enable-domain-socket --publish-app-id myapp --pubsub target --topic sample --data '{"key":"value"}'
+
+# Publish to sample topic in target pubsub via a publishing app without cloud event
+dapr publish --publish-app-id myapp --pubsub target --topic sample --data '{"key":"value"}' --metadata '{"rawPayload":"true"}'
 ```


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Adds documentation for two flags, --unix-domain-socket and --metadata to Dapr CLI's publish command reference.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
Close #2686
