### PR TITLE
Remove output binding for k8s events

### DIFF
--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -45,7 +45,7 @@
   since: "1.0"
   features:
     input: true
-    output: true
+    output: false
 - component: Local Storage
   link: localstorage
   state: Stable


### PR DESCRIPTION
Signed-off-by: Hannah Hunter <hannahhunter@microsoft.com>

## Description

Component spec for bindings landing page said K8s events output bindings were supported... and they aren't

## Issue reference

PR will close: #2970 
