### PR TITLE
Add default devcontainer for hugo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -141,10 +141,6 @@ RUN set -euo pipefail && \
 VOLUME /src
 WORKDIR /src
 
-# fatal: detected dubious ownership in repository at '/workspaces/dapr-docs'
-# https://stackoverflow.com/a/73100228/5167537
-RUN git config --global --add safe.directory '*'
-
 # expose live-refresh server on default port
 EXPOSE 1313
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,151 @@
+# the following version can be overridden at image build time with --build-arg
+ARG HUGO_VERSION=0.101.0
+# remove/comment the following line completely to compile vanilla Hugo:
+ARG HUGO_BUILD_TAGS=extended
+
+# Hugo >= v0.81.0 requires Go 1.16+ to build
+ARG GO_VERSION=1.18
+ARG ALPINE_VERSION=3.16
+
+# ---
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
+
+# renew global args from above
+# https://docs.docker.com/engine/reference/builder/#scope
+ARG HUGO_VERSION
+ARG HUGO_BUILD_TAGS
+
+ARG CGO=1
+ENV CGO_ENABLED=${CGO}
+ENV GOOS=linux
+ENV GO111MODULE=on
+
+WORKDIR /go/src/github.com/gohugoio/hugo
+
+# gcc/g++ are required to build SASS libraries for extended version
+RUN apk add --update --no-cache \
+      gcc \
+      g++ \
+      musl-dev \
+      git
+
+# clone source from Git repo:
+RUN git clone \
+      --branch "v${HUGO_VERSION}" \
+      --single-branch \
+      --depth 1 \
+      https://github.com/gohugoio/hugo.git ./
+
+# https://github.com/gohugoio/hugo/commit/241481931f5f5f2803cd4be519936b26d8648dfd
+RUN go build -v -ldflags "-X github.com/gohugoio/hugo/common/hugo.vendorInfo=docker" -tags "$HUGO_BUILD_TAGS" && \
+    mv ./hugo /go/bin/hugo
+
+# fix potential stack size problems on Alpine
+# https://github.com/microsoft/vscode-dev-containers/blob/fb63f7e016877e13535d4116b458d8f28012e87f/containers/hugo/.devcontainer/Dockerfile#L19
+RUN go install github.com/yaegashi/muslstack@latest && \
+    muslstack -s 0x800000 /go/bin/hugo
+
+# ---
+
+FROM alpine:${ALPINE_VERSION}
+
+# renew global args from above & pin any dependency versions
+ARG HUGO_VERSION
+# https://github.com/jgm/pandoc/releases
+ARG PANDOC_VERSION=2.18
+# https://github.com/sass/dart-sass-embedded/releases
+ARG DART_SASS_VERSION=1.54.0
+
+LABEL version="${HUGO_VERSION}"
+LABEL repository="https://github.com/jakejarvis/hugo-docker"
+LABEL homepage="https://jarv.is/"
+LABEL maintainer="Jake Jarvis <jake@jarv.is>"
+
+# https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source="https://github.com/jakejarvis/hugo-docker"
+
+# bring over patched binary from build stage
+COPY --from=build /go/bin/hugo /usr/bin/hugo
+
+# this step is intentionally a bit of a mess to minimize the number of layers in the final image
+RUN set -euo pipefail && \
+    if [ "$(uname -m)" = "x86_64" ]; then \
+      ARCH="amd64"; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+      ARCH="arm64"; \
+    else \
+      echo "Unknown build architecture, quitting." && exit 2; \
+    fi && \
+    # alpine packages
+    # libc6-compat & libstdc++ are required for extended SASS libraries
+    # ca-certificates are required to fetch outside resources (like Twitter oEmbeds)
+    apk add --update --no-cache \
+      ca-certificates \
+      tzdata \
+      git \
+      nodejs \
+      npm \
+      go \
+      python3 \
+      py3-pip \
+      ruby \
+      libc6-compat \
+      libstdc++ && \
+    update-ca-certificates && \
+    # npm packages
+    npm install --global --production \
+      yarn \
+      postcss \
+      postcss-cli \
+      autoprefixer \
+      @babel/core \
+      @babel/cli && \
+    npm cache clean --force && \
+    # ruby gems
+    gem install asciidoctor && \
+    # python packages
+    python3 -m pip install --no-cache-dir --upgrade Pygments==2.* docutils && \
+    # manually fetch pandoc binary
+    wget -O pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-${ARCH}.tar.gz && \
+    tar xf pandoc.tar.gz && \
+    mv ./pandoc-${PANDOC_VERSION}/bin/pandoc /usr/bin/ && \
+    chmod +x /usr/bin/pandoc && \
+    rm -rf pandoc.tar.gz pandoc-${PANDOC_VERSION} && \
+    # manually fetch Dart SASS binary (on x64 only)
+    if [ "$ARCH" = "amd64" ]; then \
+      wget -O sass-embedded.tar.gz https://github.com/sass/dart-sass-embedded/releases/download/${DART_SASS_VERSION}/sass_embedded-${DART_SASS_VERSION}-linux-x64.tar.gz && \
+      tar xf sass-embedded.tar.gz && \
+      mv ./sass_embedded/dart-sass-embedded /usr/bin/ && \
+      chmod +x /usr/bin/dart-sass-embedded && \
+      rm -rf sass-embedded.tar.gz sass_embedded; \
+    fi && \
+    # clean up some junk
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* && \
+    # make super duper sure that everything went OK, exit otherwise
+    hugo env && \
+    go version && \
+    node --version && \
+    npm --version && \
+    yarn --version && \
+    postcss --version && \
+    autoprefixer --version && \
+    babel --version && \
+    pygmentize -V && \
+    asciidoctor --version && \
+    pandoc --version && \
+    rst2html.py --version
+
+
+# add site source as volume
+VOLUME /src
+WORKDIR /src
+
+# fatal: detected dubious ownership in repository at '/workspaces/dapr-docs'
+# https://stackoverflow.com/a/73100228/5167537
+RUN git config --global --add safe.directory '*'
+
+# expose live-refresh server on default port
+EXPOSE 1313
+
+ENTRYPOINT ["hugo"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
 	"extensions": [
 		"bungcip.better-toml",
 		"davidanson.vscode-markdownlint",
-        "budparr.language-hugo-vscode"
+        "budparr.language-hugo-vscode",
+		"eamodio.gitlens",
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,10 @@
 		"dockerfile": "Dockerfile",
 	},
 
+	"settings": { 
+		"git.alwaysSignOff": true,
+	},
+
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"bungcip.better-toml",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/hugo
+{
+	"name": "Hugo",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"bungcip.better-toml",
+		"davidanson.vscode-markdownlint",
+        "budparr.language-hugo-vscode"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		1313
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Uncomment to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	//"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	//"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"bungcip.better-toml",
+		"tamasfe.even-better-toml",
 		"davidanson.vscode-markdownlint",
         "budparr.language-hugo-vscode",
 		"eamodio.gitlens",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,8 +18,13 @@
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
+	
+	// Addresses "fatal: detected dubious ownership in repository at '/workspaces/dapr-docs'"
+	// https://stackoverflow.com/a/73100228/5167537
+	"postAttachCommand": "git config --global --add safe.directory '*'",
+
 	// Uncomment to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	//"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,42 @@ git submodule update --init --recursive
 npm install
 ```
 
+## Alternative: Environment setup with devcontainer
+You may have dependencies on your machine setup exactly as you want them and do not want risk adding or updating dependencies that may break your machine for your paying job.  For that, we have a [devcontainer](https://code.visualstudio.com/docs/remote/containers).
+1. Clone this repository
+
+```sh
+git clone https://github.com/dapr/docs.git
+```
+
+2. Open in VSCode 
+```sh
+code .
+```
+
+3. When prompted with, *"Folder contains a Dev Container configuration file. Reopen folder to develop in a container."*, choose `Reopen in Container`
+
+4. In the VSCode terminal, change to daprdocs directory:
+
+```sh
+cd ./daprdocs
+```
+
+5. Update submodules:
+
+```sh
+git submodule update --init --recursive
+```
+
+6. Install npm packages:
+
+```sh
+npm install
+```
+
+You are now ready to run a local server as usual.
+
+
 ## Run local server
 
 1. Make sure you're still in the `daprdocs` directory

--- a/README.md
+++ b/README.md
@@ -62,14 +62,17 @@ npm install
 ```
 
 ## Alternative: Environment setup with devcontainer
+
 You may have dependencies on your machine setup exactly as you want them and do not want risk adding or updating dependencies that may break your machine for your paying job.  For that, we have a [devcontainer](https://code.visualstudio.com/docs/remote/containers).
+
 1. Clone this repository
 
 ```sh
 git clone https://github.com/dapr/docs.git
 ```
 
-2. Open in VSCode 
+2. Open in VSCode
+
 ```sh
 code .
 ```
@@ -95,7 +98,6 @@ npm install
 ```
 
 You are now ready to run a local server as usual.
-
 
 ## Run local server
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

A devcontainer can lower the barrier to entry for new contributors.  For example, the https://github.com/dapr/docs#pre-requisites does not specify versions of dependencies required.  Would someone with Node 1.x or Node 20.x be able to work successfully on this repo?

## Issue reference

#2717