### PR TITLE
docs: improve consistency on navigation commands

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/bindings-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/bindings-quickstart.md
@@ -46,7 +46,7 @@ Run the [PostgreSQL instance](https://www.postgresql.org/) locally in a Docker c
 In a terminal window, from the root of the Quickstarts clone directory, navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following command to set up the container:
@@ -73,7 +73,7 @@ CONTAINER ID   IMAGE      COMMAND                  CREATED         STATUS       
 In a new terminal window, navigate to the SDK directory.
 
 ```bash
-cd quickstarts/bindings/python/sdk/batch
+cd bindings/python/sdk/batch
 ```
 
 Install the dependencies:
@@ -137,7 +137,7 @@ Your output binding's `print` statement output:
 In a new terminal, verify the same data has been inserted into the database. Navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following to start the interactive Postgres CLI:
@@ -253,7 +253,7 @@ Run the [PostgreSQL instance](https://www.postgresql.org/) locally in a Docker c
 In a terminal window, from the root of the Quickstarts clone directory, navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following command to set up the container:
@@ -280,7 +280,7 @@ CONTAINER ID   IMAGE      COMMAND                  CREATED         STATUS       
 In a new terminal window, navigate to the SDK directory.
 
 ```bash
-cd quickstarts/bindings/javascript/sdk/batch
+cd bindings/javascript/sdk/batch
 ```
 
 Install the dependencies:
@@ -339,7 +339,7 @@ Your output binding's `print` statement output:
 In a new terminal, verify the same data has been inserted into the database. Navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following to start the interactive Postgres CLI:
@@ -455,7 +455,7 @@ Run the [PostgreSQL instance](https://www.postgresql.org/) locally in a Docker c
 In a terminal window, from the root of the Quickstarts clone directory, navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following command to set up the container:
@@ -482,7 +482,7 @@ CONTAINER ID   IMAGE      COMMAND                  CREATED         STATUS       
 In a new terminal window, navigate to the SDK directory.
 
 ```bash
-cd quickstarts/bindings/csharp/sdk/batch
+cd bindings/csharp/sdk/batch
 ```
 
 Install the dependencies:
@@ -543,7 +543,7 @@ Your output binding's `print` statement output:
 In a new terminal, verify the same data has been inserted into the database. Navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following to start the interactive Postgres CLI:
@@ -662,7 +662,7 @@ Run the [PostgreSQL instance](https://www.postgresql.org/) locally in a Docker c
 In a terminal window, from the root of the Quickstarts clone directory, navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following command to set up the container:
@@ -689,7 +689,7 @@ CONTAINER ID   IMAGE      COMMAND                  CREATED         STATUS       
 In a new terminal window, navigate to the SDK directory.
 
 ```bash
-cd quickstarts/bindings/java/sdk/batch
+cd bindings/java/sdk/batch
 ```
 
 Install the dependencies:
@@ -753,7 +753,7 @@ Your output binding's `print` statement output:
 In a new terminal, verify the same data has been inserted into the database. Navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following to start the interactive Postgres CLI:
@@ -869,7 +869,7 @@ Run the [PostgreSQL instance](https://www.postgresql.org/) locally in a Docker c
 In a terminal window, from the root of the Quickstarts clone directory, navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following command to set up the container:
@@ -896,7 +896,7 @@ CONTAINER ID   IMAGE      COMMAND                  CREATED         STATUS       
 In a new terminal window, navigate to the SDK directory.
 
 ```bash
-cd quickstarts/bindings/go/sdk/batch
+cd bindings/go/sdk/batch
 ```
 
 Install the dependencies:
@@ -965,7 +965,7 @@ Your output binding's `print` statement output:
 In a new terminal, verify the same data has been inserted into the database. Navigate to the `bindings/db` directory.
 
 ```bash
-cd quickstarts/bindings/db
+cd bindings/db
 ```
 
 Run the following to start the interactive Postgres CLI:

--- a/daprdocs/content/en/getting-started/quickstarts/configuration-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/configuration-quickstart.md
@@ -52,7 +52,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "101" orderId2 "102"
 From the root of the Quickstarts clone directory, navigate to the `order-processor` directory.
 
 ```bash
-cd ./configuration/python/sdk/order-processor
+cd configuration/python/sdk/order-processor
 ```
 
 Install the dependencies:
@@ -175,7 +175,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "101" orderId2 "102"
 From the root of the Quickstarts clone directory, navigate to the `order-processor` directory.
 
 ```bash
-cd ./configuration/javascript/sdk/order-processor
+cd configuration/javascript/sdk/order-processor
 ```
 
 Install the dependencies:
@@ -296,7 +296,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "101" orderId2 "102"
 From the root of the Quickstarts clone directory, navigate to the `order-processor` directory.
 
 ```bash
-cd ./configuration/csharp/sdk/order-processor
+cd configuration/csharp/sdk/order-processor
 ```
 
 Recall NuGet packages:
@@ -416,7 +416,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "101" orderId2 "102"
 From the root of the Quickstarts clone directory, navigate to the `order-processor` directory.
 
 ```bash
-cd ./configuration/java/sdk/order-processor
+cd configuration/java/sdk/order-processor
 ```
 
 Install the dependencies:
@@ -531,7 +531,7 @@ docker exec dapr_redis redis-cli MSET orderId1 "101" orderId2 "102"
 From the root of the Quickstarts clone directory, navigate to the `order-processor` directory.
 
 ```bash
-cd ./configuration/go/sdk/order-processor
+cd configuration/go/sdk/order-processor
 ```
 
 Run the `order-processor` service alongside a Dapr sidecar.


### PR DESCRIPTION
Signed-off-by: Samantha Coyle <sam@diagrid.io>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated the quickstart documentation for bindings and configuration to be more consistent with the `cd` commands from the other quickstart sections, and the assumption made that the dev is already within the `quickstart` root directory as per the instruction description.

## Issue reference

[#3060](https://github.com/dapr/docs/issues/3060)
