### PR TITLE
Update install-dapr-cli.md

### DIFF
--- a/daprdocs/content/en/getting-started/install-dapr-cli.md
+++ b/daprdocs/content/en/getting-started/install-dapr-cli.md
@@ -202,7 +202,7 @@ Each release of Dapr CLI includes various OSes and architectures. You can manual
 Verify the CLI is installed by restarting your terminal/command prompt and running the following:
 
 ```bash
-dapr
+dapr --help
 ```
 
 **Output:**


### PR DESCRIPTION
`dapr`  return empty,  `dapr --help` return the expected output

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

change verify command from `dapr` to `dapr --help`, so that it will output as expected

## Issue reference

dapr/cli#1254 

