### PR TITLE
Use Google Analytics 4 ID for v1.9

### DIFF
--- a/daprdocs/config.toml
+++ b/daprdocs/config.toml
@@ -27,7 +27,7 @@ disableKinds = ["taxonomy", "term"]
 
 # Google Analytics
 [services.googleAnalytics]
-id = "UA-149338238-3"
+id = "G-60C6Q1ETC1"
 
 # Mounts
 [module]


### PR DESCRIPTION
## Issue reference

- Contributes to #2861

## Description

This is the first PR in a series, as we migrate to the new Dapr GA4 site tag.

**IMPORTANT**:
> While we update the GA ID through the various doc versions/branches incrementally, I'll have to [connect] the GA4 ID to the original docs UA ID. Since the GA4 ID is _the_ ID for all Dapr things web, this means that **all web events**, including page_views etc. **from the main website, will be sent to the UA ID**.
>
> Please **confirm that this is ok with you** @berndverst et al.

/cc @berndverst @nate-double-u

[connect]: https://support.google.com/analytics/answer/9973999
