### PR TITLE
Update docs for rate limit HTTP middleware

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-rate-limit.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-rate-limit.md
@@ -7,11 +7,12 @@ aliases:
 - /developing-applications/middleware/supported-middleware/middleware-rate-limit/
 ---
 
-The rate limit [HTTP middleware]({{< ref middleware.md >}}) allows restricting the maximum number of allowed HTTP requests per second. Rate limiting can protect your application from denial of service (DOS) attacks. DOS attacks can be initiated by malicious 3rd parties but also by bugs in your software (a.k.a. a "friendly fire" DOS attack).
+The rate limit [HTTP middleware]({{< ref middleware.md >}}) allows restricting the maximum number of allowed HTTP requests per second. Rate limiting can protect your application from denial of service (DoS) attacks. DoS attacks can be initiated by malicious 3rd parties but also by bugs in your software (a.k.a. a "friendly fire" DoS attack).
 
 ## Component format
 
 In the following definition, the maximum requests per second are set to 10:
+
 ```yaml
 apiVersion: dapr.io/v1alpha1
 kind: Component
@@ -29,11 +30,15 @@ spec:
 
 | Field | Details | Example |
 |-------|---------|---------|
-| maxRequestsPerSecond | The maximum requests per second by remote IP and path. Something to consider is that **the limit is enforced independently in each Dapr sidecar and not cluster wide** | `10`
+| `maxRequestsPerSecond` | The maximum requests per second by remote IP.<br>The component looks at the `X-Forwarded-For` and `X-Real-IP` headers to determine the caller's IP. | `10`
 
-Once the limit is reached, the request will return *HTTP Status code 429: Too Many Requests*.
+Once the limit is reached, the requests will fail with HTTP Status code *429: Too Many Requests*.
 
-Alternatively, the [max concurrency setting]({{< ref control-concurrency.md >}}) can be used to rate limit applications and applies to all traffic regardless of remote IP or path.
+{{% alert title="Important" color="warning" %}}
+The rate limit is enforced independently in each Dapr sidecar, and not cluster-wide.
+{{% /alert %}}
+
+Alternatively, the [max concurrency setting]({{< ref control-concurrency.md >}}) can be used to rate limit applications and applies to all traffic, regardless of remote IP, protocol, or path.
 
 ## Dapr configuration
 

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-rate-limit.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-rate-limit.md
@@ -7,7 +7,7 @@ aliases:
 - /developing-applications/middleware/supported-middleware/middleware-rate-limit/
 ---
 
-The rate limit [HTTP middleware]({{< ref middleware.md >}}) allows restricting the maximum number of allowed HTTP requests per second. Rate limiting can protect your application from denial of service (DoS) attacks. DoS attacks can be initiated by malicious 3rd parties but also by bugs in your software (a.k.a. a "friendly fire" DoS attack).
+The rate limit [HTTP middleware]({{< ref middleware.md >}}) allows restricting the maximum number of allowed HTTP requests per second. Rate limiting can protect your application from Denial of Service (DoS) attacks. DoS attacks can be initiated by malicious 3rd parties but also by bugs in your software (a.k.a. a "friendly fire" DoS attack).
 
 ## Component format
 

--- a/daprdocs/data/components/middleware/http.yaml
+++ b/daprdocs/data/components/middleware/http.yaml
@@ -1,6 +1,6 @@
 - component: Rate limit
   link: middleware-rate-limit
-  state: Alpha
+  state: Stable
   version: v1
   description: Restricts the maximum number of allowed HTTP requests per second
 - component: OAuth2 Authorization Grant flow


### PR DESCRIPTION
Updates the docs for the Rate limit HTTP middleware, which is now stable in 1.11