### PR TITLE
Fixed preview features table

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/actors/actors-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/actors/actors-overview.md
@@ -92,7 +92,8 @@ Actors can deadlock on each other if there is a circular request between two act
 <img src="/images/actors_background_communication.png" width=600>
 
 #### Reentrancy
-As an enhancement to the base actors in dapr, reentrancy can now be enabled as a preview feature. To learn more about it, see [actor reentrancy]({{<ref actor-reentrancy.md>}})
+
+To allow actors to "re-enter" and invoke methods on themselves, see [Actor Reentrancy]({{<ref actor-reentrancy.md>}}).
 
 ### Turn-based access
 

--- a/daprdocs/content/en/operations/support/support-preview-features.md
+++ b/daprdocs/content/en/operations/support/support-preview-features.md
@@ -14,6 +14,7 @@ For CLI there is no explicit opt-in, just the version that this was first made a
 ## Current preview features
 
 | Feature | Description | Setting | Documentation | Version introduced |
+| --- | --- | --- | --- | --- |
 | **App Middleware** | Allow middleware components to be executed when making service-to-service calls | N/A | [App Middleware]({{<ref "middleware.md#app-middleware" >}}) | v1.9 |
 | **Streaming for HTTP service invocation** | Enables (partial) support for using streams in HTTP service invocation; see below for more details. | `ServiceInvocationStreaming` | [Details]({{< ref "support-preview-features.md#streaming-for-http-service-invocation" >}}) | v1.10 |
 | **App health checks** | Allows configuring app health checks | `AppHealthCheck` | [App health checks]({{<ref "app-health.md" >}}) | v1.9 |


### PR DESCRIPTION
The table for preview features is currently broken:

![image](https://user-images.githubusercontent.com/43508/217937269-63ca51b6-1b18-41c3-8f3b-4e04a1695f12.png)

Also, actor re-entrancy is not a preview feature anymore.