### PR TITLE
Azurite queue default port is 10001

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/storagequeues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/storagequeues.md
@@ -32,7 +32,7 @@ spec:
 # - name: decodeBase64
 #   value: "false"
 # - name: endpoint
-#   value: "http://127.0.0.1:10000"
+#   value: "http://127.0.0.1:10001"
 ```
 
 {{% alert title="Warning" color="warning" %}}
@@ -48,7 +48,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | `queueName` | Y | Input/Output | The name of the Azure Storage queue | `"myqueue"` |
 | `ttlInSeconds` | N | Output | Parameter to set the default message time to live. If this parameter is omitted, messages will expire after 10 minutes. See [also](#specifying-a-ttl-per-message) | `"60"` |
 | `decodeBase64` | N | Output | Configuration to decode base64 file content before saving to Blob Storage. (In case of saving a file with binary content). `true` is the only allowed positive value. Other positive variations like `"True", "1"` are not acceptable. Defaults to `false` | `true`, `false` |
-| `endpoint` | N | Input/Output | Optional custom endpoint URL. This is useful when using the [Azurite emulator](https://github.com/Azure/azurite) or when using custom domains for Azure Storage (although this is not officially supported). The endpoint must be the full base URL, including the protocol (`http://` or `https://`), the IP or FQDN, and optional port. | `"http://127.0.0.1:10000"` or `"https://accountName.queue.example.com"` |
+| `endpoint` | N | Input/Output | Optional custom endpoint URL. This is useful when using the [Azurite emulator](https://github.com/Azure/azurite) or when using custom domains for Azure Storage (although this is not officially supported). The endpoint must be the full base URL, including the protocol (`http://` or `https://`), the IP or FQDN, and optional port. | `"http://127.0.0.1:10001"` or `"https://accountName.queue.example.com"` |
 
 ### Azure Active Directory (Azure AD) authentication
 


### PR DESCRIPTION
fix: Update azurite port to 10001 instead of 10000

See [docs](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio#queue-listening-port-configuration)

Signed-off-by: ThumNet <jeffreytummers@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
