### PR TITLE
Mark Memcached as a stable component.

### DIFF
--- a/daprdocs/data/components/state_stores/generic.yaml
+++ b/daprdocs/data/components/state_stores/generic.yaml
@@ -88,7 +88,7 @@
     query: false
 - component: Memcached
   link: setup-memcached
-  state: Beta
+  state: Stable
   version: v1
   since: "1.9"
   features:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

PR dapr/components-contrib#2116 added certification tests for Memcached state store, turning this component into a stable one.

This PR updates the documentation to reflect that.



## Issue reference

Please reference the issue this PR will close:  dapr/components-contrib#1929

