### PR TITLE
add information about needed ports for kube api to reach

### DIFF
--- a/daprdocs/content/en/operations/troubleshooting/common_issues.md
+++ b/daprdocs/content/en/operations/troubleshooting/common_issues.md
@@ -99,15 +99,15 @@ There are some known cases where this might not properly work:
   Check with your cluster administrators to setup allow ingress
   rules to the above ports, __4000__ and __19443__, in the cluster from the kube api servers. 
 
-  ## My pod is in CrashLoopBackoff or another failed state due to the daprd sidecar
+## My pod is in CrashLoopBackoff or another failed state due to the daprd sidecar
 
-  If the Dapr sidecar (`daprd`) is taking too long to initialize, this might be surfaced as a failing health check by Kubernetes.
+If the Dapr sidecar (`daprd`) is taking too long to initialize, this might be surfaced as a failing health check by Kubernetes.
 
-  If your pod is in a failed state you should check this:
+If your pod is in a failed state you should check this:
 
-  ```bash
-  kubectl describe pod <name-of-pod>
-  ```
+```bash
+kubectl describe pod <name-of-pod>
+```
 
 You might see a table like the following at the end of the command output:
 

--- a/daprdocs/content/en/operations/troubleshooting/common_issues.md
+++ b/daprdocs/content/en/operations/troubleshooting/common_issues.md
@@ -50,55 +50,64 @@ spec:
         imagePullPolicy: Always
 ```
 
-If your pod spec template is annotated correctly and you still don't see the sidecar injected, make sure Dapr was deployed to the cluster before your deployment or pod were deployed.
+There are some known cases where this might not properly work:
 
-If this is the case, restarting the pods will fix the issue.
+- If your pod spec template is annotated correctly, and you still don't see the sidecar injected, make sure Dapr was deployed to the cluster before your deployment or pod were deployed.
 
-If you are deploying Dapr on a private GKE cluster, sidecar injection does not work without extra steps. See [Setup a Google Kubernetes Engine cluster]({{< ref setup-gke.md >}}).
+  If this is the case, restarting the pods will fix the issue.
 
-In order to further diagnose any issue, check the logs of the Dapr sidecar injector:
+- If you are deploying Dapr on a private GKE cluster, sidecar injection does not work without extra steps. See [Setup a Google Kubernetes Engine cluster]({{< ref setup-gke.md >}}).
 
-```bash
- kubectl logs -l app=dapr-sidecar-injector -n dapr-system
-```
+  In order to further diagnose any issue, check the logs of the Dapr sidecar injector:
 
-*Note: If you installed Dapr to a different namespace, replace dapr-system above with the desired namespace*
+  ```bash
+   kubectl logs -l app=dapr-sidecar-injector -n dapr-system
+  ```
 
-If you are deploying Dapr on Amazon EKS and using an overlay network such as Calico, you will need to set `hostNetwork` parameter to true, this is a limitation of EKS with such CNIs.
+  *Note: If you installed Dapr to a different namespace, replace dapr-system above with the desired namespace*
 
-You can set this parameter using Helm `values.yaml` file:
+- If you are deploying Dapr on Amazon EKS and using an overlay network such as Calico, you will need to set `hostNetwork` parameter to true, this is a limitation of EKS with such CNIs.
 
-```
-helm upgrade --install dapr dapr/dapr \
+  You can set this parameter using Helm `values.yaml` file:
+
+  ```
+  helm upgrade --install dapr dapr/dapr \
   --namespace dapr-system \
   --create-namespace \
   --values values.yaml
-```
+  ```
 
-`values.yaml`
-```yaml
-dapr_sidecar_injector:
-  hostNetwork: true
-```
+  `values.yaml`
+  ```yaml
+  dapr_sidecar_injector:
+    hostNetwork: true
+  ```
 
-or using command line:
+  or using command line:
 
-```
-helm upgrade --install dapr dapr/dapr \
+  ```
+  helm upgrade --install dapr dapr/dapr \
   --namespace dapr-system \
   --create-namespace \
   --set dapr_sidecar_injector.hostNetwork=true
-```
+  ```
+  
+- Make sure the kube api server can reach the following webhooks services:
+  - [Sidecar Mutating Webhook Injector Service](https://github.com/dapr/dapr/blob/44235fe8e8799589bb393a3124d2564db2dd6885/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml#L157) at port __4000__ that is served from the sidecar injector.
+  - [CRD Conversion Webhook Service](https://github.com/dapr/dapr/blob/44235fe8e8799589bb393a3124d2564db2dd6885/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml#L28) at port __19443__ that is served from the operator.
+  
+  Check with your cluster administrators to setup allow ingress
+  rules to the above ports, __4000__ and __19443__, in the cluster from the kube api servers. 
 
-## My pod is in CrashLoopBackoff or another failed state due to the daprd sidecar
+  ## My pod is in CrashLoopBackoff or another failed state due to the daprd sidecar
 
-If the Dapr sidecar (`daprd`) is taking too long to initialize, this might be surfaced as a failing health check by Kubernetes.
+  If the Dapr sidecar (`daprd`) is taking too long to initialize, this might be surfaced as a failing health check by Kubernetes.
 
-If your pod is in a failed state you should check this:
+  If your pod is in a failed state you should check this:
 
-```bash
-kubectl describe pod <name-of-pod>
-```
+  ```bash
+  kubectl describe pod <name-of-pod>
+  ```
 
 You might see a table like the following at the end of the command output:
 


### PR DESCRIPTION
Signed-off-by: Filinto Duran <filinto@diagrid.io>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

There is not information of why sidecar injector would not work if kube api server is not allowed to reach webhook.

## Issue reference

https://github.com/dapr/dapr/issues/5779#issuecomment-1396660625
