### PR TITLE
Marks components as beta and stable in the upcoming v1.9 release.

### DIFF
--- a/daprdocs/data/components/bindings/azure.yaml
+++ b/daprdocs/data/components/bindings/azure.yaml
@@ -8,9 +8,9 @@
     output: true
 - component: Azure Event Grid
   link: eventgrid
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     input: true
     output: true
@@ -32,9 +32,9 @@
     output: true
 - component: Azure CosmosDB
   link: cosmosdb
-  state: Beta
+  state: Stable
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     input: false
     output: true
@@ -48,9 +48,9 @@
     output: true
 - component: Azure Service Bus Queues
   link: servicebusqueues
-  state: Beta
+  state: Stable
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     input: true
     output: true

--- a/daprdocs/data/components/bindings/azure.yaml
+++ b/daprdocs/data/components/bindings/azure.yaml
@@ -40,9 +40,9 @@
     output: true
 - component: Azure Event Hubs
   link: eventhubs
-  state: Beta
+  state: Stable
   version: v1
-  since: "1.0"
+  since: "1.8"
   features:
     input: true
     output: true

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -32,9 +32,9 @@
     output: true
 - component: Kafka
   link: kafka
-  state: Beta
+  state: Stable
   version: v1
-  since: "1.7"
+  since: "1.8"
   features:
     input: true
     output: true

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -48,9 +48,9 @@
     output: true
 - component: Local Storage
   link: localstorage
-  state: Alpha
+  state: Stable
   version: v1
-  since: "1.1"
+  since: "1.9"
   features:
     input: false
     output: true
@@ -88,7 +88,7 @@
     output: true
 - component: RabbitMQ
   link: rabbitmq
-  state: Beta
+  state: Stable
   version: v1
   since: "1.9"
   features:

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -88,9 +88,9 @@
     output: true
 - component: RabbitMQ
   link: rabbitmq
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.9"
   features:
     input: true
     output: true

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -24,17 +24,17 @@
     output: true
 - component: InfluxDB
   link: influxdb
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     input: false
     output: true
 - component: Kafka
   link: kafka
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     input: true
     output: true
@@ -56,9 +56,9 @@
     output: true
 - component: MQTT
   link: mqtt
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     input: true
     output: true
@@ -96,9 +96,9 @@
     output: true
 - component: Redis
   link: redis
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     input: false
     output: true

--- a/daprdocs/data/components/pubsub/azure.yaml
+++ b/daprdocs/data/components/pubsub/azure.yaml
@@ -1,8 +1,8 @@
 - component: Azure Event Hubs
   link: setup-azure-eventhubs
-  state: Beta
+  state: Stable
   version: v1
-  since: "1.6"
+  since: "1.8"
 - component: Azure Service Bus
   link: setup-azure-servicebus
   state: Stable

--- a/daprdocs/data/components/pubsub/generic.yaml
+++ b/daprdocs/data/components/pubsub/generic.yaml
@@ -1,13 +1,13 @@
 - component: Hazelcast
   link: setup-hazelcast
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.7"
 - component: In Memory
   link: setup-inmemory
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.4"
+  since: "1.7"
 - component: Apache Kafka
   link: setup-apache-kafka
   state: Stable
@@ -25,14 +25,14 @@
   since: "1.4"
 - component: Pulsar
   link: setup-pulsar
-  state: Alpha
-  version: v1
-  since: "1.0"
-- component: MQTT
-  link: setup-mqtt
   state: Beta
   version: v1
-  since: "1.6"
+  since: "1.7"
+- component: MQTT
+  link: setup-mqtt
+  state: Stable
+  version: v1
+  since: "1.7"
 - component: NATS Streaming
   link: setup-nats-streaming
   state: Beta
@@ -40,6 +40,6 @@
   since: "1.0"
 - component: RabbitMQ
   link: setup-rabbitmq
-  state: Beta
+  state: Stable
   version: v1
-  since: "1.6"
+  since: "1.7"

--- a/daprdocs/data/components/secret_stores/generic.yaml
+++ b/daprdocs/data/components/secret_stores/generic.yaml
@@ -5,14 +5,14 @@
   since: "1.0"
 - component: Local environment variables
   link: envvar-secret-store
-  state: Beta
+  state: Stable
   version: v1
-  since: "1.0"
+  since: "1.9"
 - component: Local file
   link: file-secret-store
-  state: Beta
+  state: Stable
   version: v1
-  since: "1.0"
+  since: "1.9"
 - component: Kubernetes secrets
   link: kubernetes-secret-store
   state: Stable

--- a/daprdocs/data/components/state_stores/azure.yaml
+++ b/daprdocs/data/components/state_stores/azure.yaml
@@ -33,9 +33,9 @@
     query: false
 - component: Azure Table Storage
   link: setup-azure-tablestorage
-  state: Alpha
+  state: Stable
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     crud: true
     transactions: false

--- a/daprdocs/data/components/state_stores/azure.yaml
+++ b/daprdocs/data/components/state_stores/azure.yaml
@@ -35,7 +35,7 @@
   link: setup-azure-tablestorage
   state: Stable
   version: v1
-  since: "1.7"
+  since: "1.9"
   features:
     crud: true
     transactions: false

--- a/daprdocs/data/components/state_stores/generic.yaml
+++ b/daprdocs/data/components/state_stores/generic.yaml
@@ -88,9 +88,9 @@
     query: false
 - component: Memcached
   link: setup-memcached
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.9"
   features:
     crud: true
     transactions: false

--- a/daprdocs/data/components/state_stores/generic.yaml
+++ b/daprdocs/data/components/state_stores/generic.yaml
@@ -13,7 +13,7 @@
   link: setup-cassandra
   state: Beta
   version: v1
-  since: "1.9"
+  since: "1.7"
   features:
     crud: true
     transactions: false
@@ -22,7 +22,7 @@
     query: false
 - component: CockroachDB
   link: setup-cockroachdb
-  state: Alpha
+  state: Beta
   version: v1
   since: "1.7"
   features:
@@ -110,9 +110,9 @@
     query: true
 - component: MySQL
   link: setup-mysql
-  state: Alpha
+  state: Beta
   version: v1
-  since: "1.0"
+  since: "1.7"
   features:
     crud: true
     transactions: true


### PR DESCRIPTION
This marks components as beta and stable in the upcoming v1.9 release.

This is based on the new beta/stable component certification as outlined in my proposal which has been agreed upon.

Please merge after https://github.com/dapr/docs/pull/2755