### PR TITLE
How to define spec.type for pluggable components.

### DIFF
--- a/daprdocs/content/en/operations/components/pluggable-components-registration.md
+++ b/daprdocs/content/en/operations/components/pluggable-components-registration.md
@@ -49,7 +49,7 @@ Both your component and the Unix Socket must be running before Dapr starts.
 
 By default, Dapr looks for [Unix Domain Socket][uds] files in the folder in `/tmp/dapr-components-sockets`.
 
-Filenames in this folder are significant for component registration. They must be formed by appending the component's **name** with a file extension of your choice, more commonly `.sock`. For example, the filename `my-component.sock` is a valid UDS file name for a component named `my-component`.
+Filenames in this folder are significant for component registration. They must be formed by appending the component's **name** with a file extension of your choice, more commonly `.sock`. For example, the filename `my-component.sock` is a valid Unix Domain Socket file name for a component named `my-component`.
 
 Since you are running Dapr in the same host as the component, verify this folder and the files within it are accessible and writable by both your component and Dapr.
 
@@ -57,16 +57,16 @@ Since you are running Dapr in the same host as the component, verify this folder
 
 A pluggable component accessible through a [Unix Domain Socket][UDS] can host multiple distinct component APIs . During the components' initial discovery process, Dapr uses reflection to enumerate all the component APIs behind a UDS. The `my-component` pluggable component in the example above can contain both state store (`state`) and a pub/sub (`pubsub`) component APIs.
 
-The most common use-case is for a 1:1 mapping between pluggable components and building blocks they expose. That said, having the possibility of consolidating multiple building blocks under the same pluggable components might be healpful, specially to ease DevOps burden at the expense of fault tolerance and security. Please weight the pros and cons and, if in doubt, stick to a 1:1 approach.
+Typically, a pluggable component implements a single component API for packaging and deployment. However, at the expense of having dependencies and security, a pluggable component can have multiple component APIs implemented to ease the deployment burden. Best practice for isolation, fault tolerance, and security is a single component API implementation for each pluggable component.
 
 
 ## Define the component
 
 Define your component using a [component spec]({{< ref component-schema.md >}}). Your component's `spec.type` value is made by concatenating the following 2 parts with a `.`:
-1. the component's **building block type** (`state`, `pubsub` etc)
-2. its **name**, which is derived from the socket name, without the file extension. 
+1. The component's API (`state`, `pubsub`, `bindings`, etc)
+2. The component's **name**, which is derived from the socket name, without the file extension. 
 
-You will need to define one [component spec]({{< ref component-schema.md >}}) for each building block exposed by your pluggable component's  [Unix Domain Socket][uds]. From the example above, the UDS `my-component.sock` from the previous example, exposes a pluggable component named `my-component` with both a `state` and a `pubsub` building blocks. Two components specs, each in their own YAML file placed in the resouces-path, will be required, one for `state.my-component` and another for `pubsub.my-component`.
+You will need to define one [component spec]({{< ref component-schema.md >}}) for each API exposed by your pluggable component's [Unix Domain Socket][uds]. The Unix Domain Socket `my-component.sock` from the previous example exposes a pluggable component named `my-component` with both a `state` and a `pubsub` API. Two components specs, each in their own YAML file, placed in the `resources-path`, will be required: one for `state.my-component` and another for `pubsub.my-component`.
 
 For instance, the component spec for `state.my-component` could be:
 
