### PR TITLE
Updated API logging docs per dapr/dapr#5409

### DIFF
--- a/daprdocs/content/en/operations/monitoring/logging/logs.md
+++ b/daprdocs/content/en/operations/monitoring/logging/logs.md
@@ -6,17 +6,15 @@ weight: 1000
 description: "Understand Dapr logging"
 ---
 
-Dapr produces structured logs to stdout either as a plain text or JSON formatted. By default, all Dapr processes (runtime and control plane services) write to console out in plain text. To enable JSON formatted logs, you need to add the `--log-as-json` command flag when running Dapr processes.
+Dapr produces structured logs to stdout, either in plain-text or JSON-formatted. By default, all Dapr processes (runtime, or sidecar, and all control plane services) write logs to the console (stdout) in plain-text. To enable JSON-formatted logging, you need to add the `--log-as-json` command flag when running Dapr processes.
 
 {{% alert title="Note" color="primary" %}}
 If you want to use a search engine such as Elastic Search or Azure Monitor to search the logs, it is strongly recommended to use JSON-formatted logs which the log collector and search engine can parse using the built-in JSON parser.
 {{% /alert %}}
 
-
-
 ## Log schema
 
-Dapr produces logs based on the following schema.
+Dapr produces logs based on the following schema:
 
 | Field | Description       | Example |
 |-------|-------------------|---------|
@@ -27,53 +25,73 @@ Dapr produces logs based on the following schema.
 | scope | Logging Scope | `dapr.runtime` |
 | instance | Container Name | `dapr-pod-xxxxx` |
 | app_id | Dapr App ID | `dapr-app` |
-| ver | Dapr Runtime Version | `0.5.0` |
+| ver | Dapr Runtime Version | `1.9.0` |
+
+API logging may add other structured fields, as described in the [documentation for API logging]({{< ref "api-logs-troubleshooting.md" >}}).
 
 ## Plain text and JSON formatted logs
 
-* Plain text log examples
+* Plain-text log examples
+
 ```bash
-time="2020-03-11T17:08:48.303776-07:00" level=info msg="starting Dapr Runtime -- version 0.5.0-rc.3 -- commit v0.3.0-rc.0-155-g5dfcf2e" instance=dapr-pod-xxxx scope=dapr.runtime type=log ver=0.5.0-rc.3
-time="2020-03-11T17:08:48.303913-07:00" level=info msg="log level set to: info" instance=dapr-pod-xxxx scope=dapr.runtime type=log ver=0.5.0-rc.3
+time="2022-11-01T17:08:48.303776-07:00" level=info msg="starting Dapr Runtime -- version 1.9.0 -- commit v1.9.0-g5dfcf2e" instance=dapr-pod-xxxx scope=dapr.runtime type=log ver=1.9.0
+time="2022-11-01T17:08:48.303913-07:00" level=info msg="log level set to: info" instance=dapr-pod-xxxx scope=dapr.runtime type=log ver=1.9.0
 ```
 
-* JSON formatted log examples
+* JSON-formatted log examples
+
 ```json
-{"instance":"dapr-pod-xxxx","level":"info","msg":"starting Dapr Runtime -- version 0.5.0-rc.3 -- commit v0.3.0-rc.0-155-g5dfcf2e","scope":"dapr.runtime","time":"2020-03-11T17:09:45.788005Z","type":"log","ver":"0.5.0-rc.3"}
-{"instance":"dapr-pod-xxxx","level":"info","msg":"log level set to: info","scope":"dapr.runtime","time":"2020-03-11T17:09:45.788075Z","type":"log","ver":"0.5.0-rc.3"}
+{"instance":"dapr-pod-xxxx","level":"info","msg":"starting Dapr Runtime -- version 1.9.0 -- commit v1.9.0-g5dfcf2e","scope":"dapr.runtime","time":"2022-11-01T17:09:45.788005Z","type":"log","ver":"1.9.0"}
+{"instance":"dapr-pod-xxxx","level":"info","msg":"log level set to: info","scope":"dapr.runtime","time":"2022-11-01T17:09:45.788075Z","type":"log","ver":"1.9.0"}
 ```
 
-## Configurating plain text or JSON formatted logs
+## Log formats
 
-Dapr supports both plain text and JSON formatted logs. The default format is plain-text. If you want to use plain text with a search engine, you will not need to change any configuring options.
+Dapr supports printing either plain-text, the default, or JSON-formatted logs.
 
-To use JSON formatted logs, you need to add additional configuration  when you install Dapr and deploy your app. The recommendation is to use JSONformatted logs because most log collectors and search engines can parse JSON more easily with built-in parsers.
+To use JSON-formatted logs, you need to add additional configuration options when you install Dapr and when deploy your apps. The recommendation is to use JSON-formatted logs because most log collectors and search engines can parse JSON more easily with built-in parsers.
 
-## Configuring log format in Kubernetes
-The following steps describe how to configure JSON formatted logs for Kubernetes
+## Enabling JSON logging with the Dapr CLI
 
-### Install Dapr to your cluster using the Helm chart
+When using the Dapr CLI to run an application, pass the `--log-as-json` option to enable JSON-formatted logs, for example:
 
-You can enable JSON formatted logs for Dapr system services by adding `--set global.logAsJson=true` option to Helm command.
+```sh
+dapr run \
+  --app-id orderprocessing \
+  --components-path ./components/ \
+  --log-as-json \
+    -- python3 OrderProcessingService.py
+```
+
+## Enabling JSON logging in Kubernetes
+
+The following steps describe how to configure JSON-formatted logs for Kubernetes
+
+### Dapr control plane
+
+All services in the Dapr control plane (such as `operator`, `sentry`, etc) support a `--log-as-json` option to enable JSON-formatted logging.
+
+If you're deploying Dapr to Kubernetes using a Helm chart, you can enable JSON-formatted logs for Dapr system services by passing the `--set global.logAsJson=true` option; for example:
 
 ```bash
-helm install dapr dapr/dapr --namespace dapr-system --set global.logAsJson=true
+helm upgrade --install dapr \
+  dapr/dapr \
+  --namespace dapr-system \
+  --set global.logAsJson=true
 ```
 
-### Enable JSON formatted log for Dapr sidecars
+### Enable JSON-formatted log for Dapr sidecars
 
-You can enable JSON-formatted logs in Dapr sidecars activated by the Dapr sidecar-injector service by adding the `dapr.io/log-as-json: "true"` annotation to the deployment.
+You can enable JSON-formatted logs in Dapr sidecars by adding the `dapr.io/log-as-json: "true"` annotation to the deployment, for example:
 
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pythonapp
-  namespace: default
   labels:
     app: python
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: python
@@ -84,29 +102,30 @@ spec:
       annotations:
         dapr.io/enabled: "true"
         dapr.io/app-id: "pythonapp"
+        # This enables JSON-formatted logging
         dapr.io/log-as-json: "true"
 ...
 ```
 
 ## API Logging
 
-API logging enables you to see the API calls from your application to the Dapr sidecar to debug issues. You can combine both Dapr API logging with Dapr log events. See [configure and view Dapr Logs]({{< ref "logs-troubleshooting.md" >}}) and [configure and view Dapr API Logs]({{< ref "api-logs-troubleshooting.md" >}}) for more information.
+API logging enables you to see the API calls your application makes to the Dapr sidecar, to debug issues or monitor the behavior of your application. You can combine both Dapr API logging with Dapr log events. See [configure and view Dapr Logs]({{< ref "logs-troubleshooting.md" >}}) and [configure and view Dapr API Logs]({{< ref "api-logs-troubleshooting.md" >}}) for more information.
 
 ## Log collectors
 
-If you run Dapr in a Kubernetes cluster, [Fluentd](https://www.fluentd.org/) is a popular container log collector. You can use Fluentd with a [json parser plugin](https://docs.fluentd.org/parser/json) to parse Dapr JSON formatted logs. This [how-to]({{< ref fluentd.md >}}) shows how to configure the Fluentd in your cluster.
+If you run Dapr in a Kubernetes cluster, [Fluentd](https://www.fluentd.org/) is a popular container log collector. You can use Fluentd with a [JSON parser plugin](https://docs.fluentd.org/parser/json) to parse Dapr JSON-formatted logs. This [how-to]({{< ref fluentd.md >}}) shows how to configure Fluentd in your cluster.
 
-If you are using the Azure Kubernetes Service, you can use the default OMS Agent to collect logs with Azure Monitor without needing to install Fluentd.
+If you are using Azure Kubernetes Service, you can use the built-in agent to collect logs with Azure Monitor without needing to install Fluentd.
 
 ## Search engines
 
-If you use [Fluentd](https://www.fluentd.org/), we recommend to using Elastic Search and Kibana. This [how-to]({{< ref fluentd.md >}}) shows how to set up Elastic Search and Kibana in your Kubernetes cluster.
+If you use [Fluentd](https://www.fluentd.org/), we recommend using Elastic Search and Kibana. This [how-to]({{< ref fluentd.md >}}) shows how to set up Elastic Search and Kibana in your Kubernetes cluster.
 
-If you are using the Azure Kubernetes Service, you can use [Azure monitor for containers](https://docs.microsoft.com/azure/azure-monitor/insights/container-insights-overview) without indstalling any additional monitoring tools. Also read [How to enable Azure Monitor for containers](https://docs.microsoft.com/azure/azure-monitor/insights/container-insights-onboard)
+If you are using the Azure Kubernetes Service, you can use [Azure Monitor for containers](https://docs.microsoft.com/azure/azure-monitor/insights/container-insights-overview) without installing any additional monitoring tools. Also read [How to enable Azure Monitor for containers](https://docs.microsoft.com/azure/azure-monitor/insights/container-insights-onboard)
 
 ## References
 
-- [How-to : Set up Fleuntd, Elastic search, and Kibana]({{< ref fluentd.md >}})
-- [How-to : Set up Azure Monitor in Azure Kubernetes Service]({{< ref azure-monitor.md >}})
+- [How-to: Set up Fleuntd, Elastic search, and Kibana]({{< ref fluentd.md >}})
+- [How-to: Set up Azure Monitor in Azure Kubernetes Service]({{< ref azure-monitor.md >}})
 - [Configure and view Dapr Logs]({{< ref "logs-troubleshooting.md" >}})
 - [Configure and view Dapr API Logs]({{< ref "api-logs-troubleshooting.md" >}})

--- a/daprdocs/content/en/operations/troubleshooting/api-logs-troubleshooting.md
+++ b/daprdocs/content/en/operations/troubleshooting/api-logs-troubleshooting.md
@@ -6,54 +6,54 @@ weight: 3000
 description: "Understand how API logging works in Dapr and how to view logs"
 ---
 
-API logging enables you to see the API calls from your application to the Dapr sidecar and debug issues as a result when the flag is set. You can also combine Dapr API logging with Dapr log events (see [configure and view Dapr Logs]({{< ref "logs-troubleshooting.md" >}}) into the output, if you want to use the logging capabilities together.
+API logging enables you to see the API calls your application makes to the Dapr sidecar. This is useful to monitor your application's behavior or for other debugging purposes. You can also combine Dapr API logging with Dapr log events (see [configure and view Dapr Logs]({{< ref "logs-troubleshooting.md" >}}) into the output if you want to use the logging capabilities together.
 
 ## Overview
 
-The default value of the flag is false.
+API logging is disabled by default.
 
-To enable API logging, you can use the `--enable-api-logging` command-line option. For example:
+To enable API logging, you can use the `--enable-api-logging` command-line option when starting the `daprd` process. For example:
 
 ```bash
 ./daprd --enable-api-logging
 ```
 
-This starts the Dapr runtime with API logging.
+## Configuring API logging in self-hosted mode
 
-## Configuring API logging in self hosted mode
-
-To enable API logging when running your app with the Dapr CLI, pass the `enable-api-logging` flag:
+To enable API logging when running your app with the Dapr CLI, pass the `--enable-api-logging` flag:
 
 ```bash
-dapr run --enable-api-logging node myapp.js
+dapr run \
+  --enable-api-logging \
+  -- node myapp.js
 ```
 
-### Viewing API logs in self hosted mode
+### Viewing API logs in self-hosted mode
 
 When running Dapr with the Dapr CLI, both your app's log output and the Dapr runtime log output are redirected to the same session, for easy debugging.
 
 The example below shows some API logs:
 
 ```bash
-dapr run --enable-api-logging -- node myapp.js
+$ dapr run --enable-api-logging -- node myapp.js
 
 ℹ️  Starting Dapr with id order-processor on port 56730
 ✅  You are up and running! Both Dapr and your app logs will appear here.
 .....
