### PR TITLE
Fixed issues with a11y on component list pages

### DIFF
--- a/daprdocs/layouts/partials/components/bindings.html
+++ b/daprdocs/layouts/partials/components/bindings.html
@@ -20,11 +20,22 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-bindings/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-bindings/{{ .link }}/">{{ .component }}</a>
         </td>
-        <td align="center">{{ if .features.input }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.output }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
+        <td align="center">
+            {{ if .features.input }}
+                <span role="img" aria-label="Input binding supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Input binding not supported" aria-label="Input binding not supported">
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.output }}
+                <span role="img" aria-label="Output binding supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Output binding not supported" aria-label="Output binding not supported">
+            {{ end }}
+        </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>
         <td>{{ .since }}</td>

--- a/daprdocs/layouts/partials/components/configuration-stores.html
+++ b/daprdocs/layouts/partials/components/configuration-stores.html
@@ -13,8 +13,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-configuration-stores/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-configuration-stores/{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>

--- a/daprdocs/layouts/partials/components/description.html
+++ b/daprdocs/layouts/partials/components/description.html
@@ -1,7 +1,6 @@
 <p>Table captions:</p>
 <blockquote>
-    <p><code>Status</code>: <a href="/operations/components/certification-lifecycle/">Component
-            certification</a> status</p>
+    <p><code>Status</code>: <a href="/operations/components/certification-lifecycle/">component certification</a> status</p>
 </blockquote>
 <ul>
     <li><a href="/operations/components/certification-lifecycle/#alpha">Alpha</a></li>
@@ -9,8 +8,8 @@
     <li><a href="/operations/components/certification-lifecycle/#stable">Stable</a></li>
 </ul>
 <blockquote>
-    <p><code>Since</code>: defines from which Dapr Runtime version, the component is in the current status</p>
+    <p><code>Since</code>: the version of the Dapr Runtime in which the component first moved to the current status</p>
 </blockquote>
 <blockquote>
-    <p><code>Component version</code>: defines the version of the component</p>
+    <p><code>Component version</code>: the version of the component</p>
 </blockquote>

--- a/daprdocs/layouts/partials/components/locks.html
+++ b/daprdocs/layouts/partials/components/locks.html
@@ -13,8 +13,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-locks/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-locks/{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>

--- a/daprdocs/layouts/partials/components/middleware.html
+++ b/daprdocs/layouts/partials/components/middleware.html
@@ -13,8 +13,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .description | markdownify}}</td>
         <td>{{ .state }}</td>

--- a/daprdocs/layouts/partials/components/name-resolution.html
+++ b/daprdocs/layouts/partials/components/name-resolution.html
@@ -15,8 +15,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-name-resolution/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-name-resolution/{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>

--- a/daprdocs/layouts/partials/components/pubsub.html
+++ b/daprdocs/layouts/partials/components/pubsub.html
@@ -16,8 +16,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-pubsub/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-pubsub/{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>

--- a/daprdocs/layouts/partials/components/secret-stores.html
+++ b/daprdocs/layouts/partials/components/secret-stores.html
@@ -27,10 +27,16 @@
         </tr>
         {{ range sort $components "component" }}
         <tr>
-            <td><a href="/reference/components-reference/supported-secret-stores/{{ .link }}/" }}>{{ .component
-                    }}</a>
+            <td>
+                <a href="/reference/components-reference/supported-secret-stores/{{ .link }}/">{{ .component }}</a>
             </td>
-            <td align="center">{{ if .features.multipleKeyValuesPerSecret }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
+            <td align="center">
+                {{ if .features.multipleKeyValuesPerSecret }}
+                    <span role="img" aria-label="Multiple Key-Values Per Secret: Supported">✅</span>
+                {{else}}
+                    <img src="/images/emptybox.png" alt="Multiple Key-Values Per Secret: Not supported" aria-label="Multiple Key-Values Per Secret: Not supported" />
+                {{ end }}
+            </td>
             <td>{{ .state }}</td>
             <td>{{ .version }}</td>
             <td>{{ .since }}</td>

--- a/daprdocs/layouts/partials/components/state-stores.html
+++ b/daprdocs/layouts/partials/components/state-stores.html
@@ -23,16 +23,51 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-state-stores/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td>
+            <a href="/reference/components-reference/supported-state-stores/{{ .link }}/">{{ .component }}</a>
         </td>
-        <td align="center">{{ if .features.crud }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.transactions }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.etag }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.ttl }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if (and .features.transactions .features.etag) }}✅{{else}}<img
-                src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.query }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
+        <td align="center">
+            {{ if .features.crud }}
+                <span role="img" aria-label="CRUD: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="CRUD: Not supported" aria-label="CRUD: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.transactions }}
+                <span role="img" aria-label="Transactions: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Transactions: Not supported" aria-label="Transactions: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.etag }}
+                <span role="img" aria-label="ETag: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="ETag: Not supported" aria-label="ETag: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.ttl }}
+                <span role="img" aria-label="TTL: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="TTL: Not supported" aria-label="TTL: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if (and .features.transactions .features.etag) }}
+                <span role="img" aria-label="Actors: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Actors: Not supported" aria-label="Actors: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.query }}
+                <span role="img" aria-label="Query: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Query: Not supported" aria-label="Query: Not supported" />
+            {{ end }}
+        </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>
         <td>{{ .since }}</td>


### PR DESCRIPTION
While working on something unrelated, I found some issues in the pages that listed components. Mainly related to accessibility (images and emojis used to convey important information but did not have the required tags for screen readers), but a few other fixes are in this PR too.