### PR TITLE
Added an example for DotNet bulk subscribing

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
@@ -334,7 +334,7 @@ Please refer [Expected HTTP Response for Bulk Subscribe]({{< ref pubsub_api.md >
 
 Please refer following code samples for how to use Bulk Subscribe:
 
-{{< tabs Java Javascript Dotnet "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
+{{< tabs "Java" "JavaScript" ".NET" "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
@@ -334,7 +334,7 @@ Please refer [Expected HTTP Response for Bulk Subscribe]({{< ref pubsub_api.md >
 
 Please refer following code samples for how to use Bulk Subscribe:
 
-{{< tabs Java Javascript DotNet "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
+{{< tabs Java Javascript Dotnet "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
 
 {{% codetab %}}
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] N/A - Commands include options for Linux, MacOS, and Windows within codetabs
- [x] N/A - New file and folder names are globally unique
- [x] N/A - Page references use shortcodes instead of markdown or URL links
- [x] N/A - Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The bulk pub/sub documentation is missing the DotNet bulk subscribing example so I added an example.

