### PR TITLE
Add robots.txt to prevent search engine indexing

### DIFF
--- a/daprdocs/layouts/robots.txt
+++ b/daprdocs/layouts/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /$
+Disallow: /


### PR DESCRIPTION
Prevents search engines from indexing archived versions

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Bing is indexing archived versions of Dapr docs

## Issue reference

Fixes #3288 
