### PR TITLE
Add reconnect wait in seconds metadata for rabbitmq binding

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/rabbitmq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/rabbitmq.md
@@ -39,6 +39,8 @@ spec:
     value: 5
   - name: contentType
     value: "text/plain"
+  - name: reconnectWaitInSeconds
+    value: 5
 ```
 
 {{% alert title="Warning" color="warning" %}}
@@ -58,6 +60,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | exclusive | N | Input/Output | Determines whether the topic will be an exclusive topic or not. Defaults to `"false"` | `"true"`, `"false"` |
 | maxPriority| N | Input/Output | Parameter to set the [priority queue](https://www.rabbitmq.com/priority.html). If this parameter is omitted, queue will be created as a general queue instead of a priority queue. Value between 1 and 255. See [also](#specifying-a-priority-per-message) | `"1"`, `"10"` |
 | contentType | N | Input/Output | The content type of the message. Defaults to "text/plain". | `"text/plain"`, `"application/cloudevent+json"` and so on |
+| reconnectWaitInSeconds | N | Input/Output | Represents the duration in seconds that the client should wait before attempting to reconnect to the server after a disconnection occurs. Defaults to `"5"`. | `"5"`, `"10"` |
 ## Binding support
 
 This component supports both **input and output** binding interfaces.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add reconnect wait in seconds metadata for rabbitmq binding

## Issue reference

Please reference the issue this PR will close: #3235
