### PR TITLE
Change --resource-path to --components-path

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
@@ -305,7 +305,7 @@ asyncio.run(executeConfiguration())
 ```
 
 ```bash
-dapr run --app-id orderprocessing --resources-path components/ -- python3 OrderProcessingService.py
+dapr run --app-id orderprocessing --components-path components/ -- python3 OrderProcessingService.py
 ```
 
 {{% /codetab %}}

--- a/daprdocs/content/en/getting-started/quickstarts/configuration-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/configuration-quickstart.md
@@ -64,7 +64,7 @@ pip3 install -r requirements.txt
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ --app-port 6001 -- python3 app.py
+dapr run --app-id order-processor --components-path ../../../components/ --app-port 6001 -- python3 app.py
 ```
 
 > **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
@@ -90,7 +90,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "103" orderId2 "104"
 Run the `order-processor` service again:
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ --app-port 6001 -- python3 app.py
+dapr run --app-id order-processor --components-path ../../../components/ --app-port 6001 -- python3 app.py
 ```
 
 > **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
@@ -187,7 +187,7 @@ npm install
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ --app-protocol grpc --dapr-grpc-port 3500 -- node index.js
+dapr run --app-id order-processor --components-path ../../../components/ --app-protocol grpc --dapr-grpc-port 3500 -- node index.js
 ```
 
 The expected output:
@@ -209,7 +209,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "103" orderId2 "104"
 Run the `order-processor` service again:
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ --app-protocol grpc --dapr-grpc-port 3500 -- node index.js
+dapr run --app-id order-processor --components-path ../../../components/ --app-protocol grpc --dapr-grpc-port 3500 -- node index.js
 ```
 
 The app will return the updated configuration values:
@@ -309,7 +309,7 @@ dotnet build
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7001 -- dotnet run --project .
+dapr run --app-id order-processor-http --components-path ../../../components/ --app-port 7001 -- dotnet run --project .
 ```
 
 The expected output:
@@ -331,7 +331,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "103" orderId2 "104"
 Run the `order-processor` service again:
 
 ```bash
-dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7001 -- dotnet run --project .
+dapr run --app-id order-processor-http --components-path ../../../components/ --app-port 7001 -- dotnet run --project .
 ```
 
 The app will return the updated configuration values:
@@ -428,7 +428,7 @@ mvn clean install
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
+dapr run --app-id order-processor --components-path ../../../components -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
 ```
 
 The expected output:
@@ -450,7 +450,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "103" orderId2 "104"
 Run the `order-processor` service again:
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
+dapr run --app-id order-processor --components-path ../../../components -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
 ```
 
 The app will return the updated configuration values:
@@ -537,7 +537,7 @@ cd ./configuration/go/sdk/order-processor
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor --app-port 6001 --resources-path ../../../components -- go run .
+dapr run --app-id order-processor --app-port 6001 --components-path ../../../components -- go run .
 ```
 
 The expected output:
@@ -560,7 +560,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "103" orderId2 "104"
 Run the `order-processor` service again:
 
 ```bash
-dapr run --app-id order-processor --app-port 6001 --resources-path ../../../components -- go run .
+dapr run --app-id order-processor --app-port 6001 --components-path ../../../components -- go run .
 ```
 
 The app will return the updated configuration values:


### PR DESCRIPTION
Signed-off-by: Marc Duiker <marcduiker@gmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated the Configuration Quickstart document that used the new `--resources-path` flag that is not available yet. It has been changed back to `--components-path`.

## Issue reference

#3057 
