### PR TITLE
Fix dapr run template reference

### DIFF
--- a/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
+++ b/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
@@ -72,7 +72,7 @@ version: 1
 common: # optional section for variables shared across apps
   resourcesPath: ./app/components # any dapr resources to be shared across apps
   env:  # any environment variable shared across apps
-    - DEBUG: true
+    DEBUG: true
 apps:
   - appID: webapp # optional
     appDirPath: .dapr/webapp/ # REQUIRED


### PR DESCRIPTION
## Description
Fix template reference file environment variables. Currently uses an array when it's decoded into a `map[string]string`

Not sure which branch to target so please advise if v1.11 is not correct.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
