### PR TITLE
[WIP][v1.10] Amends DynamoDB Documentation for Partition Key Metadata Field

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/observability/tracing-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/observability/tracing-overview.md
@@ -18,7 +18,7 @@ There are two scenarios for how tracing is used:
  1. Dapr generates the trace context and you propagate the trace context to another service.
  2. You generate the trace context and Dapr propagates the trace context to a service.
 
-### Propogating sequential service calls
+### Propagating sequential service calls
 
 Dapr takes care of creating the trace headers. However, when there are more than two services, you're responsible for propagating the trace headers between them. Let's go through the scenarios with examples:
 
@@ -45,7 +45,7 @@ There are no helper methods exposed in Dapr SDKs to propagate and retrieve trace
 4. Pub/sub messages
      Dapr generates the trace headers in the published message topic. These trace headers are propagated to any services listening on that topic.
 
-### Propogating multiple different service calls
+### Propagating multiple different service calls
 
 In the following scenarios, Dapr does some of the work for you and you need to either create or propagate trace headers.
 

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -64,9 +64,11 @@ There are some scenarios where it's necessary to install Dapr from a private Hel
 - having a custom Dapr deployment
 - pulling Helm charts from trusted registries that are managed and maintained by your organization
 
+```
 export DAPR_HELM_REPO_URL="https://helm.custom-domain.com/dapr/dapr"
 export DAPR_HELM_REPO_USERNAME="username_xxx"
 export DAPR_HELM_REPO_PASSWORD="passwd_xxx"
+```
 
 Setting the above parameters will allow `dapr init -k` to install Dapr images from the configured Helm repository.
 

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -14,10 +14,10 @@ extension.
 The Wasm [HTTP middleware]({{< ref middleware.md >}}) allows you to rewrite a
 request URI with custom logic compiled to a Wasm binary. In other words, you
 can extend Dapr using external files that are not pre-compiled into the `daprd`
