### PR TITLE
Fix MacOS external tools path.

### DIFF
--- a/daprdocs/content/en/developing-applications/ides/intellij.md
+++ b/daprdocs/content/en/developing-applications/ides/intellij.md
@@ -47,7 +47,7 @@ For versions [2020.1](https://www.jetbrains.com/help/idea/2020.1/tuning-the-ide.
 
 {{% codetab %}}
 ```shell
-~/Library/Application Support/JetBrains/IntelliJIdea2020.1/tools/
+~/Library/Application\ Support/JetBrains/IntelliJIdea2020.1/tools/
 ```
 {{% /codetab %}}
 
@@ -58,7 +58,7 @@ For versions [2020.1](https://www.jetbrains.com/help/idea/2020.1/tuning-the-ide.
 
 Change the version of IntelliJ in the path if needed.
 
-Create or edit the file in `<CONFIG PATH>/tools/External\ Tools.xml` (change IntelliJ version in path if needed). The `<CONFIG PATH>` is OS dependennt as seen above.
+Create or edit the file in `<CONFIG PATH>/tools/External\ Tools.xml` (change IntelliJ version in path if needed). The `<CONFIG PATH>` is OS dependent as seen above.
 
 Add a new `<tool></tool>` entry:
 


### PR DESCRIPTION
Fix MacOS external tools path and grammar.

Signed-off-by: Yossi Spektor <easpex@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Escaped space in MacOS path to IntelliJ external tools file, fixed grammar.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
