### PR TITLE
fix links in wasm middleware docs

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -14,10 +14,10 @@ extension.
 The Wasm [HTTP middleware]({{< ref middleware.md >}}) allows you to rewrite a
 request URI with custom logic compiled to a Wasm binary. In other words, you
 can extend Dapr using external files that are not pre-compiled into the `daprd`
-binary. Dapr embeds [wazero][https://wazero.io] to accomplish this without CGO.
+binary. Dapr embeds [wazero](https://wazero.io) to accomplish this without CGO.
 
 Wasm modules are loaded from a filesystem path. On Kubernetes, see [mounting
-volumes to the Dapr sidecar]({{> kubernetes-volume-mounts.md >}}) to configure
+volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}}) to configure
 a filesystem mount that can contain Wasm modules.
 
 ## Component format


### PR DESCRIPTION
Signed-off-by: syuparn <s.hello.spagetti@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

This fixes links in WASM middleware docs ([page](https://docs.dapr.io/reference/components-reference/supported-middleware/middleware-wasm/))

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->

close: #3028 
