### PR TITLE
Change Cron Binding from `input/output` to `input` binding

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cron.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cron.md
@@ -29,7 +29,7 @@ spec:
 
 | Field              | Required | Binding support |  Details | Example |
 |--------------------|:--------:|-------|--------|---------|
-| schedule | Y | Input/Output |  The valid cron schedule to use. See [this](#schedule-format) for more details | `"@every 15m"`
+| schedule | Y | Input|  The valid cron schedule to use. See [this](#schedule-format) for more details | `"@every 15m"`
 
 ### Schedule Format
 
@@ -74,11 +74,7 @@ When running this code, note that the `/scheduled` endpoint is called every five
 
 ## Binding support
 
-This component supports both **input and output** binding interfaces.
-
-This component supports **output binding** with the following operations:
-
-- `delete`
+This component supports **input** binding interface.
 
 ## Related links
 

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -8,12 +8,12 @@
     output: true
 - component: Cron (Scheduler)
   link: cron
-  state: Alpha
+  state: Stable
   version: v1
-  since: "1.0"
+  since: "1.10"
   features:
     input: true
-    output: true
+    output: false
 - component: GraphQL
   link: graghql
   state: Alpha
@@ -45,7 +45,7 @@
   since: "1.0"
   features:
     input: true
-    output: true
+    output: false
 - component: Local Storage
   link: localstorage
   state: Stable


### PR DESCRIPTION
Signed-off-by: Sarthak Sharma <sartsharma@microsoft.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Changing cron binding to input only binding to certify it as a stable component 
See linked issue and Certification Tests PR for reference

Also fix Kubernetes Events Binding wrongly listing having output binding support

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->

https://github.com/dapr/components-contrib/issues/2308
https://github.com/dapr/components-contrib/pull/2191/