-binary. Dapr embeds [wazero][https://wazero.io] to accomplish this without CGO.
+binary. Dapr embeds [wazero](https://wazero.io) to accomplish this without CGO.
 
 Wasm modules are loaded from a filesystem path. On Kubernetes, see [mounting
-volumes to the Dapr sidecar]({{> kubernetes-volume-mounts.md >}}) to configure
+volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}}) to configure
 a filesystem mount that can contain Wasm modules.
 
 ## Component format

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
@@ -75,7 +75,7 @@ See official [AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/develo
 
 ## Partition Keys
 
-The DynamoDB state store will use the `key` property provided in the requests to the Dapr API to determine the partition key. This can be overridden by specifying a metadata field in the request with a key of `partitionKey` and a value of the desired partition.
+The DynamoDB state store uses the `key` property provided in the request to determine the partition key. This can be overridden by specifying a metadata field in the request with a key of `partitionKey` and a value of the desired partition.
 
 The following operation uses `tony-stark` as the partition key value sent to DynamoDB:
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
@@ -57,7 +57,7 @@ In order to use DynamoDB as a Dapr state store, the table must have a primary ke
 | endpoint          | N  |AWS endpoint for the component to use. Only used for local development. The `endpoint` is unncessary when running against production AWS   | `"http://localhost:4566"`
 | sessionToken      | N  |AWS session token to use.  A session token is only required if you are using temporary security credentials. | `"TOKEN"`
 | ttlAttributeName  | N  |The table attribute name which should be used for TTL. | `"expiresAt"`
-| partitionKey      | N  |The partition key used to replace the default partition key `"key"`.  See the `Partion Keys` section below. | `"pkey"`
+| partitionKey      | N  |The partition key used to replace the default partition key `"key"` (Payload only). See the `Partion Keys` section below. | `"superHero"`
 
 {{% alert title="Important" color="warning" %}}
 When running the Dapr sidecar (daprd) with your application on EKS (AWS Kubernetes), if you're using a node/pod that has already been attached to an IAM policy defining access to AWS resources, you **must not** provide AWS access-key, secret-key, and tokens in the definition of the component spec you're using.  
@@ -75,32 +75,35 @@ See official [AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/develo
 
 ## Partition Keys
 
-The DynamoDB state store uses the `key` property provided in the request to determine the partition key. This can be overridden by specifying a metadata field in the request with a key of `partitionKey` and a value of the desired partition.
+The DynamoDB state store will use the `key` property provided in the requests to the Dapr API to determine the partition key. This can be overridden by specifying a metadata field in the request with a key of `partitionKey` and a value of the desired partition.
 
-The following operation uses `tony-stark` as the partition key value:
+To learn more about DynamoDB partition keys, see the official [AWS DynamoDB Developer Guide.](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey)
+
+The following operation uses the `"key"` field to indicate that **`key`** is the partition key value used in the **`avengers`** DynamoDB Table:
 
 ```shell
-curl -X POST http://localhost:3500/v1.0/state/<store_name> \
+curl -X POST http://localhost:3500/v1.0/state/avengers \
   -H "Content-Type: application/json"
   -d '[
         {
-          "key": "tony-stark",
-          "value": "iron man"
+          "key": "key",
+          "value": "Iron Man"
         }
       ]'
 ```
 
-If you want to control the DynamoDB partition key, you can specify it in metadata. Below, reuse the previous example with a different partition key - in this case, `pkey`.
+If you want to specify a different DynamoDB partition key, you can do so by sending the `"partitionKey"` field as part of the metadata.
+
+Reusing the example above, the following operation indicates that **`superHero`**  is the partition key used in the **`avengers`** DynamoDB Table:
 
 ```shell
-curl -X POST http://localhost:3500/v1.0/state/<store_name> \
+curl -X POST http://localhost:3500/v1.0/state/avengers \
   -H "Content-Type: application/json"
   -d '[
         {
-          "key": "tony-stark",
-          "value": "iron man",
+          "value": "Iron Man",
           "metadata": {
-            "partitionKey": "pkey"
+            "partitionKey": "superHero"
           }
         }
       ]'

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
@@ -77,7 +77,7 @@ See official [AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/develo
 
 The DynamoDB state store uses the `key` property provided in the request to determine the partition key. This can be overridden by specifying a metadata field in the request with a key of `partitionKey` and a value of the desired partition.
 
-The following operation uses `tony-stark` as the partition key value sent to DynamoDB:
+The following operation uses `tony-stark` as the partition key value:
 
 ```shell
 curl -X POST http://localhost:3500/v1.0/state/<store_name> \

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
@@ -44,7 +44,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 ## Primary Key
 
-In order to use DynamoDB as a Dapr state store, the table must have a primary key named `key`. See the section `Partition Keys` for an option to change this behavior.
+In order to use DynamoDB as a Dapr state store, the table must have a primary key named `key`. See the section [Partition Keys]({{< ref "setup-dynamodb.md#partition-keys" >}}) for an option to change this behavior.
 
 ## Spec metadata fields
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
@@ -42,7 +42,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 ## Primary Key
 
-In order to use DynamoDB as a Dapr state store, the table must have a primary key named `key`.
+In order to use DynamoDB as a Dapr state store, the table must have a primary key named `key`. See the section `Partition Keys` for an option to change this behavior.
 
 ## Spec metadata fields
 
@@ -55,6 +55,7 @@ In order to use DynamoDB as a Dapr state store, the table must have a primary ke
 | endpoint          | N  |AWS endpoint for the component to use. Only used for local development. The `endpoint` is unncessary when running against production AWS   | `"http://localhost:4566"`
 | sessionToken      | N  |AWS session token to use.  A session token is only required if you are using temporary security credentials. | `"TOKEN"`
 | ttlAttributeName  | N  |The table attribute name which should be used for TTL. | `"expiresAt"`
+| partitionKey      | N  |The partition key used to replace the default partition key `"key"`.  See the `Partion Keys` section below. | `"pkey"`
 
 {{% alert title="Important" color="warning" %}}
 When running the Dapr sidecar (daprd) with your application on EKS (AWS Kubernetes), if you're using a node/pod that has already been attached to an IAM policy defining access to AWS resources, you **must not** provide AWS access-key, secret-key, and tokens in the definition of the component spec you're using.  
@@ -69,6 +70,39 @@ See [Authenticating to AWS]({{< ref authenticating-aws.md >}}) for information a
 In order to use DynamoDB TTL feature, you must enable TTL on your table and define the attribute name.
 The attribute name must be defined in the `ttlAttributeName` field.
 See official [AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html).
+
+## Partition Keys
+
+The DynamoDB state store will use the `key` property provided in the requests to the Dapr API to determine the partition key. This can be overridden by specifying a metadata field in the request with a key of `partitionKey` and a value of the desired partition.
+
+The following operation uses `tony-stark` as the partition key value sent to DynamoDB:
+
+```shell
+curl -X POST http://localhost:3500/v1.0/state/<store_name> \
+  -H "Content-Type: application/json"
+  -d '[
+        {
+          "key": "tony-stark",
+          "value": "iron man"
+        }
+      ]'
+```
+
+If you want to control the DynamoDB partition key, you can specify it in metadata.  Reusing the example above, here's how to use a different partition key, in this case, `pkey`.
+
+```shell
+curl -X POST http://localhost:3500/v1.0/state/<store_name> \
+  -H "Content-Type: application/json"
+  -d '[
+        {
+          "key": "tony-stark",
+          "value": "iron man",
+          "metadata": {
+            "partitionKey": "pkey"
+          }
+        }
+      ]'
+```
 
 ## Related links
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
@@ -34,6 +34,8 @@ spec:
     value: "myTOKEN" # Optional
   - name: ttlAttributeName
     value: "expiresAt" # Optional
+  - name: partitionKey
+    value: "pkey" # Optional
 ```
 
 {{% alert title="Warning" color="warning" %}}

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-dynamodb.md
@@ -90,7 +90,7 @@ curl -X POST http://localhost:3500/v1.0/state/<store_name> \
       ]'
 ```
 
-If you want to control the DynamoDB partition key, you can specify it in metadata.  Reusing the example above, here's how to use a different partition key, in this case, `pkey`.
+If you want to control the DynamoDB partition key, you can specify it in metadata. Below, reuse the previous example with a different partition key - in this case, `pkey`.
 
 ```shell
 curl -X POST http://localhost:3500/v1.0/state/<store_name> \

--- a/daprdocs/layouts/partials/components/bindings.html
+++ b/daprdocs/layouts/partials/components/bindings.html
@@ -20,11 +20,22 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-bindings/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-bindings/{{ .link }}/">{{ .component }}</a>
         </td>
-        <td align="center">{{ if .features.input }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.output }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
+        <td align="center">
+            {{ if .features.input }}
+                <span role="img" aria-label="Input binding supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Input binding not supported" aria-label="Input binding not supported">
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.output }}
+                <span role="img" aria-label="Output binding supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Output binding not supported" aria-label="Output binding not supported">
+            {{ end }}
+        </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>
         <td>{{ .since }}</td>

--- a/daprdocs/layouts/partials/components/configuration-stores.html
+++ b/daprdocs/layouts/partials/components/configuration-stores.html
@@ -13,8 +13,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-configuration-stores/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-configuration-stores/{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>

--- a/daprdocs/layouts/partials/components/description.html
+++ b/daprdocs/layouts/partials/components/description.html
@@ -1,7 +1,6 @@
 <p>Table captions:</p>
 <blockquote>
-    <p><code>Status</code>: <a href="/operations/components/certification-lifecycle/">Component
-            certification</a> status</p>
+    <p><code>Status</code>: <a href="/operations/components/certification-lifecycle/">component certification</a> status</p>
 </blockquote>
 <ul>
     <li><a href="/operations/components/certification-lifecycle/#alpha">Alpha</a></li>
@@ -9,8 +8,8 @@
     <li><a href="/operations/components/certification-lifecycle/#stable">Stable</a></li>
 </ul>
 <blockquote>
-    <p><code>Since</code>: defines from which Dapr Runtime version, the component is in the current status</p>
+    <p><code>Since</code>: the version of the Dapr Runtime in which the component first moved to the current status</p>
 </blockquote>
 <blockquote>
-    <p><code>Component version</code>: defines the version of the component</p>
+    <p><code>Component version</code>: the version of the component</p>
 </blockquote>

--- a/daprdocs/layouts/partials/components/locks.html
+++ b/daprdocs/layouts/partials/components/locks.html
@@ -13,8 +13,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-locks/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-locks/{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>

--- a/daprdocs/layouts/partials/components/middleware.html
+++ b/daprdocs/layouts/partials/components/middleware.html
@@ -13,8 +13,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .description | markdownify}}</td>
         <td>{{ .state }}</td>

--- a/daprdocs/layouts/partials/components/name-resolution.html
+++ b/daprdocs/layouts/partials/components/name-resolution.html
@@ -15,8 +15,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-name-resolution/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-name-resolution/{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>

--- a/daprdocs/layouts/partials/components/pubsub.html
+++ b/daprdocs/layouts/partials/components/pubsub.html
@@ -16,8 +16,7 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-pubsub/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td><a href="/reference/components-reference/supported-pubsub/{{ .link }}/">{{ .component }}</a>
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>

--- a/daprdocs/layouts/partials/components/secret-stores.html
+++ b/daprdocs/layouts/partials/components/secret-stores.html
@@ -27,10 +27,16 @@
         </tr>
         {{ range sort $components "component" }}
         <tr>
-            <td><a href="/reference/components-reference/supported-secret-stores/{{ .link }}/" }}>{{ .component
-                    }}</a>
+            <td>
+                <a href="/reference/components-reference/supported-secret-stores/{{ .link }}/">{{ .component }}</a>
             </td>
-            <td align="center">{{ if .features.multipleKeyValuesPerSecret }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
+            <td align="center">
+                {{ if .features.multipleKeyValuesPerSecret }}
+                    <span role="img" aria-label="Multiple Key-Values Per Secret: Supported">✅</span>
+                {{else}}
+                    <img src="/images/emptybox.png" alt="Multiple Key-Values Per Secret: Not supported" aria-label="Multiple Key-Values Per Secret: Not supported" />
+                {{ end }}
+            </td>
             <td>{{ .state }}</td>
             <td>{{ .version }}</td>
             <td>{{ .since }}</td>

--- a/daprdocs/layouts/partials/components/state-stores.html
+++ b/daprdocs/layouts/partials/components/state-stores.html
@@ -23,16 +23,51 @@
     </tr>
     {{ range sort $components "component" }}
     <tr>
-        <td><a href="/reference/components-reference/supported-state-stores/{{ .link }}/" }}>{{ .component
-                }}</a>
+        <td>
+            <a href="/reference/components-reference/supported-state-stores/{{ .link }}/">{{ .component }}</a>
         </td>
-        <td align="center">{{ if .features.crud }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.transactions }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.etag }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.ttl }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if (and .features.transactions .features.etag) }}✅{{else}}<img
-                src="/images/emptybox.png">{{ end }}</td>
-        <td align="center">{{ if .features.query }}✅{{else}}<img src="/images/emptybox.png">{{ end }}</td>
+        <td align="center">
+            {{ if .features.crud }}
+                <span role="img" aria-label="CRUD: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="CRUD: Not supported" aria-label="CRUD: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.transactions }}
+                <span role="img" aria-label="Transactions: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Transactions: Not supported" aria-label="Transactions: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.etag }}
+                <span role="img" aria-label="ETag: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="ETag: Not supported" aria-label="ETag: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.ttl }}
+                <span role="img" aria-label="TTL: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="TTL: Not supported" aria-label="TTL: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if (and .features.transactions .features.etag) }}
+                <span role="img" aria-label="Actors: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Actors: Not supported" aria-label="Actors: Not supported" />
+            {{ end }}
+        </td>
+        <td align="center">
+            {{ if .features.query }}
+                <span role="img" aria-label="Query: Supported">✅</span>
+            {{else}}
+                <img src="/images/emptybox.png" alt="Query: Not supported" aria-label="Query: Not supported" />
+            {{ end }}
+        </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>
         <td>{{ .since }}</td>


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Amends the AWS DynamoDB State store documentation to explain the behavior of the component when the Partition Key Metadata field is added.

## Issue reference

PR will close: #3037