@@ -81,9 +81,9 @@ spec:
   metadata:
 ```
 
-In this sample above, notice the following:
-* The contents of the field `spec.type` is `state.my-component`: this refers to a State Store being exposed as a pluggable component named `my-component`.
-* The field `metadata.name`, which is the name of the state store beging defined here, is not related with the pluggable component name.
+In the sample above, notice the following:
+* The contents of the field `spec.type` is `state.my-component`, referring to a state store being exposed as a pluggable component named `my-component`.
+* The field `metadata.name`, which is the name of the state store being defined here, is not related to the pluggable component name.
 
 Save this file as `component.yaml` in Dapr's component configuration folder. Just like the contents of `metadata.name` field, the filename for this YAML file has no impact and does not depend on the pluggable component name.
 

--- a/daprdocs/content/en/operations/components/pluggable-components-registration.md
+++ b/daprdocs/content/en/operations/components/pluggable-components-registration.md
@@ -68,7 +68,7 @@ Define your component using a [component spec]({{< ref component-schema.md >}}).
 
 You will need to define one [component spec]({{< ref component-schema.md >}}) for each building block exposed by your pluggable component's  [Unix Domain Socket][uds]. From the example above, the UDS `my-component.sock` from the previous example, exposes a pluggable component named `my-component` with both a `state` and a `pubsub` building blocks. Two components specs, each in their own YAML file placed in the resouces-path, will be required, one for `state.my-component` and another for `pubsub.my-component`.
 
-For instance, the component spec for `state.my-component` could be as follow
+For instance, the component spec for `state.my-component` could be:
 
 ```yaml
 apiVersion: dapr.io/v1alpha1

--- a/daprdocs/content/en/operations/components/pluggable-components-registration.md
+++ b/daprdocs/content/en/operations/components/pluggable-components-registration.md
@@ -55,7 +55,7 @@ Since you are running Dapr in the same host as the component, verify this folder
 
 ### Component discovery and multiplexing
 
-A pluggable component accessible through a [Unix Domain Socket][uds] can host multiple distinct bulding blocks. During the components initial discovery process, Dapr will use reflection to enumerate all building blocks behind a UDS. The `my-component` pluggable component from the example above could contain both a state store (`state`) and a Pub/Sub (`pubsub`) building-blocks.
+A pluggable component accessible through a [Unix Domain Socket][UDS] can host multiple distinct component APIs . During the components' initial discovery process, Dapr uses reflection to enumerate all the component APIs behind a UDS. The `my-component` pluggable component in the example above can contain both state store (`state`) and a pub/sub (`pubsub`) component APIs.
 
 The most common use-case is for a 1:1 mapping between pluggable components and building blocks they expose. That said, having the possibility of consolidating multiple building blocks under the same pluggable components might be healpful, specially to ease DevOps burden at the expense of fault tolerance and security. Please weight the pros and cons and, if in doubt, stick to a 1:1 approach.
 

--- a/daprdocs/content/en/operations/components/pluggable-components-registration.md
+++ b/daprdocs/content/en/operations/components/pluggable-components-registration.md
@@ -53,7 +53,7 @@ Filenames in this folder are significant for component registration. They must b
 
 Since you are running Dapr in the same host as the component, verify this folder and the files within it are accessible and writable by both your component and Dapr.
 
-### Building-blocks discovery from  behind the same component
+### Component discovery and multiplexing
 
 A pluggable component accessible through a [Unix Domain Socket][uds] can host multiple distinct bulding blocks. During the components initial discovery process, Dapr will use reflection to enumerate all building blocks behind a UDS. The `my-component` pluggable component from the example above could contain both a state store (`state`) and a Pub/Sub (`pubsub`) building-blocks.
 

--- a/daprdocs/content/en/operations/components/pluggable-components-registration.md
+++ b/daprdocs/content/en/operations/components/pluggable-components-registration.md
@@ -10,7 +10,7 @@ description: "Learn how to register a pluggable component"
 
 ## Component registration process
 
-[Pluggable, gRPC-based components]({{< ref pluggable-components-overview >}}) are typically run as containers or processes that need to communicate with the Dapr runtime via [Unix Domain Sockets][uds]. They are automatically discovered and registered in the runtime with the following steps:
+[Pluggable, gRPC-based components]({{< ref pluggable-components-overview >}}) are typically run as containers or processes that need to communicate with the Dapr runtime via [Unix Domain Sockets][uds] (or UDS for short). They are automatically discovered and registered in the runtime with the following steps:
 
 1. The component listens to an [Unix Domain Socket][uds] placed on the shared volume.
 2. The Dapr runtime lists all [Unix Domain Socket][uds] in the shared volume.
