### PR TITLE
Add call to MapSubscribeHandlers for .NET pubsub

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/subscription-methods.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/subscription-methods.md
@@ -212,6 +212,15 @@ app.MapPost("/checkout", [Topic("pubsub", "orders")] (Order order) => {
 });
 ```
 
+Both of the handlers defined above also need to be mapped to configure the `dapr/subscribe` endpoint. This is done in the application startup code while defining endpoints.
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapSubscribeHandler();
+}
+```
+
 {{% /codetab %}}
 
 {{% codetab %}}


### PR DESCRIPTION
## Description
Detail the call to `MapSubscribeHandler` for .NET programmatic subscriptions. 

## Issue reference
https://github.com/dapr/docs/issues/2649