### PR TITLE
[1.10] Docs for Cloudflare components

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cfqueues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cfqueues.md
@@ -1,15 +1,17 @@
 ---
 type: docs
-title: "Cloudflare Workers KV"
-linkTitle: "Cloudflare Workers KV"
-description: Detailed information on the Cloudflare Workers KV state store component
+title: "Cloudflare Queues bindings spec"
+linkTitle: "Cloudflare Queues"
+description: "Detailed documentation on the Cloudflare Queues component"
 aliases:
-  - "/operations/components/setup-state-store/supported-state-stores/setup-cloudflare-workerskv/"
+  - "/operations/components/setup-bindings/supported-bindings/cfqueues/"
 ---
 
-## Create a Dapr component
+## Component format
 
-To setup a [Cloudflare Workers KV](https://developers.cloudflare.com/workers/learning/how-kv-works/) state store, create a component of type `state.cloudflare.workerskv`. See [this guide]({{< ref "howto-get-save-state.md#step-1-setup-a-state-store" >}}) on how to create and apply a state store configuration.
+This output binding for Dapr allows interacting with [Cloudflare Queues](https://developers.cloudflare.com/queues/) to **publish** new messages. It is currently not possible to consume messages from a Queue using Dapr.
+
+To setup a Cloudflare Queues binding, create a component of type `bindings.cloudflare.queues`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.
 
 ```yaml
 apiVersion: dapr.io/v1alpha1
@@ -17,13 +19,13 @@ kind: Component
 metadata:
   name: <NAME>
 spec:
-  type: state.cloudflare.workerskv
+  type: bindings.cloudflare.queues
   version: v1
   # Increase the initTimeout if Dapr is managing the Worker for you
   initTimeout: "120s"
   metadata:
-    # ID of the Workers KV namespace (required)
-    - name: kvNamespaceID
+    # Name of the existing Cloudflare Queue (required)
+    - name: queueName
       value: ""
     # Name of the Worker (required)
     - name: workerName
@@ -51,45 +53,46 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 ## Spec metadata fields
 
-| Field              | Required | Details | Example |
-|--------------------|:--------:|---------|---------|
-| `kvNamespaceID` | Y | ID of the pre-created Workers KV namespace | `"123456789abcdef8b5588f3d134f74ac"`
-| `workerName` | Y | Name of the Worker to connect to | `"mydaprkv"`
-| `key` | Y | Ed25519 private key, PEM-encoded | *See example above*
-| `cfAccountID` | Y/N | Cloudflare account ID. Required to have Dapr manage the worker. | `"456789abcdef8b5588f3d134f74ac"def`
-| `cfAPIToken` | Y/N | API token for Cloudflare. Required to have Dapr manage the Worker. | `"secret-key"`
-| `workerUrl` | Y/N | URL of the Worker. Required if the Worker has been pre-provisioned outside of Dapr. | `"https://mydaprkv.mydomain.workers.dev"`
+| Field              | Required | Binding support |  Details | Example |
+|--------------------|:--------:|-------|--------|---------|
+| `queueName` | Y | Output | Name of the existing Cloudflare Queue | `"mydaprqueue"`
+| `key` | Y | Output | Ed25519 private key, PEM-encoded | *See example above*
+| `cfAccountID` | Y/N | Output | Cloudflare account ID. Required to have Dapr manage the worker. | `"456789abcdef8b5588f3d134f74ac"def`
+| `cfAPIToken` | Y/N | Output | API token for Cloudflare. Required to have Dapr manage the Worker. | `"secret-key"`
+| `workerUrl` | Y/N | Output | URL of the Worker. Required if the Worker has been pre-provisioned outside of Dapr. | `"https://mydaprqueue.mydomain.workers.dev"`
 
 > When you configure Dapr to create your Worker for you, you may need to set a longer value for the `initTimeout` property of the component, to allow enough time for the Worker script to be deployed. For example: `initTimeout: "120s"`
 
-## Create a Workers KV namespace
+## Binding support
 
-To use this component, you must have a Workers KV namespace created in your Cloudflare account.
+This component supports **output binding** with the following operations:
 
-You can create a new Workers KV namespace in one of two ways:
+- `publish` (alias: `create`): Publish a message to the Queue.  
+  The data passed to the binding is used as-is for the body of the message published to the Queue.  
+  This operation does not accept any metadata property.
+
+## Create a Cloudflare Queue
+
+To use this component, you must have a Cloudflare Queue created in your Cloudflare account.
+
+You can create a new Queue in one of two ways:
 
 - Using the [Cloudflare dashboard](https://dash.cloudflare.com/)  
-  Make note of the "ID" of the Workers KV namespace that you can see in the dashboard. This is a hex string (for example `123456789abcdef8b5588f3d134f74ac`)–not the name you used when you created it!
 - Using the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/):
   
   ```sh
   # Authenticate if needed with `npx wrangler login` first
-  wrangler kv:namespace create <NAME>
-  ```
-
-  The output will contain the ID of the namespace, for example:
-
-  ```text
-  { binding = "<NAME>", id = "123456789abcdef8b5588f3d134f74ac" }
+  npx wrangler queues create <NAME>
+  # For example: `npx wrangler queues create myqueue`
   ```
 
 ## Configuring the Worker
 
-Because Cloudflare Workers KV namespaces can only be accessed by scripts running on Workers, Dapr needs to maintain a Worker to communicate with the Workers KV storage.
+Because Cloudflare Queues can only be accessed by scripts running on Workers, Dapr needs to maintain a Worker to communicate with the Queue.
 
 Dapr can manage the Worker for you automatically, or you can pre-provision a Worker yourself. Pre-provisioning the Worker is the only supported option when running on [workerd](https://github.com/cloudflare/workerd).
 
-> **Important:** Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Workers KV state store components, and do not use the same Worker script for different Cloudflare components in Dapr (e.g. the Workers KV state store and the Queues binding).
+> **Important:** Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Queues bindings, and do not use the same Worker script for different Cloudflare components in Dapr (e.g. the Workers KV state store and the Queues binding).
 
 {{< tabs "Let Dapr manage the Worker" "Manually provision the Worker script" >}}
 
@@ -98,9 +101,9 @@ Dapr can manage the Worker for you automatically, or you can pre-provision a Wor
 
 If you want to let Dapr manage the Worker for you, you will need to provide these 3 metadata options:
 
-- **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker: for example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprkv`, the Worker that Dapr deploys will be available at `https://mydaprkv.mydomain.workers.dev`.
+- **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker: for example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprqueue`, the Worker that Dapr deploys will be available at `https://mydaprqueue.mydomain.workers.dev`.
 - **`cfAccountID`**: ID of your Cloudflare account. You can find this in your browser's URL bar after logging into the [Cloudflare dashboard](https://dash.cloudflare.com/), with the ID being the hex string right after `dash.cloudflare.com`. For example, if the URL is `https://dash.cloudflare.com/456789abcdef8b5588f3d134f74acdef`, the value for `cfAccountID` is `456789abcdef8b5588f3d134f74acdef`.
-- **`cfAPIToken`**: API token with permission to create and edit Workers and Workers KV namespaces. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
+- **`cfAPIToken`**: API token with permission to create and edit Workers. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
 
 When Dapr is configured to manage the Worker for you, when a Dapr Runtime is started it checks that the Worker exists and it's up-to-date. If the Worker doesn't exist, or if it's using an outdated version, Dapr will create or upgrade it for you automatically.
 
@@ -118,7 +121,7 @@ To manually provision a Worker script, you will need to have Node.js installed o
 3. Inside the newly-created folder, create a new `wrangler.toml` file with the contents below, filling in the missing information as appropriate:  
   
   ```toml
-  # Name of your Worker, for example "mydaprkv"
+  # Name of your Worker, for example "mydaprqueue"
   name = ""
 
   # Do not change these options
@@ -131,14 +134,14 @@ To manually provision a Worker script, you will need to have Node.js installed o
   # Example:
   # PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----\nMCowB...=\n-----END PUBLIC KEY-----
   PUBLIC_KEY = ""
-  # Set this to the name of your Worker (same as the value of the "name" property above), for example "mydaprkv".
+  # Set this to the name of your Worker (same as the value of the "name" property above), for example "mydaprqueue".
   TOKEN_AUDIENCE = ""
 
-  [[kv_namespaces]]
-  # Set the next two values to the ID (not name) of your KV namespace, for example "123456789abcdef8b5588f3d134f74ac".
+  # Set the next two values to the name of your Queue, for example "myqueue".
   # Note that they will both be set to the same value.
+  [[queues.producers]]
+  queue = ""
   binding = ""
-  id = ""
   ```
   
   > Note: see the next section for how to generate an Ed25519 key pair. Make sure you use the **public** part of the key when deploying a Worker!
@@ -160,7 +163,7 @@ To manually provision a Worker script, you will need to have Node.js installed o
 Once your Worker has been deployed, you will need to initialize the component with these two metadata options:
 
 - **`workerName`**: Name of the Worker script. This is the value you set in the `name` property in the `wrangler.toml` file.
-- **`workerUrl`**: URL of the deployed Worker. The `npx wrangler command` will show the full URL to you, for example `https://mydaprkv.mydomain.workers.dev`.
+- **`workerUrl`**: URL of the deployed Worker. The `npx wrangler command` will show the full URL to you, for example `https://mydaprqueue.mydomain.workers.dev`.
 
 {{% /codetab %}}
 
@@ -168,7 +171,7 @@ Once your Worker has been deployed, you will need to initialize the component wi
 
 ## Generate an Ed25519 key pair
 
-All Cloudflare Workers listen on the public Internet, so Dapr needs to use additional authentication and data protection measures to ensure that no other person or application can communicate with your Worker (and thus, with your Worker KV namespace). These include industry-standard measures such as:
+All Cloudflare Workers listen on the public Internet, so Dapr needs to use additional authentication and data protection measures to ensure that no other person or application can communicate with your Worker (and thus, with your Cloudflare Queue). These include industry-standard measures such as:
 
 - All requests made by Dapr to the Worker are authenticated via a bearer token (technically, a JWT) which is signed with an Ed25519 key. 
 - All communications between Dapr and your Worker happen over an encrypted connection, using TLS (HTTPS).
@@ -225,13 +228,9 @@ Regardless of how you generated your key pair, with the instructions above you'l
 Protect the private part of your key and treat it as a secret value!
 {{% /alert %}}
 
-## Additional notes
-
-- Note that Cloudflare Workers KV doesn't guarantee strong data consistency. Although changes are visible immediately (usually) for requests made to the same Cloudflare datacenter, it can take a certain amount of time (usually up to one minute) for changes to be replicated across all Cloudflare regions.
-- This state store supports TTLs with Dapr, but the minimum value for the TTL is 1 minute.
-
 ## Related links
 
 - [Basic schema for a Dapr component]({{< ref component-schema >}})
-- Read [this guide]({{< ref "howto-get-save-state.md#step-2-save-and-retrieve-a-single-state" >}}) for instructions on configuring state store components
-- [State management building block]({{< ref state-management >}})
+- [Bindings building block]({{< ref bindings >}})
+- [How-To: Use bindings to interface with external resources]({{< ref howto-bindings.md >}})
+- [Bindings API reference]({{< ref bindings_api.md >}})

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cfqueues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cfqueues.md
@@ -92,7 +92,7 @@ Because Cloudflare Queues can only be accessed by scripts running on Workers, Da
 
 Dapr can manage the Worker for you automatically, or you can pre-provision a Worker yourself. Pre-provisioning the Worker is the only supported option when running on [workerd](https://github.com/cloudflare/workerd).
 
-> **Important:** Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Queues bindings, and do not use the same Worker script for different Cloudflare components in Dapr (e.g. the Workers KV state store and the Queues binding).
+> **Important:** Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Queues bindings, and do not use the same Worker script for different Cloudflare components in Dapr (for example the Workers KV state store and the Queues binding).
 
 {{< tabs "Let Dapr manage the Worker" "Manually provision the Worker script" >}}
 
@@ -105,7 +105,7 @@ If you want to let Dapr manage the Worker for you, you will need to provide thes
 - **`cfAccountID`**: ID of your Cloudflare account. You can find this in your browser's URL bar after logging into the [Cloudflare dashboard](https://dash.cloudflare.com/), with the ID being the hex string right after `dash.cloudflare.com`. For example, if the URL is `https://dash.cloudflare.com/456789abcdef8b5588f3d134f74acdef`, the value for `cfAccountID` is `456789abcdef8b5588f3d134f74acdef`.
 - **`cfAPIToken`**: API token with permission to create and edit Workers. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
 
-When Dapr is configured to manage the Worker for you, when a Dapr Runtime is started it checks that the Worker exists and it's up-to-date. If the Worker doesn't exist, or if it's using an outdated version, Dapr will create or upgrade it for you automatically.
+When Dapr is configured to manage the Worker for you, when a Dapr Runtime is started it checks that the Worker exists and it's up-to-date. If the Worker doesn't exist, or if it's using an outdated version, Dapr creates or upgrades it for you automatically.
 
 {{% /codetab %}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
@@ -231,7 +231,7 @@ step crypto keypair \
 
 Regardless of how you generated your key pair, with the instructions above you'll have two files:
 
-- `private.pem` contains the private part of the key: use the contents of this file for the **`key`** property of the component's metadata.
+- `private.pem` contains the private part of the key; use the contents of this file for the **`key`** property of the component's metadata.
 - `public.pem` contains the public part of the key, which you'll need only if you're deploying a Worker manually (as per the instructions in the previoius section).
 
 {{% alert title="Warning" color="warning" %}}

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
@@ -4,6 +4,7 @@ title: "Cloudflare Queues bindings spec"
 linkTitle: "Cloudflare Queues"
 description: "Detailed documentation on the Cloudflare Queues component"
 aliases:
+  - "/operations/components/setup-bindings/supported-bindings/cloudflare-queues/"
   - "/operations/components/setup-bindings/supported-bindings/cfqueues/"
 ---
 
@@ -234,3 +235,4 @@ Protect the private part of your key and treat it as a secret value!
 - [Bindings building block]({{< ref bindings >}})
 - [How-To: Use bindings to interface with external resources]({{< ref howto-bindings.md >}})
 - [Bindings API reference]({{< ref bindings_api.md >}})
+- Documentation for [Cloudflare Queues](https://developers.cloudflare.com/queues/)

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
@@ -95,7 +95,9 @@ Because Cloudflare Queues can only be accessed by scripts running on Workers, Da
 
 Dapr can manage the Worker for you automatically, or you can pre-provision a Worker yourself. Pre-provisioning the Worker is the only supported option when running on [workerd](https://github.com/cloudflare/workerd).
 
-> **Important:** Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Queues bindings, and do not use the same Worker script for different Cloudflare components in Dapr (for example the Workers KV state store and the Queues binding).
+{{% alert title="Important" color="warning" %}}
+Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Queues bindings, and do not use the same Worker script for different Cloudflare components in Dapr (for example, the Workers KV state store and the Queues binding).
+{{% /alert %}}
 
 {{< tabs "Let Dapr manage the Worker" "Manually provision the Worker script" >}}
 
@@ -105,7 +107,7 @@ Dapr can manage the Worker for you automatically, or you can pre-provision a Wor
 If you want to let Dapr manage the Worker for you, you will need to provide these 3 metadata options:
 
 <!-- IGNORE_LINKS -->
-- **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker: for example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprqueue`, the Worker that Dapr deploys will be available at `https://mydaprqueue.mydomain.workers.dev`.
+- **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker. For example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprqueue`, the Worker that Dapr deploys will be available at `https://mydaprqueue.mydomain.workers.dev`.
 - **`cfAccountID`**: ID of your Cloudflare account. You can find this in your browser's URL bar after logging into the [Cloudflare dashboard](https://dash.cloudflare.com/), with the ID being the hex string right after `dash.cloudflare.com`. For example, if the URL is `https://dash.cloudflare.com/456789abcdef8b5588f3d134f74acdef`, the value for `cfAccountID` is `456789abcdef8b5588f3d134f74acdef`.
 - **`cfAPIToken`**: API token with permission to create and edit Workers. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
 <!-- END_IGNORE -->

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
@@ -203,11 +203,14 @@ You can generate a new Ed25519 key pair with OpenSSL using:
 ```sh
 openssl genpkey -algorithm ed25519 -out private.pem
 openssl pkey -in private.pem -pubout -out public.pem
-
-# On Mac, using openssl@3 from Homebrew:
-$(brew --prefix)/opt/openssl@3/bin/openssl genpkey -algorithm ed25519 -out private.pem
-$(brew --prefix)/opt/openssl@3/bin/openssl pkey -in private.pem -pubout -out public.pem
 ```
+
+> On macOS, using openssl@3 from Homebrew:
+> 
+> ```sh
+> $(brew --prefix)/opt/openssl@3/bin/openssl genpkey -algorithm ed25519 -out private.pem
+> $(brew --prefix)/opt/openssl@3/bin/openssl pkey -in private.pem -pubout -out public.pem
+> ```
 
 {{% /codetab %}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
@@ -78,6 +78,7 @@ To use this component, you must have a Cloudflare Queue created in your Cloudfla
 
 You can create a new Queue in one of two ways:
 
+<!-- IGNORE_LINKS -->
 - Using the [Cloudflare dashboard](https://dash.cloudflare.com/)  
 - Using the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/):
   
@@ -86,6 +87,7 @@ You can create a new Queue in one of two ways:
   npx wrangler queues create <NAME>
   # For example: `npx wrangler queues create myqueue`
   ```
+<!-- END_IGNORE -->
 
 ## Configuring the Worker
 
@@ -102,9 +104,11 @@ Dapr can manage the Worker for you automatically, or you can pre-provision a Wor
 
 If you want to let Dapr manage the Worker for you, you will need to provide these 3 metadata options:
 
+<!-- IGNORE_LINKS -->
 - **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker: for example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprqueue`, the Worker that Dapr deploys will be available at `https://mydaprqueue.mydomain.workers.dev`.
 - **`cfAccountID`**: ID of your Cloudflare account. You can find this in your browser's URL bar after logging into the [Cloudflare dashboard](https://dash.cloudflare.com/), with the ID being the hex string right after `dash.cloudflare.com`. For example, if the URL is `https://dash.cloudflare.com/456789abcdef8b5588f3d134f74acdef`, the value for `cfAccountID` is `456789abcdef8b5588f3d134f74acdef`.
 - **`cfAPIToken`**: API token with permission to create and edit Workers. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
+<!-- END_IGNORE -->
 
 When Dapr is configured to manage the Worker for you, when a Dapr Runtime is started it checks that the Worker exists and it's up-to-date. If the Worker doesn't exist, or if it's using an outdated version, Dapr creates or upgrades it for you automatically.
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/cloudflare-queues.md
@@ -109,7 +109,10 @@ If you want to let Dapr manage the Worker for you, you will need to provide thes
 <!-- IGNORE_LINKS -->
 - **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker. For example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprqueue`, the Worker that Dapr deploys will be available at `https://mydaprqueue.mydomain.workers.dev`.
 - **`cfAccountID`**: ID of your Cloudflare account. You can find this in your browser's URL bar after logging into the [Cloudflare dashboard](https://dash.cloudflare.com/), with the ID being the hex string right after `dash.cloudflare.com`. For example, if the URL is `https://dash.cloudflare.com/456789abcdef8b5588f3d134f74acdef`, the value for `cfAccountID` is `456789abcdef8b5588f3d134f74acdef`.
-- **`cfAPIToken`**: API token with permission to create and edit Workers. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
+- **`cfAPIToken`**: API token with permission to create and edit Workers. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard: 
+   1. Click on **"Create token"**.
+   1. Select the **"Edit Cloudflare Workers"** template.
+   1. Follow the on-screen instructions to generate a new API token.
 <!-- END_IGNORE -->
 
 When Dapr is configured to manage the Worker for you, when a Dapr Runtime is started it checks that the Worker exists and it's up-to-date. If the Worker doesn't exist, or if it's using an outdated version, Dapr creates or upgrades it for you automatically.

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
@@ -77,7 +77,7 @@ You can create a new Workers KV namespace in one of two ways:
   wrangler kv:namespace create <NAME>
   ```
 
-  The output will contain the ID of the namespace, for example:
+  The output contains the ID of the namespace, for example:
 
   ```text
   { binding = "<NAME>", id = "123456789abcdef8b5588f3d134f74ac" }

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
@@ -1,0 +1,63 @@
+---
+type: docs
+title: "Hazelcast"
+linkTitle: "Hazelcast"
+description: Detailed information on the Hazelcast state store component
+aliases:
+  - "/operations/components/setup-state-store/supported-state-stores/setup-hazelcast/"
+---
+
+## Create a Dapr component
+
+To setup Hazelcast state store create a component of type `state.hazelcast`. See [this guide]({{< ref "howto-get-save-state.md#step-1-setup-a-state-store" >}}) on how to create and apply a state store configuration.
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: <NAME>
+spec:
+  type: state.hazelcast
+  version: v1
+  metadata:
+  - name: hazelcastServers
+    value: <REPLACE-WITH-HOSTS> # Required. A comma delimited string of servers. Example: "hazelcast:3000,hazelcast2:3000"
+  - name: hazelcastMap
+    value: <REPLACE-WITH-MAP> # Required. Hazelcast map configuration.
+```
+
+{{% alert title="Warning" color="warning" %}}
+The above example uses secrets as plain strings. It is recommended to use a secret store for the secrets as described [here]({{< ref component-secrets.md >}}).
+{{% /alert %}}
+
+## Spec metadata fields
+
+| Field              | Required | Details | Example |
+|--------------------|:--------:|---------|---------|
+| hazelcastServers   | Y        | A comma delimited string of servers | `"hazelcast:3000,hazelcast2:3000"`
+| hazelcastMap       | Y        | Hazelcast Map configuration | `"foo-map"`
+
+## Setup Hazelcast
+
+{{< tabs "Self-Hosted" "Kubernetes" >}}
+
+{{% codetab %}}
+You can run Hazelcast locally using Docker:
+
+```
+docker run -e JAVA_OPTS="-Dhazelcast.local.publicAddress=127.0.0.1:5701" -p 5701:5701 hazelcast/hazelcast
+```
+
+You can then interact with the server using the `127.0.0.1:5701`.
+{{% /codetab %}}
+
+{{% codetab %}}
+The easiest way to install Hazelcast on Kubernetes is by using the [Helm chart](https://github.com/helm/charts/tree/master/stable/hazelcast).
+{{% /codetab %}}
+
+{{< /tabs >}}
+
+## Related links
+- [Basic schema for a Dapr component]({{< ref component-schema >}})
+- Read [this guide]({{< ref "howto-get-save-state.md#step-2-save-and-retrieve-a-single-state" >}}) for instructions on configuring state store components
+- [State management building block]({{< ref state-management >}})

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
@@ -194,11 +194,14 @@ You can generate a new Ed25519 key pair with OpenSSL using:
 ```sh
 openssl genpkey -algorithm ed25519 -out private.pem
 openssl pkey -in private.pem -pubout -out public.pem
-
-# On Mac, using openssl@3 from Homebrew:
-$(brew --prefix)/opt/openssl@3/bin/openssl genpkey -algorithm ed25519 -out private.pem
-$(brew --prefix)/opt/openssl@3/bin/openssl pkey -in private.pem -pubout -out public.pem
 ```
+
+> On macOS, using openssl@3 from Homebrew:
+> 
+> ```sh
+> $(brew --prefix)/opt/openssl@3/bin/openssl genpkey -algorithm ed25519 -out private.pem
+> $(brew --prefix)/opt/openssl@3/bin/openssl pkey -in private.pem -pubout -out public.pem
+> ```
 
 {{% /codetab %}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
@@ -91,7 +91,9 @@ Because Cloudflare Workers KV namespaces can only be accessed by scripts running
 
 Dapr can manage the Worker for you automatically, or you can pre-provision a Worker yourself. Pre-provisioning the Worker is the only supported option when running on [workerd](https://github.com/cloudflare/workerd).
 
-> **Important:** Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Workers KV state store components, and do not use the same Worker script for different Cloudflare components in Dapr (e.g. the Workers KV state store and the Queues binding).
+{{% alert title="Important" color="warning" %}} 
+Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Workers KV state store components, and do not use the same Worker script for different Cloudflare components in Dapr (e.g. the Workers KV state store and the Queues binding).
+{{% /alert %}}
 
 {{< tabs "Let Dapr manage the Worker" "Manually provision the Worker script" >}}
 
@@ -101,9 +103,12 @@ Dapr can manage the Worker for you automatically, or you can pre-provision a Wor
 If you want to let Dapr manage the Worker for you, you will need to provide these 3 metadata options:
 
 <!-- IGNORE_LINKS -->
-- **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker: for example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprkv`, the Worker that Dapr deploys will be available at `https://mydaprkv.mydomain.workers.dev`.
+- **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker. For example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprkv`, the Worker that Dapr deploys will be available at `https://mydaprkv.mydomain.workers.dev`.
 - **`cfAccountID`**: ID of your Cloudflare account. You can find this in your browser's URL bar after logging into the [Cloudflare dashboard](https://dash.cloudflare.com/), with the ID being the hex string right after `dash.cloudflare.com`. For example, if the URL is `https://dash.cloudflare.com/456789abcdef8b5588f3d134f74acdef`, the value for `cfAccountID` is `456789abcdef8b5588f3d134f74acdef`.
-- **`cfAPIToken`**: API token with permission to create and edit Workers and Workers KV namespaces. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
+- **`cfAPIToken`**: API token with permission to create and edit Workers and Workers KV namespaces. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard: 
+   1. Click on **"Create token"**.
+   1. Select the **"Edit Cloudflare Workers"** template.
+   1. Follow the on-screen instructions to generate a new API token.
 <!-- END_IGNORE -->
 
 When Dapr is configured to manage the Worker for you, when a Dapr Runtime is started it checks that the Worker exists and it's up-to-date. If the Worker doesn't exist, or if it's using an outdated version, Dapr will create or upgrade it for you automatically.
@@ -222,7 +227,7 @@ step crypto keypair \
 
 Regardless of how you generated your key pair, with the instructions above you'll have two files:
 
-- `private.pem` contains the private part of the key: use the contents of this file for the **`key`** property of the component's metadata.
+- `private.pem` contains the private part of the key; use the contents of this file for the **`key`** property of the component's metadata.
 - `public.pem` contains the public part of the key, which you'll need only if you're deploying a Worker manually (as per the instructions in the previoius section).
 
 {{% alert title="Warning" color="warning" %}}

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
@@ -68,6 +68,7 @@ To use this component, you must have a Workers KV namespace created in your Clou
 
 You can create a new Workers KV namespace in one of two ways:
 
+<!-- IGNORE_LINKS -->
 - Using the [Cloudflare dashboard](https://dash.cloudflare.com/)  
   Make note of the "ID" of the Workers KV namespace that you can see in the dashboard. This is a hex string (for example `123456789abcdef8b5588f3d134f74ac`)–not the name you used when you created it!
 - Using the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/):
@@ -82,6 +83,7 @@ You can create a new Workers KV namespace in one of two ways:
   ```text
   { binding = "<NAME>", id = "123456789abcdef8b5588f3d134f74ac" }
   ```
+<!-- END_IGNORE -->
 
 ## Configuring the Worker
 
@@ -98,9 +100,11 @@ Dapr can manage the Worker for you automatically, or you can pre-provision a Wor
 
 If you want to let Dapr manage the Worker for you, you will need to provide these 3 metadata options:
 
+<!-- IGNORE_LINKS -->
 - **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker: for example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprkv`, the Worker that Dapr deploys will be available at `https://mydaprkv.mydomain.workers.dev`.
 - **`cfAccountID`**: ID of your Cloudflare account. You can find this in your browser's URL bar after logging into the [Cloudflare dashboard](https://dash.cloudflare.com/), with the ID being the hex string right after `dash.cloudflare.com`. For example, if the URL is `https://dash.cloudflare.com/456789abcdef8b5588f3d134f74acdef`, the value for `cfAccountID` is `456789abcdef8b5588f3d134f74acdef`.
 - **`cfAPIToken`**: API token with permission to create and edit Workers and Workers KV namespaces. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
+<!-- END_IGNORE -->
 
 When Dapr is configured to manage the Worker for you, when a Dapr Runtime is started it checks that the Worker exists and it's up-to-date. If the Worker doesn't exist, or if it's using an outdated version, Dapr will create or upgrade it for you automatically.
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
@@ -1,15 +1,15 @@
 ---
 type: docs
-title: "Hazelcast"
-linkTitle: "Hazelcast"
-description: Detailed information on the Hazelcast state store component
+title: "Cloudflare Workers KV"
+linkTitle: "Cloudflare Workers KV"
+description: Detailed information on the Cloudflare Workers KV state store component
 aliases:
-  - "/operations/components/setup-state-store/supported-state-stores/setup-hazelcast/"
+  - "/operations/components/setup-state-store/supported-state-stores/setup-cloudflare-workerskv/"
 ---
 
 ## Create a Dapr component
 
-To setup Hazelcast state store create a component of type `state.hazelcast`. See [this guide]({{< ref "howto-get-save-state.md#step-1-setup-a-state-store" >}}) on how to create and apply a state store configuration.
+To setup a [Cloudflare Workers KV](https://developers.cloudflare.com/workers/learning/how-kv-works/) state store, create a component of type `state.cloudflare.workerskv`. See [this guide]({{< ref "howto-get-save-state.md#step-1-setup-a-state-store" >}}) on how to create and apply a state store configuration.
 
 ```yaml
 apiVersion: dapr.io/v1alpha1
@@ -17,13 +17,30 @@ kind: Component
 metadata:
   name: <NAME>
 spec:
-  type: state.hazelcast
+  type: state.cloudflare.workerskv
   version: v1
   metadata:
-  - name: hazelcastServers
-    value: <REPLACE-WITH-HOSTS> # Required. A comma delimited string of servers. Example: "hazelcast:3000,hazelcast2:3000"
-  - name: hazelcastMap
-    value: <REPLACE-WITH-MAP> # Required. Hazelcast map configuration.
+    # ID of the Workers KV namespace (required)
+    - name: kvNamespaceID
+      value: ""
+    # Name of the Worker (required)
+    - name: workerName
+      value: ""
+    # PEM-encoded private Ed25519 key (required)
+    - name: key
+      value: |
+        -----BEGIN PRIVATE KEY-----
+        MC4CAQ...
+        -----END PRIVATE KEY-----
+    # Cloudflare account ID (required to have Dapr manage the Worker)
+    - name: cfAccountID
+      value: ""
+    # API token for Cloudflare (required to have Dapr manage the Worker)
+    - name: cfAPIToken
+      value: ""
+    # URL of the Worker (required if the Worker has been pre-created outside of Dapr)
+    - name: workerUrl
+      value: ""
 ```
 
 {{% alert title="Warning" color="warning" %}}
@@ -34,30 +51,183 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 | Field              | Required | Details | Example |
 |--------------------|:--------:|---------|---------|
-| hazelcastServers   | Y        | A comma delimited string of servers | `"hazelcast:3000,hazelcast2:3000"`
-| hazelcastMap       | Y        | Hazelcast Map configuration | `"foo-map"`
+| `kvNamespaceID` | Y | ID of the pre-created Workers KV namespace | `"123456789abcdef8b5588f3d134f74ac"`
+| `workerName` | Y | Name of the Worker to connect to | `"mydaprkv"`
+| `key` | Y | Ed25519 private key, PEM-encoded | *See example above*
+| `cfAccountID` | Y/N | Cloudflare account ID. Required to have Dapr manage the worker. | `"456789abcdef8b5588f3d134f74ac"def`
+| `cfAPIToken` | Y/N | API token for Cloudflare. Required to have Dapr manage the Worker. | `"secret-key"`
+| `workerUrl` | Y/N |  URL of the Worker. Required if the Worker has been pre-provisioned outside of Dapr. | `"https://mydaprkv.mydomain.workers.dev"`
 
-## Setup Hazelcast
+## Create a Workers KV namespace
 
-{{< tabs "Self-Hosted" "Kubernetes" >}}
+To use this component, you must have a Workers KV namespace created in your Cloudflare account.
+
+You can create a new Workers KV namespace in one of two ways:
+
+- Using the [Cloudflare dashboard](https://dash.cloudflare.com/)  
+  Make note of the "ID" of the Workers KV namespace that you can see in the dashboard. This is a hex string (for example `123456789abcdef8b5588f3d134f74ac`)–not the name you used when you created it!
+- Using the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/):
+  
+  ```sh
+  # Authenticate if needed with `npx wrangler login` first
+  wrangler kv:namespace create <NAME>
+  ```
+
+  The output will contain the ID of the namespace, for example:
+
+  ```text
+  { binding = "<NAME>", id = "123456789abcdef8b5588f3d134f74ac" }
+  ```
+
+## Configuring the Worker
+
+Because Cloudflare Workers KV namespaces can only be accessed by scripts running on Workers, Dapr needs to maintain a Worker to communicate with the Workers KV storage.
+
+Dapr can manage the Worker for you automatically, or you can pre-provision a Worker yourself. Pre-provisioning the Worker is the only supported option when running on [workerd](https://github.com/cloudflare/workerd).
+
+> **Important:** Use a separate Worker for each Dapr component. Do not use the same Worker script for different Cloudflare Workers KV state store components, and do not use the same Worker script for different Cloudflare components in Dapr (e.g. the Workers KV state store and the Queues binding).
+
+{{< tabs "Let Dapr manage the Worker" "Manually provision the Worker script" >}}
 
 {{% codetab %}}
-You can run Hazelcast locally using Docker:
+<!-- Let Dapr manage the Worker -->
 
-```
-docker run -e JAVA_OPTS="-Dhazelcast.local.publicAddress=127.0.0.1:5701" -p 5701:5701 hazelcast/hazelcast
-```
+If you want to let Dapr manage the Worker for you, you will need to provide these 3 metadata options:
 
-You can then interact with the server using the `127.0.0.1:5701`.
+- **`workerName`**: Name of the Worker script. This will be the first part of the URL of your Worker: for example, if the "workers.dev" domain configured for your Cloudflare account is `mydomain.workers.dev` and you set `workerName` to `mydaprkv`, the Worker that Dapr deploys will be available at `https://mydaprkv.mydomain.workers.dev`.
+- **`cfAccountID`**: ID of your Cloudflare account. You can find this in your browser's URL bar after logging into the [Cloudflare dashboard](https://dash.cloudflare.com/), with the ID being the hex string right after `dash.cloudflare.com`. For example, if the URL is `https://dash.cloudflare.com/456789abcdef8b5588f3d134f74acdef`, the value for `cfAccountID` is `456789abcdef8b5588f3d134f74acdef`.
+- **`cfAPIToken`**: API token with permission to create and edit Workers and Workers KV namespaces. You can create it from the ["API Tokens" page](https://dash.cloudflare.com/profile/api-tokens) in the "My Profile" section in the Cloudflare dashboard. Click on "Create token", select the **"Edit Cloudflare Workers"** template, then follow the on-screen instructions to generate a new API token.
+
+When Dapr is configured to manage the Worker for you, when a Dapr Runtime is started it checks that the Worker exists and it's up-to-date. If the Worker doesn't exist, or if it's using an outdated version, Dapr will create or upgrade it for you automatically.
+
 {{% /codetab %}}
 
 {{% codetab %}}
-The easiest way to install Hazelcast on Kubernetes is by using the [Helm chart](https://github.com/helm/charts/tree/master/stable/hazelcast).
+<!-- Manually provision the Worker script -->
+
+If you'd rather not give Dapr permissions to deploy Worker scripts for you, you can manually provision a Worker for Dapr to use. Note that if you have multiple Dapr components that interact with Cloudflare services via a Worker, you will need to create a separate Worker for each one of them.
+
+To manually provision a Worker script, you will need to have Node.js installed on your local machine.
+
+1. Create a new folder where you'll place the source code of the Worker, for example: `daprworker`.
+2. If you haven't already, authenticate with Wrangler (the Cloudflare Workers CLI) using: `npx wrangler login`.
+3. Inside the newly-created folder, create a new `wrangler.toml` file with the contents below, filling in the missing information as appropriate:  
+  
+  ```toml
+  # Name of your Worker, for example "mydaprkv"
+  name = ""
+
+  # Do not change these options
+  main = "worker.js"
+  compatibility_date = "2022-12-09"
+  usage_model = "bundled"
+
+  [vars]
+  # Set this to the **public** part of the Ed25519 key, PEM-encoded (with newlines replaced with `\n`).
+  # Example:
+  # PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----\nMCowB...=\n-----END PUBLIC KEY-----
+  PUBLIC_KEY = ""
+  # Set this to the name of your Worker (same as the value of the "name" property above), for example "mydaprkv".
+  TOKEN_AUDIENCE = ""
+
+  [[kv_namespaces]]
+  # Set the next two values to the ID (not name) of your KV namespace, for example "123456789abcdef8b5588f3d134f74ac".
+  # Note that they will both be set to the same value.
+  binding = ""
+  id = ""
+  ```
+  
+  > Note: see the next section for how to generate an Ed25519 key pair. Make sure you use the **public** part of the key when deploying a Worker!
+
+4. Copy the (pre-compiled and minified) code of the Worker in the `worker.js` file. You can do that with this command:  
+  
+  ```sh
+  # Set this to the version of Dapr that you're using
+  DAPR_VERSION="release-{{% dapr-latest-version short="true" %}}"
+  curl -LfO "https://raw.githubusercontent.com/dapr/components-contrib/${DAPR_VERSION}/internal/component/cloudflare/workers/code/worker.js"
+  ```
+
+5. Deploy the Worker using Wrangler:
+  
+  ```sh
+  npx wrangler publish
+  ```
+
+Once your Worker has been deployed, you will need to initialize the component with these two metadata options:
+
+- **`workerName`**: Name of the Worker script. This is the value you set in the `name` property in the `wrangler.toml` file.
+- **`workerUrl`**: URL of the deployed Worker. The `npx wrangler command` will show the full URL to you, for example `https://mydaprkv.mydomain.workers.dev`.
+
 {{% /codetab %}}
 
 {{< /tabs >}}
 
+## Generate an Ed25519 key pair
+
+All Cloudflare Workers listen on the public Internet, so Dapr needs to use additional authentication and data protection measures to ensure that no other person or application can communicate with your Worker (and thus, with your Worker KV namespace). These include industry-standard measures such as:
+
+- All requests made by Dapr to the Worker are authenticated via a bearer token (technically, a JWT) which is signed with an Ed25519 key. 
+- All communications between Dapr and your Worker happen over an encrypted connection, using TLS (HTTPS).
+- The bearer token is generated on each request and is valid for a brief period of time only (currently, one minute).
+
+To let Dapr issue bearer tokens, and have your Worker validate them, you will need to generate a new Ed25519 key pair. Here are examples of generating the key pair using OpenSSL or the step CLI.
+
+{{< tabs "Generate with OpenSSL" "Generate with the step CLI" >}}
+
+{{% codetab %}}
+<!-- Generate with OpenSSL -->
+
+> Support for generating Ed25519 keys is available since OpenSSL 1.1.0, so the commands below will not work if you're using an older version of OpenSSL.
+
+> Note for Mac users: on macOS, the "openssl" binary that is shipped by Apple is actually based on LibreSSL, which as of writing doesn't support Ed25519 keys. If you're using macOS, either use the step CLI, or install OpenSSL 3.0 from Homebrew using `brew install openssl@3` then replacing `openssl` in the commands below with `$(brew --prefix)/opt/openssl@3/bin/openssl`.
+
+You can generate a new Ed25519 key pair with OpenSSL using:
+
+```sh
+openssl genpkey -algorithm ed25519 -out private.pem
+openssl pkey -in private.pem -pubout -out public.pem
+
+# On Mac, using openssl@3 from Homebrew:
+$(brew --prefix)/opt/openssl@3/bin/openssl genpkey -algorithm ed25519 -out private.pem
+$(brew --prefix)/opt/openssl@3/bin/openssl pkey -in private.pem -pubout -out public.pem
+```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+<!-- Generate with the step CLI -->
+
+If you don't have the step CLI already, install it following the [official instructions](https://smallstep.com/docs/step-cli/installation).
+
+Next, you can generate a new Ed25519 key pair with the step CLI using:
+
+```sh
+step crypto keypair \
+  public.pem private.pem \
+  --kty OKP --curve Ed25519 \
+  --insecure --no-password
+```
+
+{{% /codetab %}}
+
+{{< /tabs >}}
+
+Regardless of how you generated your key pair, with the instructions above you'll have two files:
+
+- `private.pem` contains the private part of the key: use the contents of this file for the **`key`** property of the component's metadata.
+- `public.pem` contains the public part of the key, which you'll need only if you're deploying a Worker manually (as per the instructions in the previoius section).
+
+{{% alert title="Warning" color="warning" %}}
+Protect the private part of your key and treat it as a secret value!
+{{% /alert %}}
+
+## Additional notes
+
+- Note that Cloudflare Workers KV doesn't guarantee strong data consistency. Although changes are visible immediately (usually) for requests made to the same Cloudflare datacenter, it can take a certain amount of time (usually up to one minute) for changes to be replicated across all Cloudflare regions.
+- This state store supports TTLs with Dapr, but the minimum value for the TTL is 1 minute.
+
 ## Related links
+
 - [Basic schema for a Dapr component]({{< ref component-schema >}})
 - Read [this guide]({{< ref "howto-get-save-state.md#step-2-save-and-retrieve-a-single-state" >}}) for instructions on configuring state store components
 - [State management building block]({{< ref state-management >}})

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-cloudflare-workerskv.md
@@ -235,3 +235,4 @@ Protect the private part of your key and treat it as a secret value!
 - [Basic schema for a Dapr component]({{< ref component-schema >}})
 - Read [this guide]({{< ref "howto-get-save-state.md#step-2-save-and-retrieve-a-single-state" >}}) for instructions on configuring state store components
 - [State management building block]({{< ref state-management >}})
+- Documentation for [Cloudflare Workers KV](https://developers.cloudflare.com/workers/learning/how-kv-works/)

--- a/daprdocs/data/components/bindings/cloudflare.yaml
+++ b/daprdocs/data/components/bindings/cloudflare.yaml
@@ -1,5 +1,5 @@
 - component: Cloudflare Queues
-  link: cfqueues
+  link: cloudflare-queues
   state: Alpha
   version: v1
   since: "1.10"

--- a/daprdocs/data/components/bindings/cloudflare.yaml
+++ b/daprdocs/data/components/bindings/cloudflare.yaml
@@ -1,0 +1,8 @@
+- component: Cloudflare Queues
+  link: cfqueues
+  state: Alpha
+  version: v1
+  since: "1.10"
+  features:
+    input: false
+    output: true

--- a/daprdocs/data/components/state_stores/cloudflare.yaml
+++ b/daprdocs/data/components/state_stores/cloudflare.yaml
@@ -1,0 +1,12 @@
+- component: Workers KV
+  link: setup-cloudflare-workerskv
+  state: Beta
+  version: v1
+  since: "1.10"
+  features:
+    crud: true
+    transactions: false
+    etag: false
+    ttl: true
+    query: false
+

--- a/daprdocs/data/components/state_stores/cloudflare.yaml
+++ b/daprdocs/data/components/state_stores/cloudflare.yaml
@@ -1,4 +1,4 @@
-- component: Workers KV
+- component: Cloudflare Workers KV
   link: setup-cloudflare-workerskv
   state: Beta
   version: v1

--- a/daprdocs/layouts/partials/components/bindings.html
+++ b/daprdocs/layouts/partials/components/bindings.html
@@ -4,6 +4,7 @@
 "Alibaba Cloud" $.Site.Data.components.bindings.alibaba
 "Google Cloud Platform (GCP)" $.Site.Data.components.bindings.gcp
 "Amazon Web Services (AWS)" $.Site.Data.components.bindings.aws
+"Cloudflare" $.Site.Data.components.bindings.cloudflare
 "Zeebe (Camunda Cloud)" $.Site.Data.components.bindings.zeebe
 }}
 

--- a/daprdocs/layouts/partials/components/state-stores.html
+++ b/daprdocs/layouts/partials/components/state-stores.html
@@ -3,6 +3,7 @@
 "Microsoft Azure" $.Site.Data.components.state_stores.azure
 "Google Cloud Platform (GCP)" $.Site.Data.components.state_stores.gcp
 "Amazon Web Services (AWS)" $.Site.Data.components.state_stores.aws
+"Cloudflare" $.Site.Data.components.state_stores.cloudflare
 "Oracle Cloud" $.Site.Data.components.state_stores.oracle
 }}
 


### PR DESCRIPTION
This PR contains docs for the new Cloudflare components (Cloudflare KV state store, Cloudflare Queues binding) added in Dapr 1.10.

Code change: https://github.com/dapr/components-contrib/pull/2363

Fixes #3026 