### PR TITLE
Fix stop signal command

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/resiliency/resiliency-serviceinvo-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/resiliency/resiliency-serviceinvo-quickstart.md
@@ -149,30 +149,9 @@ Since the `resiliency.yaml` spec defines the `order-processor` service as a resi
 
 In the `order-processor` window, stop the service:
 
-{{< tabs "MacOs" "Windows" >}}
-
- <!-- MacOS -->
-
-{{% codetab %}}
-
-```script
-CMD + C
-```
-
-{{% /codetab %}}
-
- <!-- Windows -->
-
-{{% codetab %}}
-
 ```script
 CTRL + C
 ```
-
-{{% /codetab %}}
-
-{{< /tabs >}}
-
 
 Once the first request fails, the retry policy titled `retryForever` is applied:
 


### PR DESCRIPTION
On Mac, commands are stopped with CTRL+C too