### PR TITLE
Adding mariner in dapr init docs

### DIFF
--- a/daprdocs/content/en/reference/cli/dapr-init.md
+++ b/daprdocs/content/en/reference/cli/dapr-init.md
@@ -34,6 +34,7 @@ dapr init [flags]
 | `--namespace`, `-n`   |                      | `dapr-system` | The Kubernetes namespace to install Dapr in                                          |
 | `--network`           |                      |               | The Docker network on which to install and deploy the Dapr runtime                                          |
 | `--runtime-version`   |                      | `latest`      | The version of the Dapr runtime to install, for example: `1.0.0`                     |
+| `--image-variant`   |                      |                 | The image variant to use for the Dapr runtime, for example: `mariner`               |
 | `--set`               |                      |               | Configure options on the command line to be passed to the Dapr Helm chart and the Kubernetes cluster upon install. Can specify multiple values in a comma-separated list, for example: `key1=val1,key2=val2`                     |
 | `--slim`, `-s`        |                      | `false`       | Exclude placement service, Redis and Zipkin containers from self-hosted installation |
 | `--timeout`           |                      | `300`         | The wait timeout for the Kubernetes installation                                     |
@@ -57,6 +58,12 @@ You can also specify a specific runtime version. Be default, the latest version 
 
 ```bash
 dapr init --runtime-version 1.4.0
+```
+
+You can also install Dapr with a particular image variant, for example: `mariner`.
+
+```bash
+dapr init --image-variant mariner
 ```
 
 Dapr can also run [Slim self-hosted mode]({{< ref self-hosted-no-docker.md >}}) without Docker.

--- a/daprdocs/content/en/reference/cli/dapr-init.md
+++ b/daprdocs/content/en/reference/cli/dapr-init.md
@@ -60,7 +60,7 @@ You can also specify a specific runtime version. Be default, the latest version 
 dapr init --runtime-version 1.4.0
 ```
 
-You can also install Dapr with a particular image variant, for example: [mariner](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/#using-mariner-based-images).
+You can also install Dapr with a particular image variant, for example: [mariner]({{< ref "kubernetes-deploy.md#using-mariner-based-images" >}}).
 
 ```bash
 dapr init --image-variant mariner

--- a/daprdocs/content/en/reference/cli/dapr-init.md
+++ b/daprdocs/content/en/reference/cli/dapr-init.md
@@ -60,7 +60,7 @@ You can also specify a specific runtime version. Be default, the latest version 
 dapr init --runtime-version 1.4.0
 ```
 
-You can also install Dapr with a particular image variant, for example: `mariner`.
+You can also install Dapr with a particular image variant, for example: [mariner](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/#using-mariner-based-images).
 
 ```bash
 dapr init --image-variant mariner


### PR DESCRIPTION
Signed-off-by: shivam <shivamkm07@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Adding `--image-variant` flag in dapr init docs

## Issue reference

Please reference the issue this PR will close: #2747 
