### PR TITLE
Updated resourcepath in statementmanagement quickstart

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
@@ -51,7 +51,7 @@ pip3 install -r requirements.txt
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ -- python3 app.py
+dapr run --app-id order-processor --resources-path ../../../resources/ -- python3 app.py
 ```
 
 > **Note**: Since Python3.exe is not defined in Windows, you may need to use `python app.py` instead of `python3 app.py`.
@@ -172,7 +172,7 @@ Verify you have the following files included in the service directory:
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ -- npm run start
+dapr run --app-id order-processor --resources-path ../../../resources/ -- npm run start
 ```
 The `order-processor` service writes, reads, and deletes an `orderId` key/value pair to the `statestore` instance [defined in the `statestore.yaml` component]({{< ref "#statestoreyaml-component-file" >}}). As soon as the service starts, it performs a loop.
 
@@ -300,7 +300,7 @@ dotnet build
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ -- dotnet run
+dapr run --app-id order-processor --resources-path ../../../resources/ -- dotnet run
 ```
 
 The `order-processor` service writes, reads, and deletes an `orderId` key/value pair to the `statestore` instance [defined in the `statestore.yaml` component]({{< ref "#statestoreyaml-component-file" >}}). As soon as the service starts, it performs a loop.


### PR DESCRIPTION
## Description

The components folder in the quickstart is renamed to resources, with this change the command line example is changed

