### PR TITLE
Fix app protocol in template reference doc

### DIFF
--- a/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
+++ b/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
@@ -78,13 +78,13 @@ apps:
     appDirPath: .dapr/webapp/ # REQUIRED
     resourcesPath: .dapr/resources # (optional) can be default by convention
     configFilePath: .dapr/config.yaml # (optional) can be default by convention too, ignore if file is not found.
-    appProtocol: HTTP
+    appProtocol: http
     appPort: 8080
     appHealthCheckPath: "/healthz" 
     command: ["python3" "app.py"]
   - appID: backend # optional 
     appDirPath: .dapr/backend/ # REQUIRED
-    appProtocol: GRPC
+    appProtocol: grpc
     appPort: 3000
     unixDomainSocket: "/tmp/test-socket"
     env:
@@ -112,7 +112,7 @@ The properties for the Multi-App Run template align with the `dapr run` CLI flag
 | `appID`                  | N        | Application's app ID. If not provided, will be derived from `appDirPath` | `webapp`, `backend` |
 | `resourcesPath`          | N        | Path to your Dapr resources. Can be default by convention; ignore if directory isn't found | `./app/components`, `./webapp/components` |
 | `configFilePath`         | N        | Path to your application's configuration file | `./webapp/config.yaml` |
-| `appProtocol`            | N        | The protocol Dapr uses to talk to the application. | `HTTP`, `GRPC` |
+| `appProtocol`            | N        | The protocol Dapr uses to talk to the application. | `http`, `grpc` |
 | `appPort`                | N        | The port your application is listening on | `8080`, `3000` |
 | `daprHTTPPort`           | N        | Dapr HTTP port |  |
 | `daprGRPCPort`           | N        | Dapr GRPC port |  |


### PR DESCRIPTION
## Description
Currently the template reference document uses the app protocol strings `HTTP` and `GRPC`, however, when you use these they do not match the strings defined in `daprd` and it fails to setup the app channel. They are currently compared in a case sensitive way which we may want to fix but for now this doc is incorrect. See: https://github.com/dapr/dapr/blob/41dd1dc182c94e40eb132576e1306b5cbe356746/pkg/runtime/runtime.go#L2943
