### PR TITLE
Update information for daprsystem configuration

### DIFF
--- a/daprdocs/content/en/operations/configuration/configuration-overview.md
+++ b/daprdocs/content/en/operations/configuration/configuration-overview.md
@@ -214,7 +214,7 @@ See the [preview features]({{< ref "preview-features.md" >}}) guide for informat
 
 ### Example sidecar configuration
 
-The following yaml shows an example configuration file that can be applied to an applications' Dapr sidecar.
+The following YAML shows an example configuration file that can be applied to an applications' Dapr sidecar.
 
 ```yml
 apiVersion: dapr.io/v1alpha1
@@ -266,15 +266,21 @@ There is a single configuration file called `daprsystem` installed with the Dapr
 
 ### Control-plane configuration settings
 
-A Dapr control plane configuration can configure the following settings:
+A Dapr control plane configuration contains the following sections:
+
+- [`mtls`](#mtls-mutual-tls) for mTLS (Mutual TLS)
+
+### mTLS (Mutual TLS)
+
+The `mtls` section contains properties for mTLS.
 
 | Property         | Type   | Description |
 |------------------|--------|-------------|
-| enabled          | bool   | Set mtls to be enabled or disabled
-| allowedClockSkew | string | The extra time to give for certificate expiry based on possible clock skew on a machine. Default is 15 minutes.
-| workloadCertTTL  | string | Time a certificate is valid for. Default is 24 hours
+| `enabled`          | bool   | If true, enables mTLS for communication between services and apps in the cluster.
+| `allowedClockSkew` | string | Allowed tolerance when checking the expiration of TLS certificates, to allow for clock skew. Follows the format used by [Go's time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Default is `15m` (15 minutes).
+| `workloadCertTTL`  | string | How long a certificate TLS issued by Dapr is valid for. Follows the format used by [Go's time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Default is `24h` (24 hours).
 
-See the [Mutual TLS]({{< ref "mtls.md" >}}) HowTo and [security concepts]({{< ref "security-concept.md" >}}) for more information.
+See the [mTLS how-to]({{< ref "mtls.md" >}}) and [security concepts]({{< ref "security-concept.md" >}}) for more information.
 
 ### Example control plane configuration
 
@@ -282,7 +288,7 @@ See the [Mutual TLS]({{< ref "mtls.md" >}}) HowTo and [security concepts]({{< re
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: default
+  name: daprsystem
   namespace: default
 spec:
   mtls:


### PR DESCRIPTION
Contains some corrections and other improvements to the section documenting the Dapr control-plane configuration: https://docs.dapr.io/operations/configuration/configuration-overview/#control-plane-configuration

1. In the example, make sure the name is `daprsystem` because that's a constant
2. Clarify some details on the configuration for mTLS