### PR TITLE
Update Kubernetes job page

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-job.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-job.md
@@ -14,9 +14,12 @@ To address this issue the Dapr sidecar has an endpoint to `Shutdown` the sidecar
 
 When running a basic [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) you will need to call the `/shutdown` endpoint for the sidecar to gracefully stop and the job will be considered `Completed`.
 
-When a job is finish without calling `Shutdown` your job will be in a `NotReady` state with only the `daprd` container running endlessly.
+When a job is finished without calling `Shutdown`, your job will be in a `NotReady` state with only the `daprd` container running endlessly.
 
-Be sure and use the *POST* HTTP verb when calling the shutdown API.
+Stopping the dapr sidecar will cause its readiness and liveness probes to fail in your container because the dapr sidecar was shutdown.
+To prevent Kubernetes from trying to restart your job, set your job's `restartPolicy` to `Never`.
+
+Be sure to use the *POST* HTTP verb when calling the shutdown HTTP API.
 
 ```yaml
 apiVersion: batch/v1
@@ -37,7 +40,7 @@ spec:
       restartPolicy: Never
 ```
 
-You can also call the `Shutdown` from any of the Dapr SDK
+You can also call the `Shutdown` from any of the Dapr SDKs
 
 ```go
 package main


### PR DESCRIPTION
Add a paragraph mentioning `restartPolicy` needs to be set to `Never` for successful job completion.

Signed-off-by: Renato L. de F. Cunha <renatocunha@acm.org>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add a paragraph mentioning `restartPolicy` needs to be set to `Never` for successful job completion.

## Issue reference

#2972
