### PR TITLE
Add .NET, Go, Java state store TTL examples

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
@@ -91,10 +91,15 @@ dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-g
 ```java
 //dependencies
 
+import io.dapr.client.DaprClient;
+import io.dapr.client.DaprClientBuilder;
 
 //code
 
-
+client.saveState(STATE_STORE_NAME, "order_1", Integer.toString(orderId)).block();
+client.saveState(STATE_STORE_NAME, "order_2", Integer.toString(orderId)).block();
+Mono<State<String>> result = client.getState(STATE_STORE_NAME, "order_1", String.class);
+log.info("Result after get" + result, singletonMap(Metadata.TTL_IN_SECONDS));
 ```
 
 To launch a Dapr sidecar and run the above example application, you'd then run a command similar to the following:
@@ -112,9 +117,14 @@ dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-g
 ```go
 // dependencies
 
+import (
+	dapr "github.com/dapr/go-sdk/client"
+)
 
 // code
 
+err = client.SaveState(ctx, STATE_STORE_NAME, "order_1", []byte(strconv.Itoa(orderId)), nil)
+Metadata: map[string]string{"ttlInSeconds": "120"},
 ```
 
 To launch a Dapr sidecar and run the above example application, you'd then run a command similar to the following:

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
@@ -97,9 +97,9 @@ import (
 
 // code
 
-err = client.SaveState(ctx, STATE_STORE_NAME, "order_1", []byte(strconv.Itoa(orderId)), nil)
-metadata := map[string]string{
- "ttlInSeconds": "120"
+md := map[string]string{"ttlInSeconds": "120"}
+if err := client.SaveState(ctx, store, "key1", []byte("hello world"), md); err != nil {
+   panic(err)
 }
 ```
 

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
@@ -97,6 +97,10 @@ import (
 
 // code
 
+err = client.SaveState(ctx, STATE_STORE_NAME, "order_1", []byte(strconv.Itoa(orderId)), nil)
+metadata := map[string]string{
+ "ttlInSeconds": "120"
+}
 ```
 
 To launch a Dapr sidecar and run the above example application, you'd then run a command similar to the following:

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
@@ -97,14 +97,12 @@ import (
 
 // code
 
-err = client.SaveState(ctx, STATE_STORE_NAME, "order_1", []byte(strconv.Itoa(orderId)), nil)
-Metadata: map[string]string{"ttlInSeconds": "120"},
 ```
 
 To launch a Dapr sidecar and run the above example application, you'd then run a command similar to the following:
 
 ```bash
-dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 go run OrderProcessingService.go
+dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 go run .
 ```
 
 {{% /codetab %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
@@ -86,32 +86,6 @@ dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-g
 
 {{% codetab %}}
 
-<!--java-->
-
-```java
-//dependencies
-
-import io.dapr.client.DaprClient;
-import io.dapr.client.DaprClientBuilder;
-
-//code
-
-client.saveState(STATE_STORE_NAME, "order_1", Integer.toString(orderId)).block();
-client.saveState(STATE_STORE_NAME, "order_2", Integer.toString(orderId)).block();
-Mono<State<String>> result = client.getState(STATE_STORE_NAME, "order_1", String.class);
-log.info("Result after get" + result, singletonMap(Metadata.TTL_IN_SECONDS));
-```
-
-To launch a Dapr sidecar and run the above example application, you'd then run a command similar to the following:
-
-```bash
-dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 mvn spring-boot:run
-```
-
-{{% /codetab %}}
-
-{{% codetab %}}
-
 <!--go-->
 
 ```go

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
@@ -28,9 +28,11 @@ Refer to the TTL column in the [state store components guide]({{< ref supported-
 
 You can set state TTL in the metadata as part of the state store set request:
 
-{{< tabs Python "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs Python ".NET" Java Go "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
+
+<!--python-->
 
 ```python
 #dependencies
@@ -52,6 +54,73 @@ To launch a Dapr sidecar and run the above example application, you'd then run a
 
 ```bash
 dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 -- python3 OrderProcessingService.py
+```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+
+<!--dotnet-->
+
+```csharp
+// dependencies
+
+using Dapr.Client;
+
+// code
+
+await client.SaveStateAsync(storeName, stateKeyName, state, metadata: new Dictionary<string, string>() { 
+    { 
+        "metadata.ttlInSeconds", "120" 
+    } 
+});
+```
+
+To launch a Dapr sidecar and run the above example application, you'd then run a command similar to the following:
+
+```bash
+dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 dotnet run
+```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+
+<!--java-->
+
+```java
+//dependencies
+
+
+//code
+
+
+```
+
+To launch a Dapr sidecar and run the above example application, you'd then run a command similar to the following:
+
+```bash
+dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 mvn spring-boot:run
+```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+
+<!--go-->
+
+```go
+// dependencies
+
+
+// code
+
+```
+
+To launch a Dapr sidecar and run the above example application, you'd then run a command similar to the following:
+
+```bash
+dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 go run OrderProcessingService.go
 ```
 
 {{% /codetab %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/state-store-ttl.md
@@ -28,7 +28,7 @@ Refer to the TTL column in the [state store components guide]({{< ref supported-
 
 You can set state TTL in the metadata as part of the state store set request:
 
-{{< tabs Python ".NET" Java Go "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs ".NET" Python Go "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 


### PR DESCRIPTION
## Description

Current doc only has Python, so adding more SDK examples. TTL currently not supported by JS, will add later.

Need:
- [x] Go example review @yaron2 
- [x] Remove Java (unsupported right now)
- [x] .NET example review

## Issue reference

PR will close: #3119 
