### PR TITLE
Include the newly added `time` field for CloudEvent

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-cloudevents.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-cloudevents.md
@@ -23,6 +23,7 @@ Dapr implements the following CloudEvents fields when creating a message topic.
 - `specversion`
 - `type`
 - `traceparent`
+- `time`
 - `datacontenttype` (optional)
 
 The following example demonstrates an `orders` topic message sent by Dapr that includes a W3C `traceid` unique to the message, the `data` and the fields for the CloudEvent where the data content is serialized as JSON.
@@ -41,6 +42,7 @@ The following example demonstrates an `orders` topic message sent by Dapr that i
     "datacontenttype": "application/json; charset=utf-8",
     "source": "checkout",
     "type": "com.dapr.event.sent",
+    "time": "2020-09-23T06:23:21Z",
     "traceparent": "00-113ad9c4e42b27583ae98ba698d54255-e3743e35ff56f219-01"
 }
 ```


### PR DESCRIPTION
Closes https://github.com/dapr/docs/issues/2845

Signed-off-by: Yash Nisar <yashnisar@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Include the newly added `time` field for CloudEvent

## Issue reference

https://github.com/dapr/docs/issues/2845
