### PR TITLE
Update docs runtime version to 1.9.3

### DIFF
--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -34,6 +34,7 @@ The table below shows the versions of Dapr releases that have been tested togeth
 
 | Release date | Runtime     | CLI  | SDKs  | Dashboard  | Status |
 |--------------------|:--------:|:--------|---------|---------|---------|
+| November 4th 2022 | 1.9.3</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.1 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported (current) |
 | November 1st 2022 | 1.9.2</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.1 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported (current) |
 | October 26th 2022 | 1.9.1</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.1 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported |
 | October 13th 2022 | 1.9.0</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.3 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported |
@@ -74,21 +75,18 @@ General guidance on upgrading can be found for [self hosted mode]({{< ref self-h
 
 |  Current Runtime version | Must upgrade through  | Target Runtime version   |
 |--------------------------|-----------------------|------------------------- |
-| 1.4.0 to 1.4.2           |                   N/A |                    1.4.4 |
-|                          |                 1.4.4 |                    1.5.2 |
-|                          |                 1.5.2 |                    1.6.0 |
-|                          |                 1.6.0 |                    1.6.2 |
-|                          |                 1.6.0 |                    1.7.4 |
-|                          |                 1.6.0 |                    1.7.5 |
 | 1.5.0 to 1.5.2           |                   N/A |                    1.6.0 |
 |                          |                 1.6.0 |                    1.6.2 |
-|                          |                 1.6.0 |                    1.7.4 |
-|                          |                 1.6.0 |                    1.7.5 |
-| 1.6.0                    |                   N/A |                    1.6.2 |
-| 1.6.0                    |                   N/A |                    1.7.5 |
-| 1.7.0 to 1.7.5           |                   N/A |                    1.8.0 |
-| 1.8.0                    |                   N/A |                    1.8.6 |
-| 1.9.0                    |                   N/A |                    1.9.2 |
+|                          |                 1.6.2 |                    1.7.5 |
+|                          |                 1.7.5 |                    1.8.6 |
+|                          |                 1.8.6 |                    1.9.3 |
+| 1.6.0 to 1.6.2           |                   N/A |                    1.7.5 |
+|                          |                 1.7.5 |                    1.8.6 |
+|                          |                 1.8.6 |                    1.9.3 |
+| 1.7.0 to 1.7.5           |                   N/A |                    1.8.6 |
+|                          |                 1.8.6 |                    1.9.3 |
+| 1.8.0 to 1.8.6           |                   N/A |                    1.9.3 |
+| 1.9.0                    |                   N/A |                    1.9.3 |
 
 ## Breaking changes and deprecations
 

--- a/daprdocs/layouts/shortcodes/dapr-latest-version.html
+++ b/daprdocs/layouts/shortcodes/dapr-latest-version.html
@@ -1,1 +1,1 @@
-{{- if .Get "short" }}1.9{{ else if .Get "long" }}1.9.0{{ else if .Get "cli" }}1.9.0{{ else }}1.9.0{{ end -}}
+{{- if .Get "short" }}1.9{{ else if .Get "long" }}1.9.3{{ else if .Get "cli" }}1.9.0{{ else }}1.9.3{{ end -}}


### PR DESCRIPTION
Signed-off-by: Nick Greenfield <nigreenf@microsoft.com>

Thank you for helping make the Dapr documentation better!

Update docs to 1.9.3 version. 