### PR TITLE
fix: Use correct HTTP verb for Invoke actor

### DIFF
--- a/daprdocs/content/en/reference/api/actors_api.md
+++ b/daprdocs/content/en/reference/api/actors_api.md
@@ -18,7 +18,7 @@ Invoke an actor method through Dapr.
 #### HTTP Request
 
 ```
-POST/GET/PUT/DELETE http://localhost:<daprPort>/v1.0/actors/<actorType>/<actorId>/method/<method>
+POST http://localhost:<daprPort>/v1.0/actors/<actorType>/<actorId>/method/<method>
 ```
 
 #### HTTP Response Codes


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The HTTP verb for "Invoke Actor" feels odd and most probably only `POST` should be used.

## Issue reference

N/A
