### PR TITLE
wasm middleware: change path property to url

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -44,7 +44,7 @@ How to compile this is described later.
 
 | Field | Details                                                        | Required | Example        |
 |-------|----------------------------------------------------------------|----------|----------------|
-| url   | The URL of the resource including the Wasm binary to instantiate. The supported schemes include "file://". The path of a "file://" URL is relative to the Dapr process unless it begins with '/'. | true     | "file://hello.wasm" |
+| url   | The URL of the resource including the Wasm binary to instantiate. The supported schemes include `file://`. The path of a `file://` URL is relative to the Dapr process unless it begins with `/`. | true     | `file://hello.wasm` |
 
 ## Dapr configuration
 

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -17,7 +17,7 @@ binary. In other words, you can extend Dapr using external files that are not
 pre-compiled into the `daprd` binary. Dapr embeds [wazero](https://wazero.io)
 to accomplish this without CGO.
 
-Wasm modules are loaded from a URL. For example, a URL "file://rewrite.wasm"
+Wasm binaries are loaded from a URL. For example, the URL `file://rewrite.wasm`
 loads "rewrite.wasm" from the current directory of the process. On Kubernetes,
 see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
 to configure a filesystem mount that can contain Wasm modules.

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -19,7 +19,7 @@ to accomplish this without CGO.
 
 Wasm binaries are loaded from a URL. For example, the URL `file://rewrite.wasm`
 loads `rewrite.wasm` from the current directory of the process. On Kubernetes,
-see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
+see [How to: Mount Pod volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
 to configure a filesystem mount that can contain Wasm modules.
 
 ## Component format

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -18,7 +18,7 @@ pre-compiled into the `daprd` binary. Dapr embeds [wazero](https://wazero.io)
 to accomplish this without CGO.
 
 Wasm binaries are loaded from a URL. For example, the URL `file://rewrite.wasm`
-loads "rewrite.wasm" from the current directory of the process. On Kubernetes,
+loads `rewrite.wasm` from the current directory of the process. On Kubernetes,
 see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
 to configure a filesystem mount that can contain Wasm modules.
 

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -17,9 +17,10 @@ binary. In other words, you can extend Dapr using external files that are not
 pre-compiled into the `daprd` binary. Dapr embeds [wazero](https://wazero.io)
 to accomplish this without CGO.
 
-Wasm modules are loaded from a filesystem path. On Kubernetes, see [mounting
-volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}}) to configure
-a filesystem mount that can contain Wasm modules.
+Wasm modules are loaded from a URL. For example, a URL "file://rewrite.wasm"
+loads "rewrite.wasm" from the current directory of the process. On Kubernetes,
+see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
+to configure a filesystem mount that can contain Wasm modules.
 
 ## Component format
 
@@ -32,8 +33,8 @@ spec:
   type: middleware.http.wasm
   version: v1
   metadata:
-  - name: path
-    value: "./router.wasm"
+  - name: url
+    value: "file://router.wasm"
 ```
 
 ## Spec metadata fields
@@ -41,9 +42,9 @@ spec:
 Minimally, a user must specify a Wasm binary implements the [http-handler](https://http-wasm.io/http-handler/).
 How to compile this is described later.
 
-| Field    | Details                                                        | Required | Example        |
-|----------|----------------------------------------------------------------|----------|----------------|
-| path     | A relative or absolute path to the Wasm binary to instantiate. | true     | "./hello.wasm" |
+| Field | Details                                                        | Required | Example        |
+|-------|----------------------------------------------------------------|----------|----------------|
+| url   | The URL of the resource including the Wasm binary to instantiate. The supported schemes include "file://". The path of a "file://" URL is relative to the Dapr process unless it begins with '/'. | true     | "file://hello.wasm" |
 
 ## Dapr configuration
 
@@ -109,7 +110,7 @@ func handleRequest(req api.Request, resp api.Response) (next bool, reqCtx uint32
 ```
 
 If using TinyGo, compile as shown below and set the spec metadata field named
-"path" to the location of the output (ex "router.wasm"):
+"url" to the location of the output (ex "file://router.wasm"):
 
 ```bash
 tinygo build -o router.wasm -scheduler=none --no-debug -target=wasi router.go`
@@ -145,7 +146,7 @@ func rewrite(requestURI []byte) ([]byte, error) {
 ```
 
 If using TinyGo, compile as shown below and set the spec metadata field named
-"path" to the location of the output (ex "example.wasm"):
+"url" to the location of the output (ex "file://example.wasm"):
 
 ```bash
 tinygo build -o example.wasm -scheduler=none --no-debug -target=wasi example.go

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -110,7 +110,7 @@ func handleRequest(req api.Request, resp api.Response) (next bool, reqCtx uint32
 ```
 
 If using TinyGo, compile as shown below and set the spec metadata field named
-"url" to the location of the output (ex "file://router.wasm"):
+"url" to the location of the output (for example, `file://router.wasm`):
 
 ```bash
 tinygo build -o router.wasm -scheduler=none --no-debug -target=wasi router.go`

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -146,7 +146,7 @@ func rewrite(requestURI []byte) ([]byte, error) {
 ```
 
 If using TinyGo, compile as shown below and set the spec metadata field named
-"url" to the location of the output (ex "file://example.wasm"):
+"url" to the location of the output (for example, `file://example.wasm`):
 
 ```bash
 tinygo build -o example.wasm -scheduler=none --no-debug -target=wasi example.go


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [n/a] Commands include options for Linux, MacOS, and Windows within codetabs
- [n/a] New file and folder names are globally unique
- [n/a] Page references use shortcodes instead of markdown or URL links
- [n/a] Images use HTML style and have alternative text
- [n/a] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This changes the configuration item for the Wasm binary from path to
url. In doing so, we ease migration from other sources including HTTP
and OCI.

## Issue reference

https://github.com/dapr/components-contrib/pull/2817 - change that results in this update
https://github.com/dapr/components-contrib/issues/2700 - the change enables this issue to complete in 1.12