-INFO[0000] HTTP API Called: POST /v1.0/state/statestore  app_id=order-processor instance=QTM-SWATHIKIL-1.redmond.corp.microsoft.com scope=dapr.runtime.http type=log ver=edge
+INFO[0000] HTTP API Called app_id=order-processor instance=mypc method="POST /v1.0/state/{name}" scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
 == APP == INFO:root:Saving Order: {'orderId': '483'}
-INFO[0000] HTTP API Called: GET /v1.0/state/statestore/483  app_id=order-processor instance=QTM-SWATHIKIL-1.redmond.corp.microsoft.com scope=dapr.runtime.http type=log ver=edge
+INFO[0000] HTTP API Called app_id=order-processor instance=mypc method="GET /v1.0/state/{name}/{key}" scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
 == APP == INFO:root:Getting Order: {'orderId': '483'}
-INFO[0000] HTTP API Called: DELETE /v1.0/state/statestore  app_id=order-processor instance=QTM-SWATHIKIL-1.redmond.corp.microsoft.com scope=dapr.runtime.http type=log ver=edge
+INFO[0000] HTTP API Called app_id=order-processor instance=mypc method="DELETE /v1.0/state/{name}" scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
 == APP == INFO:root:Deleted Order: {'orderId': '483'}
-INFO[0000] HTTP API Called: PUT /v1.0/metadata/cliPID    app_id=order-processor instance=QTM-SWATHIKIL-1.redmond.corp.microsoft.com scope=dapr.runtime.http type=log ver=edge
+INFO[0000] HTTP API Called app_id=order-processor instance=mypc method="PUT /v1.0/metadata/cliPID" scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
 ```
 
 ##  Configuring API logging in Kubernetes
 
-You can enable the API logs for every sidecar by providing the following annotation in your pod spec template:
+You can enable the API logs for a sidecar by adding the following annotation in your pod spec template:
 
-```yml
+```yaml
 annotations:
   dapr.io/enable-api-logging: "true"
 ```
@@ -71,9 +71,9 @@ kubectl logs <pod_name> daprd -n <name_space>
 The example below show `info` level API logging in Kubernetes.
 
 ```bash
-time="2022-03-16T18:32:02.487041454Z" level=info msg="HTTP API Called: GET /v1.0/invoke/invoke-receiver/method/my-method" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http type=log ver=edge
-time="2022-03-16T18:32:02.698387866Z" level=info msg="HTTP API Called: GET /v1.0/invoke/invoke-receiver/method/my-method" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http type=log ver=edge
-time="2022-03-16T18:32:02.917629403Z" level=info msg="HTTP API Called: GET /v1.0/invoke/invoke-receiver/method/my-method" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http type=log ver=edge
-time="2022-03-16T18:32:03.137830112Z" level=info msg="HTTP API Called: GET /v1.0/invoke/invoke-receiver/method/my-method" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http type=log ver=edge
-time="2022-03-16T18:32:03.359097916Z" level=info msg="HTTP API Called: GET /v1.0/invoke/invoke-receiver/method/my-method" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http type=log ver=edge
+time="2022-03-16T18:32:02.487041454Z" level=info msg="HTTP API Called" method="POST /v1.0/invoke/{id}/method/{method:*}" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
+time="2022-03-16T18:32:02.698387866Z" level=info msg="HTTP API Called" method="POST /v1.0/invoke/{id}/method/{method:*}" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
+time="2022-03-16T18:32:02.917629403Z" level=info msg="HTTP API Called" method="POST /v1.0/invoke/{id}/method/{method:*}" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
+time="2022-03-16T18:32:03.137830112Z" level=info msg="HTTP API Called" method="POST /v1.0/invoke/{id}/method/{method:*}" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
+time="2022-03-16T18:32:03.359097916Z" level=info msg="HTTP API Called" method="POST /v1.0/invoke/{id}/method/{method:*}" app_id=invoke-caller instance=invokecaller-f4f949886-cbnmt scope=dapr.runtime.http-info type=log useragent=Go-http-client/1.1 ver=edge
 ```


### PR DESCRIPTION
The format of API logs changed with  dapr/dapr#5409 . This PR updates the docs to reflect the updated format.

PS: In the process, I also reworded the page about logs, improving the language in a bunch of places.