@@ -55,7 +55,7 @@ Since you are running Dapr in the same host as the component, verify this folder
 
 ### Component discovery and multiplexing
 
-A pluggable component accessible through a [Unix Domain Socket][UDS] can host multiple distinct component APIs . During the components' initial discovery process, Dapr uses reflection to enumerate all the component APIs behind a UDS. The `my-component` pluggable component in the example above can contain both state store (`state`) and a pub/sub (`pubsub`) component APIs.
+A pluggable component accessible through a [Unix Domain Socket][UDS] (UDS) can host multiple distinct component APIs . During the components' initial discovery process, Dapr uses reflection to enumerate all the component APIs behind a UDS. The `my-component` pluggable component in the example above can contain both state store (`state`) and a pub/sub (`pubsub`) component APIs.
 
 Typically, a pluggable component implements a single component API for packaging and deployment. However, at the expense of increasing its dependencies and broadening its security attack surface, a pluggable component can have multiple component APIs implemented. This could be done to ease the deployment and monitoring burden. Best practice for isolation, fault tolerance, and security is a single component API implementation for each pluggable component.
 
@@ -63,8 +63,8 @@ Typically, a pluggable component implements a single component API for packaging
 ## Define the component
 
 Define your component using a [component spec]({{< ref component-schema.md >}}). Your component's `spec.type` value is made by concatenating the following 2 parts with a `.`:
-1. The component's API (`state`, `pubsub`, `bindings`, etc)
-2. The component's **name**, which is derived from the socket name, without the file extension. 
+1. The component's API (`state`, `pubsub`, `bindings` etc)
+2. The component's **name**, which is derived from the [Unix Domain Socket][uds] filename, without the file extension. 
 
 You will need to define one [component spec]({{< ref component-schema.md >}}) for each API exposed by your pluggable component's [Unix Domain Socket][uds]. The Unix Domain Socket `my-component.sock` from the previous example exposes a pluggable component named `my-component` with both a `state` and a `pubsub` API. Two components specs, each in their own YAML file, placed in the `resources-path`, will be required: one for `state.my-component` and another for `pubsub.my-component`.
 

--- a/daprdocs/content/en/operations/components/pluggable-components-registration.md
+++ b/daprdocs/content/en/operations/components/pluggable-components-registration.md
@@ -57,7 +57,7 @@ Since you are running Dapr in the same host as the component, verify this folder
 
 A pluggable component accessible through a [Unix Domain Socket][UDS] can host multiple distinct component APIs . During the components' initial discovery process, Dapr uses reflection to enumerate all the component APIs behind a UDS. The `my-component` pluggable component in the example above can contain both state store (`state`) and a pub/sub (`pubsub`) component APIs.
 
-Typically, a pluggable component implements a single component API for packaging and deployment. However, at the expense of having dependencies and security, a pluggable component can have multiple component APIs implemented to ease the deployment burden. Best practice for isolation, fault tolerance, and security is a single component API implementation for each pluggable component.
+Typically, a pluggable component implements a single component API for packaging and deployment. However, at the expense of increasing its dependencies and broadening its security attack surface, a pluggable component can have multiple component APIs implemented. This could be done to ease the deployment and monitoring burden. Best practice for isolation, fault tolerance, and security is a single component API implementation for each pluggable component.
 
 
 ## Define the component


### PR DESCRIPTION
## Description

Expands on multiple building blocks behind a single pluggable components and how how to define the contents of the field `spec.type` in a component spec.


## Issue reference

Please reference the issue this PR will close: #2985


## Checklist

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:
