### PR TITLE
Add lightweight analytics pixel to dapr website

### DIFF
--- a/daprdocs/layouts/partials/footer.html
+++ b/daprdocs/layouts/partials/footer.html
@@ -24,6 +24,7 @@
       </div>
     </div>
   </div>
+  <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=4848fb3b-3edb-4329-90a9-a9d79afff054" />
 </footer>
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">


### PR DESCRIPTION
Signed-off-by: Arjun Devarajan <arjun@scarf.sh>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
It didn't seem appropriate for an alt text here but let me know if you'd like me to add one. 
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This analytics pixel provides high-level web traffic insights for project maintainers so they can better understand how docs are being read and used. This pixel does not use cookies (or JavaScript at all) and is GDPR-compliant. It is a clear 1x1 pixel that won't affect page rendering or load times.

## Issue reference

This is not referencing any existing issue because it is a result of direct conversation with Mark and Yaron at dapr but let me know if you'd like me to create an issue first. 