### PR TITLE
Changed postgres output binding from Alpha to Stable

### DIFF
--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -72,9 +72,9 @@
     output: true
 - component: PostgreSql
   link: postgres
-  state: Alpha
+  state: Stable
   version: v1
-  since: "1.0"
+  since: "1.9"
   features:
     input: false
     output: true


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Changed Postgres binding from Alpha to Stable.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->

#(https://github.com/dapr/components-contrib/issues/1984)
