### PR TITLE
Document all brokers support bulk pub/sub

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
@@ -419,10 +419,6 @@ Watch [this video for an demo on bulk pub/sub](https://youtu.be/BxiKpEmchgQ?t=11
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/BxiKpEmchgQ?start=1170" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-## Supported components
-
-Refer to the [component reference]({{< ref supported-pubsub >}}) to see which components support bulk publish and subscribe operations.
-
 ## Related links
 
 - List of [supported pub/sub components]({{< ref supported-pubsub >}})

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -304,6 +304,8 @@ Apache Kafka component supports sending and receiving multiple messages in a sin
 
 When subscribing to a topic, you can configure `bulkSubscribe` options. Refer to [Subscribing messages in bulk]({{< ref "pubsub-bulk#subscribing-messages-in-bulk" >}}) for more details. Learn more about [the bulk subscribe API]({{< ref pubsub-bulk.md >}}).
 
+Apache Kafka supports the following bulk metadata options:
+
 | Configuration | Default |
 |----------|---------|
 | `maxBulkAwaitDurationMs` | `10000` (10s) |

--- a/daprdocs/layouts/partials/components/pubsub.html
+++ b/daprdocs/layouts/partials/components/pubsub.html
@@ -10,8 +10,6 @@
 <table width="100%">
     <tr>
         <th>Component</th>
-        <th>Bulk Publish</th>
-        <th>Bulk Subscribe</th>
         <th>Status</th>
         <th>Component version</th>
         <th>Since runtime version</th>
@@ -19,20 +17,6 @@
     {{ range sort $components "component" }}
     <tr>
         <td><a href="/reference/components-reference/supported-pubsub/{{ .link }}/">{{ .component }}</a>
-        </td>
-        <td align="center">
-            {{ if .features.bulkPublish }}
-                <span role="img" aria-label="Bulk publish supported">✅</span>
-            {{else}}
-                <img src="/images/emptybox.png" alt="Bulk publish not supported" aria-label="Bulk publish not supported">
-            {{ end }}
-        </td>
-        <td align="center">
-            {{ if .features.bulkSubscribe }}
-                <span role="img" aria-label="Bulk subscribe supported">✅</span>
-            {{else}}
-                <img src="/images/emptybox.png" alt="Bulk subscribe not supported" aria-label="Bulk subscribe not supported">
-            {{ end }}
         </td>
         <td>{{ .state }}</td>
         <td>{{ .version }}</td>


### PR DESCRIPTION
The docs today are wrong in that only Apache Kafka appears to support bulk pub/sub. This is incorrect, as every call to the Dapr APIs, whether through an SDK or directly via HTTP and gRPC, will succeed and accept bulk messages for every pub/sub component. The same is true for subscriptions.

The initial thinking behind the current docs was to show that Kafka has a native driver support for bulk publishing. This is an internal, non-user facing implementation detail that shouldn't give users the wrong impression that Dapr will not accept requests for bulk pub/sub brokers other than Kafka.
