### PR TITLE
Update doc for CEL match for numeric values

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-route-messages.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-route-messages.md
@@ -270,7 +270,9 @@ Match deposits greater than $10,000:
 ```javascript
 event.type == "deposit" && int(event.data.amount) > 10000
 ```
-**N.B. By default the numeric values ​​are written as double-precision floating-point. There are no automatic arithmetic conversions for numeric values, in this case if `event.data.amount` is not cast as integer the match is not performed. For more see the [CEL documentation](https://github.com/google/cel-spec/blob/master/doc/langdef.md)**
+{{% alert title="Note" color="primary" %}}
+By default the numeric values ​​are written as double-precision floating-point. There are no automatic arithmetic conversions for numeric values. In this case, if `event.data.amount` is not cast as integer, the match is not performed. For more information, see the [CEL documentation](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
+{{% /alert %}}
 
 Match multiple versions of a message:
 

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-route-messages.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-route-messages.md
@@ -268,8 +268,9 @@ has(event.data.important) && event.data.important == true
 Match deposits greater than $10,000:
 
 ```javascript
-event.type == "deposit" && event.data.amount > 10000
+event.type == "deposit" && int(event.data.amount) > 10000
 ```
+**N.B. By default the numeric values ​​are written as double-precision floating-point. There are no automatic arithmetic conversions for numeric values, in this case if `event.data.amount` is not cast as integer the match is not performed. For more see the [CEL documentation](https://github.com/google/cel-spec/blob/master/doc/langdef.md)**
 
 Match multiple versions of a message:
 


### PR DESCRIPTION
Signed-off-by: Federico Codognotto <fcodognotto@tempestive.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Fix the CEL match for numeric values because by default ​​are written as double-precision floating-point.

## Issue reference

This PR will close: #3017 
