### PR TITLE
SecretStores: Fix column ordering in supported components table

### DIFF
--- a/daprdocs/layouts/partials/components/secret-stores.html
+++ b/daprdocs/layouts/partials/components/secret-stores.html
@@ -27,10 +27,10 @@
         </tr>
         {{ range sort $components "component" }}
         <tr>
-            <td align="center">{{ if .features.multipleKeyValuesPerSecret }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
             <td><a href="/reference/components-reference/supported-secret-stores/{{ .link }}/" }}>{{ .component
                     }}</a>
             </td>
+            <td align="center">{{ if .features.multipleKeyValuesPerSecret }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
             <td>{{ .state }}</td>
             <td>{{ .version }}</td>
             <td>{{ .since }}</td>


### PR DESCRIPTION
**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

PR https://github.com/dapr/docs/pull/2863 added a new column for feature multipleKeyValuesPerSecret. But the while the ordering of this new column is OK in the header, it is wrong in the actual table data.

This PR fixes that.


## Issue reference

Please reference the issue this PR will close: #2787
