### PR TITLE
RethinkDB now Beta, but has no transactions, etags

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-rethinkdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-rethinkdb.md
@@ -38,16 +38,7 @@ spec:
 The above example uses secrets as plain strings. It is recommended to use a secret store for the secrets, as described [here]({{< ref component-secrets.md >}}).
 {{% /alert %}}
 
-If you wish to use RethinkDB as an actor store, append the following to the YAML.
-
-```yaml
-  - name: actorStateStore
-    value: "true"
-```
-
-RethinkDB state store supports transactions, so it can be used to persist Dapr Actor state. By default, the state will be stored in table named `daprstate` in the specified database.
-
-Additionally, if the optional `archive` metadata is set to `true`, on each state change, the RethinkDB state store will also log state changes with timestamp in the `daprstate_archive` table. This allows for time series analyses of the state managed by Dapr.
+If the optional `archive` metadata is set to `true`, on each state change, the RethinkDB state store will also log state changes with timestamp in the `daprstate_archive` table. This allows for time series analyses of the state managed by Dapr.
 
 ## Spec metadata fields
 

--- a/daprdocs/data/components/state_stores/generic.yaml
+++ b/daprdocs/data/components/state_stores/generic.yaml
@@ -154,13 +154,13 @@
     query: true
 - component: RethinkDB
   link: setup-rethinkdb
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.9"
   features:
     crud: true
-    transactions: true
-    etag: true
+    transactions: false
+    etag: false
     ttl: false
     query: false
 - component: Zookeeper


### PR DESCRIPTION
RethinkDB is now Beta

RethinkDB does not support transactions, etags