### PR TITLE
Commands to change directory have incorrect path

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/resiliency/resiliency-serviceinvo-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/resiliency/resiliency-serviceinvo-quickstart.md
@@ -47,7 +47,7 @@ git clone https://github.com/dapr/quickstarts.git
 In a terminal window, from the root of the Quickstart directory, navigate to `order-processor` directory.
 
 ```bash
-cd ../service_invocation/python/http/order-processor
+cd service_invocation/python/http/order-processor
 ```
 
 Install dependencies:
@@ -67,7 +67,7 @@ dapr run --app-port 8001 --app-id order-processor  --config ../config.yaml --com
 In a new terminal window, from the root of the Quickstart directory, navigate to the `checkout` directory.
 
 ```bash
-cd ../service_invocation/python/http/checkout
+cd service_invocation/python/http/checkout
 ```
 
 Install dependencies:
@@ -275,7 +275,7 @@ In a terminal window, from the root of the Quickstart directory,
 navigate to `order-processor` directory.
 
 ```bash
-cd ../service_invocation/javascript/http/order-processor
+cd service_invocation/javascript/http/order-processor
 ```
 
 Install dependencies:
@@ -505,7 +505,7 @@ navigate to `order-processor` directory.
 
 
 ```bash
-cd ../service_invocation/csharp/http/order-processor
+cd service_invocation/csharp/http/order-processor
 ```
 
 Install dependencies:
@@ -527,7 +527,7 @@ In a new terminal window, from the root of the Quickstart directory,
 navigate to the `checkout` directory.
 
 ```bash
-cd ../service_invocation/csharp/http/checkout
+cd service_invocation/csharp/http/checkout
 ```
 
 Install dependencies:
@@ -739,7 +739,7 @@ In a terminal window, from the root of the Quickstart directory,
 navigate to `order-processor` directory.
 
 ```bash
-cd ../service_invocation/java/http/order-processor
+cd service_invocation/java/http/order-processor
 ```
 
 Install dependencies:
@@ -760,7 +760,7 @@ In a new terminal window, from the root of the Quickstart directory,
 navigate to the `checkout` directory.
 
 ```bash
-cd ../service_invocation/java/http/checkout
+cd service_invocation/java/http/checkout
 ```
 
 Install dependencies:
@@ -968,7 +968,7 @@ In a terminal window, from the root of the Quickstart directory,
 navigate to `order-processor` directory.
 
 ```bash
-cd ../service_invocation/go/http/order-processor
+cd service_invocation/go/http/order-processor
 ```
 
 Install dependencies:
@@ -989,7 +989,7 @@ In a new terminal window, from the root of the Quickstart directory,
 navigate to the `checkout` directory.
 
 ```bash
-cd ../service_invocation/go/http/checkout
+cd service_invocation/go/http/checkout
 ```
 
 Install dependencies:


### PR DESCRIPTION
Signed-off-by: Sujit D'Mello <sujit@hotmail.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The Quickstart instructions contain various instances where the user is expected to change directory from the root of the quickstart folder, but the **cd** command listed has an incorrect path specified so it does not work as intended. Most will figure out the typo off course but this will make the experience a bit better for those new to Dapr.

Here's an example of one instance:

Old command:

```bash
cd ../service_invocation/go/http/checkout
```

New command:

```bash
cd service_invocation/go/http/checkout
```

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
