### PR TITLE
[1.9+] Fixed incorrect information on resiliency policies

### DIFF
--- a/daprdocs/content/en/operations/resiliency/policies.md
+++ b/daprdocs/content/en/operations/resiliency/policies.md
@@ -71,7 +71,7 @@ spec:
 
 ## Circuit Breakers
 
-Circuit Breaker (CB) policies are used when other applications/services/components are experiencing elevated failure rates. CBs monitor the requests and shut off all traffic to the impacted service when a certain criteria is met ("open" state). By doing this, CBs give the service time to recover from their outage instead of flooding it with events. The CB can also allow partial traffic through to see if the system has healed ("half-open" state). Once requests resume being successful, the CB can get into "closed" state and allow traffic to resume.
+Circuit Breaker (CB) policies are used when other applications/services/components are experiencing elevated failure rates. CBs monitor the requests and shut off all traffic to the impacted service when a certain criteria is met ("open" state). By doing this, CBs give the service time to recover from their outage instead of flooding it with events. The CB can also allow partial traffic through to see if the system has healed ("half-open" state). Once requests resume being successful, the CB gets into "closed" state and allows traffic to completely resume.
 
 | Retry option | Description |
 | ------------ | ----------- |

--- a/daprdocs/content/en/operations/resiliency/policies.md
+++ b/daprdocs/content/en/operations/resiliency/policies.md
@@ -69,18 +69,16 @@ spec:
         maxRetries: -1 # Retry indefinitely
 ```
 
-## Circuit breakers
+## Circuit Breakers
 
-Circuit breakers (CBs) policies are used when other applications/services/components are experiencing elevated failure rates. CBs monitor the requests and shut off all traffic to the impacted service when a certain criteria is met. By doing this, CBs give the service time to recover from their outage instead of flooding them with events. The CB can also allow partial traffic through to see if the system has healed (half-open state). Once successful requests start to occur, the CB can close and allow traffic to resume.
+Circuit Breaker (CB) policies are used when other applications/services/components are experiencing elevated failure rates. CBs monitor the requests and shut off all traffic to the impacted service when a certain criteria is met ("open" state). By doing this, CBs give the service time to recover from their outage instead of flooding it with events. The CB can also allow partial traffic through to see if the system has healed ("half-open" state). Once requests resume being successful, the CB can get into "closed" state and allow traffic to resume.
 
 | Retry option | Description |
 | ------------ | ----------- |
 | `maxRequests` | The maximum number of requests allowed to pass through when the CB is half-open (recovering from failure). Defaults to `1`. |
 | `interval` | The cyclical period of time used by the CB to clear its internal counts. If set to 0 seconds, this never clears. Defaults to `0s`. |
 | `timeout` | The period of the open state (directly after failure) until the CB switches to half-open. Defaults to `60s`. |
-| `trip` | A Common Expression Language (CEL) statement that is evaluated by the CB. When the statement evaluates to true, the CB trips and becomes open. Defaults to `consecutiveFailures > 5`. |
-| `circuitBreakerScope` | Specify whether circuit breaking state should be scoped to an individual actor ID, all actors across the actor type, or both. Possible values include `id`, `type`, or `both`|
-| `circuitBreakerCacheSize` | Specify a cache size for the number of CBs to keep in memory. The value should be larger than the expected number of active actor instances.  Provide an integer value, for example `5000`. |
+| `trip` | A [Common Expression Language (CEL)](https://github.com/google/cel-spec) statement that is evaluated by the CB. When the statement evaluates to true, the CB trips and becomes open. Defaults to `consecutiveFailures > 5`. |
 
 Example:
 
@@ -147,21 +145,21 @@ If these policies are defined, they are used for every operation to a service, a
 
 Below is a table of all possible default policy keywords and how they translate into a policy name.
 
-| Keyword                        | Target Operation                                     | Example Policy Name                                       |
-| ------------------------------ | ---------------------------------------------------- | --------------------------------------------------------- |
-| App                            | Service invocation.                                  | DefaultAppRetryPolicy                                     |
-| Actor                          | Actor invocation.                                    | DefaultActorTimeoutPolicy                                 |
-| Component                      | All component operations.                            | DefaultComponentCircuitBreakerPolicy                      |
-| ComponentInbound               | All inbound component operations.                    | DefaultComponentInboundRetryPolicy                        |
-| ComponentOutbound              | All outbound component operations.                   | DefaultComponentOutboundTimeoutPolicy                     |
-| StatestoreComponentOutbound    | All statestore component operations.                 | DefaultStatestoreComponentOutboundCircuitBreakerPolicy    |
-| PubsubComponentOutbound        | All outbound pubusub (publish) component operations. | DefaultPubsubComponentOutboundRetryPolicy                 |
-| PubsubComponentInbound         | All inbound pubsub (subscribe) component operations. | DefaultPubsubComponentInboundTimeoutPolicy                |
-| BindingComponentOutbound       | All outbound binding (invoke) component operations.  | DefaultBindingComponentOutboundCircuitBreakerPolicy       |
-| BindingComponentInbound        | All inbound binding (read) component operations.     | DefaultBindingComponentInboundRetryPolicy                 |
-| SecretstoreComponentOutbound   | All secretstore component operations.                | DefaultSecretstoreComponentTimeoutPolicy                  |
-| ConfigurationComponentOutbound | All configuration component operations.              | DefaultConfigurationComponentOutboundCircuitBreakerPolicy |
-| LockComponentOutbound          | All lock component operations.                       | DefaultLockComponentOutboundRetryPolicy                   | 
+| Keyword                          | Target Operation                                     | Example Policy Name                                         |
+| -------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------- |
+| `App`                            | Service invocation.                                  | `DefaultAppRetryPolicy`                                     |
+| `Actor`                          | Actor invocation.                                    | `DefaultActorTimeoutPolicy`                                 |
+| `Component`                      | All component operations.                            | `DefaultComponentCircuitBreakerPolicy`                      |
+| `ComponentInbound`               | All inbound component operations.                    | `DefaultComponentInboundRetryPolicy`                        |
+| `ComponentOutbound`              | All outbound component operations.                   | `DefaultComponentOutboundTimeoutPolicy`                     |
+| `StatestoreComponentOutbound`    | All statestore component operations.                 | `DefaultStatestoreComponentOutboundCircuitBreakerPolicy`    |
+| `PubsubComponentOutbound`        | All outbound pubusub (publish) component operations. | `DefaultPubsubComponentOutboundRetryPolicy`                 |
+| `PubsubComponentInbound`         | All inbound pubsub (subscribe) component operations. | `DefaultPubsubComponentInboundTimeoutPolicy`                |
+| `BindingComponentOutbound`       | All outbound binding (invoke) component operations.  | `DefaultBindingComponentOutboundCircuitBreakerPolicy`       |
+| `BindingComponentInbound`        | All inbound binding (read) component operations.     | `DefaultBindingComponentInboundRetryPolicy`                 |
+| `SecretstoreComponentOutbound`   | All secretstore component operations.                | `DefaultSecretstoreComponentTimeoutPolicy`                  |
+| `ConfigurationComponentOutbound` | All configuration component operations.              | `DefaultConfigurationComponentOutboundCircuitBreakerPolicy` |
+| `LockComponentOutbound`          | All lock component operations.                       | `DefaultLockComponentOutboundRetryPolicy`                   |
 
 ### Policy hierarchy resolution
 
@@ -281,14 +279,14 @@ spec:
 
 The table below is a break down of which policies are applied when attempting to call the various targets in this solution.
 
-| Target             | Policy Used                                     |
-| ------------------ | ----------------------------------------------- |
-| AppA               | fastRetries                                     |
-| AppB               | retryForever                                    |
-| AppC               | DefaultAppRetryPolicy / DaprBuiltInActorRetries |
-| pubsub - Publish   | DefaultRetryPolicy                              |
-| pubsub - Subscribe | DefaultComponentInboundRetryPolicy              |
-| statestore         | DefaultStatestoreComponentOutboundRetryPolicy   |
-| actorstore         | fastRetries                                     |
-| EventActor         | retryForever                                    |
-| SummaryActor       | DefaultActorRetryPolicy                         |
+| Target             | Policy Used                                         |
+| ------------------ | --------------------------------------------------- |
+| AppA               | `fastRetries`                                       |
+| AppB               | `retryForever`                                      |
+| AppC               | `DefaultAppRetryPolicy` / `DaprBuiltInActorRetries` |
+| pubsub - Publish   | `DefaultRetryPolicy`                                |
+| pubsub - Subscribe | `DefaultComponentInboundRetryPolicy`                |
+| statestore         | `DefaultStatestoreComponentOutboundRetryPolicy`     |
+| actorstore         | `fastRetries`                                       |
+| EventActor         | `retryForever`                                      |
+| SummaryActor       | `DefaultActorRetryPolicy`                           |

--- a/daprdocs/content/en/operations/resiliency/targets.md
+++ b/daprdocs/content/en/operations/resiliency/targets.md
@@ -44,7 +44,7 @@ Policies can be applied for `outbound` operations (calls to the Dapr sidecar) an
 `outbound` operations are calls from the sidecar to a component, such as:
 
 - Persisting or retrieving state.
-- Publishing a message.
+- Publishing a message on a PubSub component.
 - Invoking an output binding.
 
 > Some components may have built-in retry capabilities and are configured on a per-component basis.
@@ -65,7 +65,7 @@ spec:
 
 `inbound` operations are calls from the sidecar to your application, such as:
 
-- Subscriptions when delivering a message.
+- PubSub subscriptions when delivering a message.
 - Input bindings.
 
 > Some components may have built-in retry capabilities and are configured on a per-component basis.
@@ -107,15 +107,13 @@ spec:
 
 With the `actors` target, you can apply `retry`, `timeout`, and `circuitBreaker` policies to actor operations. 
 
-When using a `circuitBreaker` policy, you can specify whether circuit breaking state should be scoped to:
+When using a `circuitBreaker` policy, you can specify whether circuit breaking state should be scoped to by using `circuitBreakerScope`:
 
-- An individual actor ID.
-- All actors across the actor type.
-- Both.
+- `id`: an individual actor ID
+- `type`: all actors of a given actor type
+- `both`: both of the above
 
-Specify `circuitBreakerScope` with values `id`, `type`, or `both`.
-
-You can specify a cache size for the number of circuit breakers to keep in memory. Do this by specifying `circuitBreakerCacheSize` and providing an integer value, e.g. `5000`.
+You can also specify a cache size for the number of circuit breakers to keep in memory with the `circuitBreakerCacheSize` property, providing an integer value, e.g. `5000`.
 
 Example
 

--- a/daprdocs/content/en/operations/resiliency/targets.md
+++ b/daprdocs/content/en/operations/resiliency/targets.md
@@ -107,7 +107,7 @@ spec:
 
 With the `actors` target, you can apply `retry`, `timeout`, and `circuitBreaker` policies to actor operations. 
 
-When using a `circuitBreaker` policy, you can specify whether circuit breaking state should be scoped to by using `circuitBreakerScope`:
+When using a `circuitBreaker` policy for the `actors` target, you can specify how circuit breaking state should be scoped by using `circuitBreakerScope`:
 
 - `id`: an individual actor ID
 - `type`: all actors of a given actor type


### PR DESCRIPTION
The documentation for Resiliency contained some incorrect information. Most critically, `circuitBreakerScope` and `circuitBreakerCacheSize` are to be set on targets and not policies