### PR TITLE
Add version subcommand to CLI help output

### DIFF
--- a/daprdocs/content/en/getting-started/install-dapr-cli.md
+++ b/daprdocs/content/en/getting-started/install-dapr-cli.md
@@ -188,6 +188,7 @@ Available Commands:
   stop           Stop Dapr instances and their associated apps. . Supported platforms: Self-hosted
   uninstall      Uninstall Dapr runtime. Supported platforms: Kubernetes and self-hosted
   upgrade        Upgrades a Dapr control plane installation in a cluster. Supported platforms: Kubernetes
+  version        Print the Dapr runtime and CLI version
 
 Flags:
   -h, --help      help for dapr

--- a/daprdocs/content/en/reference/cli/cli-overview.md
+++ b/daprdocs/content/en/reference/cli/cli-overview.md
@@ -42,6 +42,7 @@ Available Commands:
   stop           Stop Dapr instances and their associated apps. Supported platforms: Self-hosted
   uninstall      Uninstall Dapr runtime. Supported platforms: Kubernetes and self-hosted
   upgrade        Upgrades a Dapr control plane installation in a cluster. Supported platforms: Kubernetes
+  version        Print the Dapr runtime and CLI version
 
 Flags:
   -h, --help          help for dapr
@@ -73,7 +74,7 @@ You can learn more about each Dapr command from the links below.
  - [`dapr stop`]({{< ref dapr-stop.md >}})
  - [`dapr uninstall`]({{< ref dapr-uninstall.md >}})
  - [`dapr upgrade`]({{< ref dapr-upgrade.md >}})
- - [`dapr-version`]({{< ref dapr-version.md >}})
+ - [`dapr version`]({{< ref dapr-version.md >}})
 
 ### Environment Variables
 


### PR DESCRIPTION
The `dapr cli` has moved the version invocation from a flag to a sub command. Updates docs to reflect this change.