### PR TITLE
[1.10] Rename mqtt components to mqtt3

### DIFF
--- a/daprdocs/content/en/operations/components/component-schema.md
+++ b/daprdocs/content/en/operations/components/component-schema.md
@@ -44,7 +44,7 @@ spec:
 
 ### Special metadata values
 
-Metadata values can contain a `{uuid}` tag that is replaced with a randomly generate UUID when the Dapr sidecar starts up. A new UUID is generated on every start up. It can be used, for example, to have a pod on Kubernetes with multiple application instances consuming a [shared MQTT subscription]({{< ref "setup-mqtt.md" >}}). Below is an example of using the `{uuid}` tag.
+Metadata values can contain a `{uuid}` tag that is replaced with a randomly generate UUID when the Dapr sidecar starts up. A new UUID is generated on every start up. It can be used, for example, to have a pod on Kubernetes with multiple application instances consuming a [shared MQTT subscription]({{< ref "setup-mqtt3.md" >}}). Below is an example of using the `{uuid}` tag.
 
 ```yaml
 apiVersion: dapr.io/v1alpha1
@@ -52,7 +52,7 @@ kind: Component
 metadata:
   name: messagebus
 spec:
-  type: pubsub.mqtt
+  type: pubsub.mqtt3
   version: v1
   metadata:
     - name: consumerID

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/mqtt3.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/mqtt3.md
@@ -1,15 +1,16 @@
 ---
 type: docs
-title: "MQTT binding spec"
-linkTitle: "MQTT"
-description: "Detailed documentation on the MQTT binding component"
+title: "MQTT3 binding spec"
+linkTitle: "MQTT3"
+description: "Detailed documentation on the MQTT3 binding component"
 aliases:
+  - "/operations/components/setup-bindings/supported-bindings/mqtt3/"
   - "/operations/components/setup-bindings/supported-bindings/mqtt/"
 ---
 
 ## Component format
 
-To setup MQTT binding create a component of type `bindings.mqtt`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.
+To setup a MQTT3 binding create a component of type `bindings.mqtt3`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.
 
 ```yaml
 apiVersion: dapr.io/v1alpha1
@@ -17,7 +18,7 @@ kind: Component
 metadata:
   name: <NAME>
 spec:
-  type: bindings.mqtt
+  type: bindings.mqtt3
   version: v1
   metadata:
   - name: url
@@ -63,7 +64,7 @@ kind: Component
 metadata:
   name: mqtt-binding
 spec:
-  type: bindings.mqtt
+  type: bindings.mqtt3
   version: v1
   metadata:
   - name: url
@@ -103,7 +104,7 @@ metadata:
   name: mqtt-binding
   namespace: default
 spec:
-  type: bindings.mqtt
+  type: bindings.mqtt3
   version: v1
   metadata:
   - name: consumerID

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-mqtt3.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-mqtt3.md
@@ -1,15 +1,16 @@
 ---
 type: docs
-title: "MQTT"
-linkTitle: "MQTT"
-description: "Detailed documentation on the MQTT pubsub component"
+title: "MQTT3"
+linkTitle: "MQTT3"
+description: "Detailed documentation on the MQTT3 pubsub component"
 aliases:
+  - "/operations/components/setup-pubsub/supported-pubsub/setup-mqtt3/"
   - "/operations/components/setup-pubsub/supported-pubsub/setup-mqtt/"
 ---
 
 ## Component format
 
-To setup MQTT pubsub create a component of type `pubsub.mqtt`. See [this guide]({{< ref "howto-publish-subscribe.md#step-1-setup-the-pubsub-component" >}}) on how to create and apply a pubsub configuration
+To setup a MQTT3 pubsub create a component of type `pubsub.mqtt3`. See [this guide]({{< ref "howto-publish-subscribe.md#step-1-setup-the-pubsub-component" >}}) on how to create and apply a pubsub configuration
 
 ```yaml
 apiVersion: dapr.io/v1alpha1
@@ -17,7 +18,7 @@ kind: Component
 metadata:
   name: mqtt-pubsub
 spec:
-  type: pubsub.mqtt
+  type: pubsub.mqtt3
   version: v1
   metadata:
   - name: url
@@ -59,7 +60,7 @@ kind: Component
 metadata:
   name: mqtt-pubsub
 spec:
-  type: pubsub.mqtt
+  type: pubsub.mqtt3
   version: v1
   metadata:
   - name: url
@@ -96,7 +97,7 @@ kind: Component
 metadata:
   name: mqtt-pubsub
 spec:
-  type: pubsub.mqtt
+  type: pubsub.mqtt3
   version: v1
   metadata:
     - name: consumerID
@@ -119,7 +120,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 Note that in the case, the value of the consumer ID is random every time Dapr restarts, so we are setting `cleanSession` to true as well.
 
-## Create a MQTT broker
+## Create a MQTT3 broker
 
 {{< tabs "Self-Hosted" "Kubernetes">}}
 
@@ -134,7 +135,7 @@ You can then interact with the server using the client port: `mqtt://localhost:1
 {{% /codetab %}}
 
 {{% codetab %}}
-You can run a MQTT broker in kubernetes using following yaml:
+You can run a MQTT3 broker in kubernetes using following yaml:
 
 ```yaml
 apiVersion: apps/v1

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -54,8 +54,8 @@
   features:
     input: false
     output: true
-- component: MQTT
-  link: mqtt
+- component: MQTT3
+  link: mqtt3
   state: Beta
   version: v1
   since: "1.7"

--- a/daprdocs/data/components/pubsub/generic.yaml
+++ b/daprdocs/data/components/pubsub/generic.yaml
@@ -28,8 +28,8 @@
   state: Beta
   version: v1
   since: "1.7"
-- component: MQTT
-  link: setup-mqtt
+- component: MQTT3
+  link: setup-mqtt3
   state: Stable
   version: v1
   since: "1.7"


### PR DESCRIPTION
See https://github.com/dapr/components-contrib/issues/2359

The old component names are still available as aliases