### PR TITLE
Fix two typo's

### DIFF
--- a/daprdocs/content/en/operations/troubleshooting/common_issues.md
+++ b/daprdocs/content/en/operations/troubleshooting/common_issues.md
@@ -230,9 +230,9 @@ This is usually due to one of the following issues
 
 ## Service invocation is failing and my Dapr service is missing an appId (macOS)
 
-Some organizations will implement software that filters out all UPD traffic, which is what mDNS is based on. Mostly commonly, on MacOS, `Microsoft Content Filter` is the culprit.
+Some organizations will implement software that filters out all UDP traffic, which is what mDNS is based on. Mostly commonly, on MacOS, `Microsoft Content Filter` is the culprit.
 
-In order for mDNS to function properly, ensure `Micorosft Content Filter` is inactive.
+In order for mDNS to function properly, ensure `Microsoft Content Filter` is inactive.
 
 - Open a terminal shell.
 - Type `mdatp system-extension network-filter disable` and hit enter.


### PR DESCRIPTION
Signed-off-by: Maarten Mulders <mthmulders@users.noreply.github.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

I've fixed two obvious typo's.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
