### PR TITLE
Documentation for receiving of custom properties from IoT Hub through endpoint that is compatible with Event Hubs

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -200,7 +200,7 @@ scopes:
 - orderprocessing
 - checkout
 ```
-This ensures enriched messages containing additional properties are forwarded as headers. For example, the device-to-cloud events created by Azure IoT Hub devices can contain user defined additional [IoT Hub Application Properties](https://learn.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-construct#application-properties-of-d2c-iot-hub-messages). The Azure Event Hubs pub/sub component for Dapr returns the following as part of the response metadata (in this example, `iothub-creation-time-utc` is application property):
+Adding this metadata entry ensures enriched messages containing additional properties are forwarded as headers. For example, the device-to-cloud events created by Azure IoT Hub devices can contain extra user-defined [IoT Hub Application Properties](https://learn.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-construct#application-properties-of-d2c-iot-hub-messages). The Azure Event Hubs pub/sub component for Dapr returns the following as part of the response metadata (in this example, `iothub-creation-time-utc` is the application property):
 
 ```js
 {

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -180,6 +180,47 @@ For example, the headers of a delivered HTTP subscription message would contain:
   'traceparent': '00-4655608164bc48b985b42d39865f3834-ed6cf3697c86e7bd-01'
 }
 ```
+## Subscribing to Application Properties (enriched messages) from an Event hub
+
+It possible to get application properties (enriched messages) from an Event Hub by declaratively adding the `requireAllProperties` metadata entry to subscription specification.
+
+```yaml
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: order-pub-sub
+spec:
+  topic: orders
+  routes: 
+    default: /checkout
+  pubsubname: order-pub-sub
+  metadata:
+     requireAllProperties: "true"
+scopes:
+- orderprocessing
+- checkout
+```
+This ensures enriched messages containing additional properties are forwarded as headers. For example, the device-to-cloud events created by Azure IoT Hub devices can contain user defined additional [IoT Hub Application Properties](https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-construct#application-properties-of-d2c-iot-hub-messages), and the Azure Event Hubs pubsub component for Dapr will return the following as part of the response metadata ( in this example `iothub-creation-time-utc` is application property ):
+
+```js
+{
+  'user-agent': 'fasthttp',
+  'host': '127.0.0.1:3000',
+  'content-type': 'application/json',
+  'content-length': '120',
+  'iothub-connection-device-id': 'my-test-device',
+  'iothub-connection-auth-generation-id': '637618061680407492',
+  'iothub-connection-auth-method': '{"scope":"module","type":"sas","issuer":"iothub","acceptingIpFilterRule":null}',
+  'iothub-connection-module-id': 'my-test-module-a',
+  'iothub-enqueuedtime': '2021-07-13T22:08:09Z',
+  'message-id': 'my-custom-message-id',
+  'iothub-creation-time-utc': '2021-01-29T16:45:39.021Z',
+  'x-opt-sequence-number': '35',
+  'x-opt-enqueued-time': '2021-07-13T22:08:09Z',
+  'x-opt-offset': '21560',
+  'traceparent': '00-4655608164bc48b985b42d39865f3834-ed6cf3697c86e7bd-01'
+}
+```
 
 ## Related links
 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -182,7 +182,7 @@ For example, the headers of a delivered HTTP subscription message would contain:
 ```
 ## Subscribing to Application Properties (enriched messages) from an Event hub
 
-It possible to get application properties (enriched messages) from an Event Hub by declaratively adding the `requireAllProperties` metadata entry to subscription specification.
+It is possible to get application properties (enriched messages) from an Event Hub by declaratively adding the `requireAllProperties` metadata entry to the subscription specification.
 
 ```yaml
 apiVersion: dapr.io/v2alpha1

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-azure-eventhubs.md
@@ -200,7 +200,7 @@ scopes:
 - orderprocessing
 - checkout
 ```
-This ensures enriched messages containing additional properties are forwarded as headers. For example, the device-to-cloud events created by Azure IoT Hub devices can contain user defined additional [IoT Hub Application Properties](https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-construct#application-properties-of-d2c-iot-hub-messages), and the Azure Event Hubs pubsub component for Dapr will return the following as part of the response metadata ( in this example `iothub-creation-time-utc` is application property ):
+This ensures enriched messages containing additional properties are forwarded as headers. For example, the device-to-cloud events created by Azure IoT Hub devices can contain user defined additional [IoT Hub Application Properties](https://learn.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-construct#application-properties-of-d2c-iot-hub-messages). The Azure Event Hubs pub/sub component for Dapr returns the following as part of the response metadata (in this example, `iothub-creation-time-utc` is application property):
 
 ```js
 {


### PR DESCRIPTION
Documentation for [Receiving of custom properties from IoT Hub through endpoint that is compatible with Event Hubs](https://github.com/dapr/components-contrib/pull/2298)

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This includes documentation for receiving Application Properties (enriched messages) from an Event hub . The feature ensured enriched messages containing additional properties are forwarded as headers.

Feature PR : [Receiving of custom properties from IoT Hub through endpoint that is compatible with Event Hubs](https://github.com/dapr/components-contrib/pull/2298)

Also can act as a reference for [#6075 : Propagate arbitrary/configurable http headers from publisher to subscribers](https://github.com/dapr/dapr/issues/6075)
