### PR TITLE
Deprecate Twitter Binding

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/twitter.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/twitter.md
@@ -7,6 +7,10 @@ aliases:
   - "/operations/components/setup-bindings/supported-bindings/twitter/"
 ---
 
+{{% alert title="Deprecation notice" color="warning" %}}
+The Twitter binding component has been deprecated and will be removed in a future release. See [this GitHub issue](https://github.com/dapr/components-contrib/issues/2503) for details.
+{{% /alert %}}
+
 ## Component format
 
 To setup Twitter binding create a component of type `bindings.twitter`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

Twitter binding is deprecated starting 1.10 and will be removed in the future (likely 1.11)
https://github.com/dapr/components-contrib/issues/2503