### PR TITLE
Update version to 1.9.5

### DIFF
--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -34,9 +34,10 @@ The table below shows the versions of Dapr releases that have been tested togeth
 
 | Release date | Runtime     | CLI  | SDKs  | Dashboard  | Status |
 |--------------------|:--------:|:--------|---------|---------|---------|
-| November 17th 2022 | 1.94</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.3 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported (current) |
-| November 4th 2022 | 1.9.3</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.3 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported (current) |
-| November 1st 2022 | 1.9.2</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.1 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported (current) |
+| December 2nd 2022 | 1.9.5</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.3 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported (current) |
+| November 17th 2022 | 1.9.4</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.3 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported |
+| November 4th 2022 | 1.9.3</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.3 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported |
+| November 1st 2022 | 1.9.2</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.1 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported |
 | October 26th 2022 | 1.9.1</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.1 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported |
 | October 13th 2022 | 1.9.0</br>  | 1.9.1 | Java 1.7.0 </br>Go 1.6.0 </br>PHP 1.1.0 </br>Python 1.8.3 </br>.NET 1.9.0 </br>JS 2.4.2 | 0.11.0 | Supported |
 | October 26th 2022 | 1.8.6</br>  | 1.8.1 | Java 1.6.0 </br>Go 1.5.0 </br>PHP 1.1.0 </br>Python 1.7.0 </br>.NET 1.8.0 </br>JS 2.3.0 | 0.11.0 | Supported |
@@ -80,14 +81,14 @@ General guidance on upgrading can be found for [self hosted mode]({{< ref self-h
 |                          |                 1.6.0 |                    1.6.2 |
 |                          |                 1.6.2 |                    1.7.5 |
 |                          |                 1.7.5 |                    1.8.6 |
-|                          |                 1.8.6 |                    1.9.4 |
+|                          |                 1.8.6 |                    1.9.5 |
 | 1.6.0 to 1.6.2           |                   N/A |                    1.7.5 |
 |                          |                 1.7.5 |                    1.8.6 |
-|                          |                 1.8.6 |                    1.9.4 |
+|                          |                 1.8.6 |                    1.9.5 |
 | 1.7.0 to 1.7.5           |                   N/A |                    1.8.6 |
-|                          |                 1.8.6 |                    1.9.4 |
-| 1.8.0 to 1.8.6           |                   N/A |                    1.9.4 |
-| 1.9.0                    |                   N/A |                    1.9.4 |
+|                          |                 1.8.6 |                    1.9.5 |
+| 1.8.0 to 1.8.6           |                   N/A |                    1.9.5 |
+| 1.9.0                    |                   N/A |                    1.9.5 |
 
 ## Breaking changes and deprecations
 

--- a/daprdocs/layouts/shortcodes/dapr-latest-version.html
+++ b/daprdocs/layouts/shortcodes/dapr-latest-version.html
@@ -1,1 +1,1 @@
-{{- if .Get "short" }}1.9{{ else if .Get "long" }}1.9.4{{ else if .Get "cli" }}1.9.0{{ else }}1.9.4{{ end -}}
+{{- if .Get "short" }}1.9{{ else if .Get "long" }}1.9.5{{ else if .Get "cli" }}1.9.0{{ else }}1.9.5{{ end -}}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

Update latest version of runtime to 1.9.5
