### PR TITLE
Fix incorrect reference link in Redis Configstore spec

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-configuration-stores/redis-configuration-store.md
+++ b/daprdocs/content/en/reference/components-reference/supported-configuration-stores/redis-configuration-store.md
@@ -9,8 +9,7 @@ aliases:
 
 ## Component format
 
-To setup Redis configuration store create a component of type `configuration.redis`. See [this guide]({{< ref "howto-get-save-state.md#step-1-setup-a-state-store" >}}) on how to create and apply a configuration store configuration.
-
+To setup Redis configuration store create a component of type `configuration.redis`. See [this guide]({{< ref "howto-manage-configuration.md#configure-a-dapr-configuration-store" >}}) on how to create and apply a configuration store configuration.
 ```yaml
 apiVersion: dapr.io/v1alpha1
 kind: Component


### PR DESCRIPTION
Signed-off-by: Sarthak Sharma <sartsharma@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
The redis configstore spec page has an incorrect link to state store setup guide instead of guide for creating and applying config store configuration. 

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->