### PR TITLE
Replaces http wasm middleware with more flexible implementation

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -11,10 +11,11 @@ WebAssembly is a way to safely run code compiled in other languages. Runtimes
 execute WebAssembly Modules (Wasm), which are most often binaries with a `.wasm`
 extension.
 
-The Wasm [HTTP middleware]({{< ref middleware.md >}}) allows you to rewrite a
-request URI with custom logic compiled to a Wasm binary. In other words, you
-can extend Dapr using external files that are not pre-compiled into the `daprd`
-binary. Dapr embeds [wazero](https://wazero.io) to accomplish this without CGO.
+The Wasm [HTTP middleware]({{< ref middleware.md >}}) allows you to manipulate
+an incoming request or serve a response with custom logic compiled to a Wasm
+binary. In other words, you can extend Dapr using external files that are not
+pre-compiled into the `daprd` binary. Dapr embeds [wazero](https://wazero.io)
+to accomplish this without CGO.
 
 Wasm modules are loaded from a filesystem path. On Kubernetes, see [mounting
 volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}}) to configure
@@ -28,27 +29,21 @@ kind: Component
 metadata:
   name: wasm
 spec:
-  type: middleware.http.wasm.basic
+  type: middleware.http.wasm
   version: v1
   metadata:
   - name: path
-    value: "./hello.wasm"
-  - name: poolSize
-    value: 1
+    value: "./router.wasm"
 ```
 
 ## Spec metadata fields
 
-Minimally, a user must specify a Wasm binary that contains the custom logic
-used to rewrite requests. An instance of the Wasm binary is not safe to use
-concurrently. The below configuration fields control both the binary to
-instantiate and how large an instance pool to use. A larger pool allows higher
-concurrency while consuming more memory.
+Minimally, a user must specify a Wasm binary implements the [http-handler](https://http-wasm.io/http-handler/).
+How to compile this is described later.
 
 | Field    | Details                                                        | Required | Example        |
 |----------|----------------------------------------------------------------|----------|----------------|
 | path     | A relative or absolute path to the Wasm binary to instantiate. | true     | "./hello.wasm" |
-| poolSize | Number of concurrent instances of the Wasm binary. Default: 10 | false    | 1              |
 
 ## Dapr configuration
 
@@ -64,7 +59,60 @@ spec:
   httpPipeline:
     handlers:
     - name: wasm
-      type: middleware.http.wasm.basic
+      type: middleware.http.wasm
+```
+
+*Note*: WebAssembly middleware uses more resources than native middleware. This
+result in a resource constraint faster than the same logic in native code.
+Production usage should [Control max concurrency]({{< ref control-concurrency.md >}}).
+
+### Generating Wasm
+
+This component lets you manipulate an incoming request or serve a response with
+custom logic compiled using the [http-handler](https://http-wasm.io/http-handler/)
+Application Binary Interface (ABI). The `handle_request` function receives an
+incoming request and can manipulate it or serve a response as necessary.
+
+To compile your Wasm, you must compile source using a http-handler compliant
+guest SDK such as [TinyGo](https://github.com/http-wasm/http-wasm-guest-tinygo).
+
+Here's an example in TinyGo:
+
+```go
+package main
+
+import (
+	"strings"
+
+	"github.com/http-wasm/http-wasm-guest-tinygo/handler"
+	"github.com/http-wasm/http-wasm-guest-tinygo/handler/api"
+)
+
+func main() {
+	handler.HandleRequestFn = handleRequest
+}
+
+// handleRequest implements a simple HTTP router.
+func handleRequest(req api.Request, resp api.Response) (next bool, reqCtx uint32) {
+	// If the URI starts with /host, trim it and dispatch to the next handler.
+	if uri := req.GetURI(); strings.HasPrefix(uri, "/host") {
+		req.SetURI(uri[5:])
+		next = true // proceed to the next handler on the host.
+		return
+	}
+
+	// Serve a static response
+	resp.Headers().Set("Content-Type", "text/plain")
+	resp.Body().WriteString("hello")
+	return // skip the next handler, as we wrote a response.
+}
+```
+
+If using TinyGo, compile as shown below and set the spec metadata field named
+"path" to the location of the output (ex "router.wasm"):
+
+```bash
+tinygo build -o router.wasm -scheduler=none --no-debug -target=wasi router.go`
 ```
 
 ### Generating Wasm
@@ -108,4 +156,4 @@ tinygo build -o example.wasm -scheduler=none --no-debug -target=wasi example.go
 - [Middleware]({{< ref middleware.md >}})
 - [Configuration concept]({{< ref configuration-concept.md >}})
 - [Configuration overview]({{< ref configuration-overview.md >}})
-- [waPC protocol](https://wapc.io/docs/spec/)
+- [Control max concurrency]({{< ref control-concurrency.md >}})


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Currently, http wasm middleware uses a proof of concept simple rewrite function. This replaces it with a faster executing and more complete middleware: http-wasm

## Issue reference

This adds the new middleware, and after that, it has to be linked in dapr/dapr https://github.com/dapr/components-contrib/pull/2239
