### PR TITLE
Adding KubeMQ Pubsub and Binding documentation

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
@@ -1,0 +1,118 @@
+---
+type: docs
+title: "KubeMQ binding spec"
+linkTitle: "KubeMQ"
+description: "Detailed documentation on the KubeMQ binding component"
+aliases:
+  - "/operations/components/setup-bindings/supported-bindings/kubemq/"
+---
+
+## Component format
+
+To setup KubeMQ binding create a component of type `bindings.kubemq`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.
+
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: binding-topic
+spec:
+  type: bindings.kubemq
+  version: v1
+  metadata:
+    - name: address
+      value: localhost:50000
+    - name: channel
+      value: queue1
+```
+
+## Spec metadata fields
+
+| Field              | Required | Details                                                      | Example                                |
+|--------------------|:--------:|--------------------------------------------------------------|----------------------------------------|
+| address            |    Y     | Address of the KubeMQ server                                 | `"localhost:50000"`                    |
+| channel            |    Y     | The Queue channel name                                       | `queue1`)                              |
+| authToken          |    N     | Auth JWT token for connection                                | `ew...`                                |
+| autoAcknowledged   |    N     | Sets if received queue message is automatically acknowledged | `true` or `false` (default is `false`) |
+| pollMaxItems       |    N     | Sets the number of messages to poll on every connection      | `1`                                    |
+| pollMaxItems       |    N     | Sets the number of messages to poll on every connection      | `1`                                    |
+| pollTimeoutSeconds |    N     | Sets the time in seconds for each poll interval              | `3600`                                 |
+
+## Binding support
+
+This component supports both **input and output** binding interfaces.
+
+
+## Create a KubeMQ broker
+
+{{< tabs "Self-Hosted" "Kubernetes">}}
+
+{{% codetab %}}
+1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/login/register](https://account.kubemq.io/login/register) and register for a key.
+2. Wait for an email confirmation with your Key
+
+You can run a KubeMQ broker with Docker:
+
+```bash
+docker run -d -p 8080:8080 -p 50000:50000 -p 9090:9090 -e KUBEMQ_TOKEN=<your-key> kubemq/kubemq
+```
+You can then interact with the server using the client port: `localhost:50000`
+
+{{% /codetab %}}
+
+{{% codetab %}}
+1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/login/register](https://account.kubemq.io/login/register) and register for a key.
+2. Wait for an email confirmation with your Key
+
+Then Run the following kubectl commands:
+
+```bash
+kubectl apply -f https://deploy.kubemq.io/init
+```
+
+```bash
+kubectl apply -f https://deploy.kubemq.io/key/<your-key>
+```
+{{% /codetab %}}
+
+{{< /tabs >}}
+
+## Install KubeMQ CLI
+Go to [KubeMQ CLI](https://github.com/kubemq-io/kubemqctl/releases) and download the latest version of the CLI.
+
+## Browse KubeMQ Dashboard
+
+{{< tabs "Self-Hosted" "Kubernetes">}}
+
+{{% codetab %}}
+Open a browser and navigate to [http://localhost:8080](http://localhost:9090)
+
+{{% /codetab %}}
+
+{{% codetab %}}
+With KubeMQCTL installed, run the following command:
+
+```bash
+kubemqctl get dashboard
+```
+Or, with kubectl installed, run port-forward command:
+
+```bash
+kubectl port-forward svc/kubemq-cluster-api -n kubemq 8080:8080
+```
+{{% /codetab %}}
+
+{{< /tabs >}}
+```
+
+## KubeMQ Documentation
+Please visit [KubeMQ Documentation](https://docs.kubemq.io/) for more information.
+
+## Related links
+
+- [Basic schema for a Dapr component]({{< ref component-schema >}})
+- [Bindings building block]({{< ref bindings >}})
+- [How-To: Trigger application with input binding]({{< ref howto-triggers.md >}})
+- [How-To: Use bindings to interface with external resources]({{< ref howto-bindings.md >}})
+- [Bindings API reference]({{< ref bindings_api.md >}})

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
@@ -85,8 +85,9 @@ Go to [KubeMQ CLI](https://github.com/kubemq-io/kubemqctl/releases) and download
 {{< tabs "Self-Hosted" "Kubernetes">}}
 
 {{% codetab %}}
-Open a browser and navigate to [http://localhost:8080](http://localhost:9090)
-
+<!-- IGNORE_LINKS -->
+Open a browser and navigate to [http://localhost:8080](http://localhost:8080)
+<!-- END_IGNORE -->
 {{% /codetab %}}
 
 {{% codetab %}}

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
@@ -29,15 +29,14 @@ spec:
 
 ## Spec metadata fields
 
-| Field              | Required | Details                                                      | Example                                |
-|--------------------|:--------:|--------------------------------------------------------------|----------------------------------------|
-| address            |    Y     | Address of the KubeMQ server                                 | `"localhost:50000"`                    |
-| channel            |    Y     | The Queue channel name                                       | `queue1`)                              |
-| authToken          |    N     | Auth JWT token for connection                                | `ew...`                                |
-| autoAcknowledged   |    N     | Sets if received queue message is automatically acknowledged | `true` or `false` (default is `false`) |
-| pollMaxItems       |    N     | Sets the number of messages to poll on every connection      | `1`                                    |
-| pollMaxItems       |    N     | Sets the number of messages to poll on every connection      | `1`                                    |
-| pollTimeoutSeconds |    N     | Sets the time in seconds for each poll interval              | `3600`                                 |
+| Field              | Required | Details                                                                                                                      | Example                                |
+|--------------------|:--------:|------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| address            |    Y     | Address of the KubeMQ server                                                                                                 | `"localhost:50000"`                    |
+| channel            |    Y     | The Queue channel name                                                                                                       | `queue1`                               |
+| authToken          |    N     | Auth JWT token for connection. Check out [KubeMQ Authentication](https://docs.kubemq.io/learn/access-control/authentication) | `ew...`                                |
+| autoAcknowledged   |    N     | Sets if received queue message is automatically acknowledged                                                                 | `true` or `false` (default is `false`) |
+| pollMaxItems       |    N     | Sets the number of messages to poll on every connection                                                                      | `1`                                    |
+| pollTimeoutSeconds |    N     | Sets the time in seconds for each poll interval                                                                              | `3600`                                 |
 
 ## Binding support
 
@@ -107,7 +106,7 @@ kubectl port-forward svc/kubemq-cluster-api -n kubemq 8080:8080
 ```
 
 ## KubeMQ Documentation
-Please visit [KubeMQ Documentation](https://docs.kubemq.io/) for more information.
+Visit [KubeMQ Documentation](https://docs.kubemq.io/) for more information.
 
 ## Related links
 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-kubemq.md
@@ -1,0 +1,110 @@
+---
+type: docs
+title: "KubeMQ"
+linkTitle: "KubeMQ"
+description: "Detailed documentation on the KubeMQ pubsub component"
+aliases:
+  - "/operations/components/setup-pubsub/supported-pubsub/setup-kubemq/"
+---
+
+## Component format
+
+To setup KubeMQ pub/sub, create a component of type `pubsub.kubemq`. See [this guide]({{< ref "howto-publish-subscribe.md#step-1-setup-the-pubsub-component" >}}) on how to create and apply a pub/sub configuration.
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: kubemq-pubsub
+spec:
+  type: pubsub.kubemq
+  version: v1
+  metadata:
+    - name: address
+      value: localhost:50000
+    - name: store
+      value: false
+```
+
+## Spec metadata fields
+
+| Field             | Required | Details                                                                                | Example                                |
+|-------------------|:--------:|----------------------------------------------------------------------------------------|----------------------------------------|
+| address           |    Y     | Address of the KubeMQ server                                                           | `"localhost:50000"`                    |
+| store             |    N     | type of pubsub, true: pubsub persisted (EventsStore), false: pubsub in-memory (Events) | `true` or `false` (default is `false`) |
+| clientID          |    N     | Name for client id connection                                                          | `sub-client-12345`                     |
+| authToken         |    N     | Auth JWT token for connection                                                          | `ew...`                                |
+| group             |    N     | Subscriber group for load balancing                                                    | `g1`                                   |
+| disableReDelivery |    N     | Sets if message will be re-deliver in case of error coming from DAPR component         | `true` or `false` (default is `false`) |
+
+## Create a KubeMQ broker
+
+{{< tabs "Self-Hosted" "Kubernetes">}}
+
+{{% codetab %}}
+1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/login/register](https://account.kubemq.io/login/register) and register for a key.
+2. Wait for an email confirmation with your Key
+
+You can run a KubeMQ broker with Docker:
+
+```bash
+docker run -d -p 8080:8080 -p 50000:50000 -p 9090:9090 -e KUBEMQ_TOKEN=<your-key> kubemq/kubemq
+```
+You can then interact with the server using the client port: `localhost:50000`
+
+{{% /codetab %}}
+
+{{% codetab %}}
+1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/login/register](https://account.kubemq.io/login/register) and register for a key.
+2. Wait for an email confirmation with your Key
+
+Then Run the following kubectl commands:
+
+```bash
+kubectl apply -f https://deploy.kubemq.io/init
+```
+
+```bash
+kubectl apply -f https://deploy.kubemq.io/key/<your-key>
+```
+{{% /codetab %}}
+
+{{< /tabs >}}
+
+## Install KubeMQ CLI
+Go to [KubeMQ CLI](https://github.com/kubemq-io/kubemqctl/releases) and download the latest version of the CLI.
+
+## Browse KubeMQ Dashboard
+
+{{< tabs "Self-Hosted" "Kubernetes">}}
+
+{{% codetab %}}
+Open a browser and navigate to [http://localhost:8080](http://localhost:9090)
+
+{{% /codetab %}}
+
+{{% codetab %}}
+With KubeMQCTL installed, run the following command:
+
+```bash
+kubemqctl get dashboard
+```
+Or, with kubectl installed, run port-forward command:
+
+```bash
+kubectl port-forward svc/kubemq-cluster-api -n kubemq 8080:8080
+```
+{{% /codetab %}}
+
+{{< /tabs >}}
+```
+
+## KubeMQ Documentation
+Please visit [KubeMQ Documentation](https://docs.kubemq.io/) for more information.
+
+
+## Related links
+
+- [Basic schema for a Dapr component]({{< ref component-schema >}})
+- Read [this guide]({{< ref "howto-publish-subscribe.md#step-2-publish-a-topic" >}}) for instructions on configuring pub/sub components
+- [Pub/sub building block]({{< ref pubsub >}})

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-kubemq.md
@@ -28,14 +28,14 @@ spec:
 
 ## Spec metadata fields
 
-| Field             | Required | Details                                                                                | Example                                |
-|-------------------|:--------:|----------------------------------------------------------------------------------------|----------------------------------------|
-| address           |    Y     | Address of the KubeMQ server                                                           | `"localhost:50000"`                    |
-| store             |    N     | type of pubsub, true: pubsub persisted (EventsStore), false: pubsub in-memory (Events) | `true` or `false` (default is `false`) |
-| clientID          |    N     | Name for client id connection                                                          | `sub-client-12345`                     |
-| authToken         |    N     | Auth JWT token for connection                                                          | `ew...`                                |
-| group             |    N     | Subscriber group for load balancing                                                    | `g1`                                   |
-| disableReDelivery |    N     | Sets if message will be re-deliver in case of error coming from DAPR component         | `true` or `false` (default is `false`) |
+| Field             | Required | Details                                                                                                                     | Example                                |
+|-------------------|:--------:|-----------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| address           |    Y     | Address of the KubeMQ server                                                                                                | `"localhost:50000"`                    |
+| store             |    N     | type of pubsub, true: pubsub persisted (EventsStore), false: pubsub in-memory (Events)                                      | `true` or `false` (default is `false`) |
+| clientID          |    N     | Name for client id connection                                                                                               | `sub-client-12345`                     |
+| authToken         |    N     | Auth JWT token for connection Check out [KubeMQ Authentication](https://docs.kubemq.io/learn/access-control/authentication) | `ew...`                                |
+| group             |    N     | Subscriber group for load balancing                                                                                         | `g1`                                   |
+| disableReDelivery |    N     | Set if message should be re-delivered in case of error coming from application                                              | `true` or `false` (default is `false`) |
 
 ## Create a KubeMQ broker
 
@@ -100,7 +100,7 @@ kubectl port-forward svc/kubemq-cluster-api -n kubemq 8080:8080
 ```
 
 ## KubeMQ Documentation
-Please visit [KubeMQ Documentation](https://docs.kubemq.io/) for more information.
+Visit [KubeMQ Documentation](https://docs.kubemq.io/) for more information.
 
 
 ## Related links

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-kubemq.md
@@ -79,8 +79,9 @@ Go to [KubeMQ CLI](https://github.com/kubemq-io/kubemqctl/releases) and download
 {{< tabs "Self-Hosted" "Kubernetes">}}
 
 {{% codetab %}}
-Open a browser and navigate to [http://localhost:8080](http://localhost:9090)
-
+<!-- IGNORE_LINKS -->
+Open a browser and navigate to [http://localhost:8080](http://localhost:8080)
+<!-- END_IGNORE -->
 {{% /codetab %}}
 
 {{% codetab %}}

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -142,3 +142,11 @@
   features:
     input: false
     output: true
+- component: KubeMQ
+  link: kubemq
+  state: Beta
+  version: v1
+  since: "1.10"
+  features:
+    input: true
+    output: true

--- a/daprdocs/data/components/pubsub/generic.yaml
+++ b/daprdocs/data/components/pubsub/generic.yaml
@@ -86,3 +86,11 @@
   features:
     bulkPublish: false
     bulkSubscribe: false
+- component: Solace-AMQP
+  link: setup-kubemq
+  state: Beta
+  version: v1
+  since: "1.10"
+  features:
+    bulkPublish: false
+    bulkSubscribe: false

--- a/daprdocs/data/components/pubsub/generic.yaml
+++ b/daprdocs/data/components/pubsub/generic.yaml
@@ -86,7 +86,7 @@
   features:
     bulkPublish: false
     bulkSubscribe: false
-- component: Solace-AMQP
+- component: KubeMQ
   link: setup-kubemq
   state: Beta
   version: v1


### PR DESCRIPTION
Signed-off-by: Lior Nabat <lior.nabat@kubemq.io>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x ] Commands include options for Linux, MacOS, and Windows within codetabs
- [x ] New file and folder names are globally unique
- [x ] Page references use shortcodes instead of markdown or URL links
- [ x] Images use HTML style and have alternative text
- [ x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Add KubeMQ Pubsub and Binding documentation 
## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
