### PR TITLE
Fix typos in MongoDB state configuration file example

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mongodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mongodb.md
@@ -33,9 +33,9 @@ spec:
     value: <REPLACE-WITH-DATABASE-NAME> # Optional. default: "daprStore"
   - name: collectionName
     value: <REPLACE-WITH-COLLECTION-NAME> # Optional. default: "daprCollection"
-  - name: writeconcern
+  - name: writeConcern
     value: <REPLACE-WITH-WRITE-CONCERN> # Optional.
-  - name: readconcern
+  - name: readConcern
     value: <REPLACE-WITH-READ-CONCERN> # Optional.
   - name: operationTimeout
     value: <REPLACE-WITH-OPERATION-TIMEOUT> # Optional. default: "5s"
@@ -65,8 +65,8 @@ If you wish to use MongoDB as an actor store, append the following to the yaml.
 | password           | N        | The password of the user (applicable in conjunction with `host`) | `"password"`
 | databaseName       | N        | The name of the database to use. Defaults to `"daprStore"` | `"daprStore"`
 | collectionName     | N        | The name of the collection to use. Defaults to `"daprCollection"` | `"daprCollection"`
-| writeconcern       | N        | The write concern to use | `"majority"`
-| readconcern        | N        | The read concern to use  | `"majority"`, `"local"`,`"available"`, `"linearizable"`, `"snapshot"`
+| writeConcern       | N        | The write concern to use | `"majority"`
+| readConcern        | N        | The read concern to use  | `"majority"`, `"local"`,`"available"`, `"linearizable"`, `"snapshot"`
 | operationTimeout   | N        | The timeout for the operation. Defaults to `"5s"` | `"5s"`
 | params             | N<sup>**</sup> | Additional parameters to use | `"?authSource=daprStore&ssl=true"`
 


### PR DESCRIPTION
Closes https://github.com/dapr/docs/issues/2774

Signed-off-by: Yash Nisar <yashnisar@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
The MongoDB state store yaml example has a typo for `readconcern` and `writeconcern`. It should be `readConcern` and `writeConcern`.  
See https://github.com/dapr/components-contrib/blob/bcea284c7b0c1a5a07294021a2bb6cc74909da35/state/mongodb/mongodb.go#L47-L48

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
Closes https://github.com/dapr/docs/issues/2774