### PR TITLE
Sets TTL support for mongodb state store to enabled

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mongodb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mongodb.md
@@ -112,6 +112,10 @@ The username is `admin` by default.
 
 {{< /tabs >}}
 
+### TTLs and cleanups
+
+This state store supports [Time-To-Live (TTL)]({{< ref state-store-ttl.md >}}) for records stored with Dapr. When storing data using Dapr, you can set the `ttlInSeconds` metadata property to indicate when the data should be considered "expired".
+
 ## Related links
 - [Basic schema for a Dapr component]({{< ref component-schema >}})
 - Read [this guide]({{< ref "howto-get-save-state.md#step-2-save-and-retrieve-a-single-state" >}}) for instructions on configuring state store components

--- a/daprdocs/data/components/state_stores/generic.yaml
+++ b/daprdocs/data/components/state_stores/generic.yaml
@@ -106,7 +106,7 @@
     crud: true
     transactions: true
     etag: true
-    ttl: false
+    ttl: true
     query: true
 - component: MySQL
   link: setup-mysql


### PR DESCRIPTION
Implemented [here](https://github.com/dapr/components-contrib/pull/2535).
