### PR TITLE
fix typo

### DIFF
--- a/daprdocs/content/en/reference/cli/dapr-mtls/dapr-mtls-renew-certificate.md
+++ b/daprdocs/content/en/reference/cli/dapr-mtls/dapr-mtls-renew-certificate.md
@@ -48,7 +48,7 @@ Generates new root and issuer certificates for the Kubernetes cluster with a giv
 ```bash
 dapr mtls renew-certificate -k --valid-until <no of days>
 ```
-Generates new root and issuer certificates for the Kubernetes cluster with a given validity time and restarts the Dapr control place services.
+Generates new root and issuer certificates for the Kubernetes cluster with a given validity time and restarts the Dapr control plane services.
 ```bash
 dapr mtls renew-certificate -k --valid-until <no of days> --restart
 ```


### PR DESCRIPTION

## Description

`Generates new root and issuer certificates for the Kubernetes cluster with a given validity time and restarts the Dapr control place services.`

there is a typo for the words "Dapr control plane",  instead "Dapr control place"

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
#[[issue number](https://github.com/dapr/docs/issues/2750)]
