### PR TITLE
Fix broken link in components-concept page

### DIFF
--- a/daprdocs/content/en/concepts/components-concept.md
+++ b/daprdocs/content/en/concepts/components-concept.md
@@ -11,7 +11,7 @@ Dapr uses a modular design where functionality is delivered as a component. Each
 You can contribute implementations and extend Dapr's component interfaces capabilities via:
 
 - The [components-contrib repository](https://github.com/dapr/components-contrib)
-- [Pluggable components]({{<ref "components-concept.md#pluggable-components" >}}).
+- [Pluggable components]({{<ref "components-concept.md#built-in-and-pluggable-components" >}}).
 
 A building block can use any combination of components. For example, the [actors]({{<ref "actors-overview.md">}}) and the [state management]({{<ref "state-management-overview.md">}}) building blocks both use [state components](https://github.com/dapr/components-contrib/tree/master/state).
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Commit https://github.com/dapr/docs/pull/2875/commits/043a39d3d161a7b44b95a7099ec862329d70eefa shuffled content around and removed a section called "Pluggable Components", breaking an existing link to this section. This PR fixes the link to point to the section now hosting the appropriate content.


## Issue reference

Please reference the issue this PR will close: #2897
