### PR TITLE
Document minimum requirement of K8s 1.23

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
@@ -6,11 +6,13 @@ weight: 40000
 description: "Recommendations and practices for deploying Dapr to a Kubernetes cluster in a production-ready configuration"
 ---
 
-## Cluster capacity requirements
+## Cluster and capacity requirements
+
+Dapr is supported on Kubernetes 1.23 or higher.
 
 For a production-ready Kubernetes cluster deployment, we recommended you run a cluster of at least 3 worker nodes to support a highly-available control plane installation.
 
-Use the following resource settings as a starting point. Requirements will vary depending on cluster size and other factors, so you should perform individual testing to find the right values for your environment:
+Use the following resource settings as a starting point. Requirements will vary depending on cluster size, number of pods, and other factors, so you should perform individual testing to find the right values for your environment:
 
 | Deployment  | CPU | Memory
 |-------------|-----|-------

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
@@ -8,7 +8,7 @@ description: "Recommendations and practices for deploying Dapr to a Kubernetes c
 
 ## Cluster and capacity requirements
 
-Dapr is supported on Kubernetes 1.23 or higher.
+Dapr support for Kubernetes is aligned with [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/). 
 
 For a production-ready Kubernetes cluster deployment, we recommended you run a cluster of at least 3 worker nodes to support a highly-available control plane installation.
 


### PR DESCRIPTION
Fixes #2936

Note that although the linked issue sets 1.22 as absolute minimum, 1.22 is EOL and in our CI we test against 1.23 and higher only. So feel that 1.23 is a more appropriate minimum for us to declare we "support it".