### PR TITLE
Improve bulk subscribe statuses description

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
@@ -313,10 +313,17 @@ A JSON-encoded payload body with the processing status against each entry needs 
 
 ```json
 {
-  "statuses": {
-    "entryId": "<entryId>",
+  "statuses": 
+  [ 
+    {
+    "entryId": "<entryId1>",
     "status": "<status>"
-  }
+    }, 
+    {
+    "entryId": "<entryId2>",
+    "status": "<status>"
+    } 
+  ]
 }
 ```
 
@@ -334,7 +341,7 @@ Please refer [Expected HTTP Response for Bulk Subscribe]({{< ref pubsub_api.md >
 
 Please refer following code samples for how to use Bulk Subscribe:
 
-{{< tabs "Java" "JavaScript" ".NET" "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
+{{< tabs "Java" "JavaScript" ".NET" >}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/reference/api/pubsub_api.md
+++ b/daprdocs/content/en/reference/api/pubsub_api.md
@@ -262,10 +262,17 @@ A JSON-encoded payload body with the processing status against each entry needs 
 
 ```json
 {
-  "statuses": {
-    "entryId": "<entryId>",
+  "statuses": 
+  [ 
+    {
+    "entryId": "<entryId1>",
     "status": "<status>"
-  }
+    }, 
+    {
+    "entryId": "<entryId2>",
+    "status": "<status>"
+    } 
+  ]
 }
 ```
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Provides correct json, in array form, for statuses from Bulk Subscribe.
Removes extra tabs from Bulk Subscribe examples.

## Issue reference

Please reference the issue this PR will close: #3337 
