### PR TITLE
Fixes bad link for AWS CLI named profiles

### DIFF
--- a/daprdocs/content/en/developing-applications/integrations/AWS/authenticating-aws.md
+++ b/daprdocs/content/en/developing-applications/integrations/AWS/authenticating-aws.md
@@ -44,7 +44,7 @@ When running Dapr (or the Dapr runtime directly) in stand-alone mode, you have t
 FOO=bar daprd --app-id myapp
 ```
 
-If you have [configured named AWS profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) locally , you can tell Dapr (or the Dapr runtime) which profile to use by specifying the "AWS_PROFILE" environment variable:
+If you have [configured named AWS profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-using-profiles) locally , you can tell Dapr (or the Dapr runtime) which profile to use by specifying the "AWS_PROFILE" environment variable:
 
 ```bash
 AWS_PROFILE=myprofile dapr run...


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [n/a] Commands include options for Linux, MacOS, and Windows within codetabs
- [n/a] New file and folder names are globally unique
- [n/a] Page references use shortcodes instead of markdown or URL links
- [n/a] Images use HTML style and have alternative text
- [n/a] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixes bad link for AWS CLI named profiles

## Issue reference

found in #3359