### PR TITLE
Wasm binding update

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -27,7 +27,6 @@ Minimally, you must specify a Wasm binary compiled with the canonical WASI
 version `wasi_snapshot_preview1` (a.k.a. `wasip1`), often abbreviated to `wasi`.
 
 > **Note:** If compiling in Go 1.21+, this is `GOOS=wasip1 GOARCH=wasm`. In TinyGo, Rust, and Zig, this is the target `wasm32-wasi`.
-in TinyGo, Rust and Zig, this is the target `wasm32-wasi`.
 
 You can also re-use an existing binary. For example, [Wasm Language Runtimes](https://github.com/vmware-labs/webassembly-language-runtimes)
 distributes interpreters including PHP, Python and Ruby, already compiled to

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -65,7 +65,7 @@ spec:
 
 | Field | Details                                                        | Required | Example        |
 |-------|----------------------------------------------------------------|----------|----------------|
-| url   | The URL of the resource including the Wasm binary to instantiate. The supported schemes include "file://". The path of a "file://" URL is relative to the Dapr process unless it begins with '/'. | true     | "file://hello.wasm" |
+| url   | The URL of the resource including the Wasm binary to instantiate. The supported schemes include `file://`. The path of a `file://` URL is relative to the Dapr process unless it begins with `/`. | true     | `file://hello.wasm` |
 
 
 ## Binding support

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -15,7 +15,7 @@ extension.
 
 The Wasm Binding allows you to invoke a program compiled to Wasm by passing
 commandline args or environment variables to it, similar to how you would with
-a normal subprocess. For example, you can satisfy an invocation using Python
+a normal subprocess. For example, you can satisfy an invocation using Python,
 even though Dapr is written in go and running on a platform that doesn't have
 Python installed!
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -29,7 +29,7 @@ version `wasi_snapshot_preview1` (a.k.a. `wasip1`), often abbreviated to `wasi`.
 > **Note:** If compiling in Go 1.21+, this is `GOOS=wasip1 GOARCH=wasm`. In TinyGo, Rust, and Zig, this is the target `wasm32-wasi`.
 
 You can also re-use an existing binary. For example, [Wasm Language Runtimes](https://github.com/vmware-labs/webassembly-language-runtimes)
-distributes interpreters including PHP, Python and Ruby, already compiled to
+distributes interpreters (including PHP, Python, and Ruby) already compiled to
 WASI.
 
 Wasm binaries are loaded from a URL. For example, a URL "file://rewrite.wasm"

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -34,7 +34,7 @@ WASI.
 
 Wasm binaries are loaded from a URL. For example, the URL `file://rewrite.wasm`
 loads `rewrite.wasm` from the current directory of the process. On Kubernetes,
-see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
+see [How to: Mount Pod volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
 to configure a filesystem mount that can contain Wasm binaries.
 
 Dapr uses [wazero](https://wazero.io) to run these binaries, because it has no

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -32,7 +32,7 @@ You can also re-use an existing binary. For example, [Wasm Language Runtimes](ht
 distributes interpreters (including PHP, Python, and Ruby) already compiled to
 WASI.
 
-Wasm binaries are loaded from a URL. For example, a URL "file://rewrite.wasm"
+Wasm binaries are loaded from a URL. For example, the URL `file://rewrite.wasm`
 loads "rewrite.wasm" from the current directory of the process. On Kubernetes,
 see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
 to configure a filesystem mount that can contain Wasm binaries.

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -16,7 +16,7 @@ extension.
 The Wasm Binding allows you to invoke a program compiled to Wasm by passing
 commandline args or environment variables to it, similar to how you would with
 a normal subprocess. For example, you can satisfy an invocation using Python,
-even though Dapr is written in go and running on a platform that doesn't have
+even though Dapr is written in Go and is running on a platform that doesn't have
 Python installed!
 
 The Wasm binary must be a program compiled with the WebAssembly System

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -39,7 +39,7 @@ see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >
 to configure a filesystem mount that can contain Wasm binaries.
 
 Dapr embeds [wazero](https://wazero.io) which loads programs compiled with the
-WebAssembly System Interface (WASI), obviating platform dependencies or forking
+WASI, obviating platform dependencies or forking
 otherwise needed to accomplish something like this.
 
 ## Component format

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -82,7 +82,7 @@ pass metadata properties with each request:
 - `args` any CLI arguments, comma-separated. This excludes the program name.
 
 For example, if your Wasm binary is `ruby.wasm`, the following request would
-have the response data "Hello, salaboy"
+have the response data "Hello, salaboy":
 
 ```json
 {

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -38,9 +38,9 @@ loads "rewrite.wasm" from the current directory of the process. On Kubernetes,
 see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
 to configure a filesystem mount that can contain Wasm binaries.
 
-Dapr embeds [wazero](https://wazero.io) which loads programs compiled with the
-WASI, obviating platform dependencies or forking
-otherwise needed to accomplish something like this.
+Dapr uses [wazero](https://wazero.io) to run these binaries, because it has no
+dependencies. This allows use of WebAssembly with no installation process
+except Dapr itself.
 
 ## Component format
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -1,0 +1,103 @@
+---
+type: docs
+title: "Wasm"
+linkTitle: "Wasm"
+description: "Detailed documentation on the WebAssembly binding component"
+aliases:
+- "/operations/components/setup-bindings/supported-bindings/wasm/"
+---
+
+## Overview
+
+WebAssembly is a way to safely run code compiled in other languages. Runtimes
+execute WebAssembly Modules (Wasm), which are most often binaries with a `.wasm`
+extension.
+
+The Wasm Binding allows you to invoke a program compiled to wasm, by passing
+commandline args or environment variables to it, similar to how you would with
+a normal subprocess. For example, you can satisfy an invocation using Python
+even though Dapr is written in go and running on a platform that doesn't have
+Python installed!
+
+The Wasm binary must be a program compiled with the WebAssembly System
+Interface (WASI). The binary can be a program you've written such as in Go, or
+an interpreter you use to run inlined scripts, such as Python.
+
+Minimally, a user must specify a Wasm binary compiled with the canonical WASI
+version `wasi_snapshot_preview1` a.k.a. `wasip1`, often abbreviated to `wasi`.
+
+If compiling yourself in Go 1.21+, this is `GOOS=wasip1 GOARCH=wasm`, whereas
+in TinyGo, Rust and Zig, this is the target `wasm32-wasi`.
+
+You can also re-use an existing binary. For example, [Wasm Language Runtimes](https://github.com/vmware-labs/webassembly-language-runtimes)
+distributes interpreters including PHP, Python and Ruby, already compiled to
+WASI.
+
+Wasm binaries are loaded from a URL. For example, a URL "file://rewrite.wasm"
+loads "rewrite.wasm" from the current directory of the process. On Kubernetes,
+see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
+to configure a filesystem mount that can contain Wasm binaries.
+
+Dapr embeds [wazero](https://wazero.io) which loads programs compiled with the
+WebAssembly System Interface (WASI), obviating platform dependencies or forking
+otherwise needed to accomplish something like this.
+
+## Component format
+
+To configure a WebAssembly (Wasm) binding, create a component of type
+`bindings.wasm`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}})
+on how to create and apply a binding configuration.
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: wasm
+spec:
+  type: bindings.wasm
+  version: v1
+  metadata:
+  - name: url
+    value: "file://uppercase.wasm"
+```
+
+## Spec metadata fields
+
+| Field | Details                                                        | Required | Example        |
+|-------|----------------------------------------------------------------|----------|----------------|
+| url   | The URL of the resource including the Wasm binary to instantiate. The supported schemes include "file://". The path of a "file://" URL is relative to the Dapr process unless it begins with '/'. | true     | "file://hello.wasm" |
+
+
+## Binding support
+
+This component supports **output binding** with the following operations:
+
+- `execute`
+
+## Example request
+
+The `data` field, if present will be the program's STDIN. You can optionally
+pass metadata properties with each request:
+
+- `args` any CLI arguments, comma-separated. This excludes the program name.
+
+For example, if your Wasm binary is `ruby.wasm`, the following request would
+have the response data "Hello, salaboy"
+
+```json
+{
+  "operation": "execute",
+  "metadata": {
+    "args": "-ne,'print \"Hello, \"; print'"
+  },
+  "data": "salaboy"
+}
+```
+
+## Related links
+
+- [Basic schema for a Dapr component]({{< ref component-schema >}})
+- [Bindings building block]({{< ref bindings >}})
+- [How-To: Trigger application with input binding]({{< ref howto-triggers.md >}})
+- [How-To: Use bindings to interface with external resources]({{< ref howto-bindings.md >}})
+- [Bindings API reference]({{< ref bindings_api.md >}})

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -24,7 +24,7 @@ Interface (WASI). The binary can be a program you've written such as in Go, or
 an interpreter you use to run inlined scripts, such as Python.
 
 Minimally, you must specify a Wasm binary compiled with the canonical WASI
-version `wasi_snapshot_preview1` a.k.a. `wasip1`, often abbreviated to `wasi`.
+version `wasi_snapshot_preview1` (a.k.a. `wasip1`), often abbreviated to `wasi`.
 
 If compiling yourself in Go 1.21+, this is `GOOS=wasip1 GOARCH=wasm`, whereas
 in TinyGo, Rust and Zig, this is the target `wasm32-wasi`.

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Overview
 
-WebAssembly is a way to safely run code compiled in other languages. Runtimes
+With WebAssembly, you can safely run code compiled in other languages. Runtimes
 execute WebAssembly Modules (Wasm), which are most often binaries with a `.wasm`
 extension.
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -23,7 +23,7 @@ The Wasm binary must be a program compiled with the WebAssembly System
 Interface (WASI). The binary can be a program you've written such as in Go, or
 an interpreter you use to run inlined scripts, such as Python.
 
-Minimally, a user must specify a Wasm binary compiled with the canonical WASI
+Minimally, you must specify a Wasm binary compiled with the canonical WASI
 version `wasi_snapshot_preview1` a.k.a. `wasip1`, often abbreviated to `wasi`.
 
 If compiling yourself in Go 1.21+, this is `GOOS=wasip1 GOARCH=wasm`, whereas

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -44,7 +44,7 @@ otherwise needed to accomplish something like this.
 
 ## Component format
 
-To configure a WebAssembly (Wasm) binding, create a component of type
+To configure a Wasm binding, create a component of type
 `bindings.wasm`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}})
 on how to create and apply a binding configuration.
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -13,7 +13,7 @@ With WebAssembly, you can safely run code compiled in other languages. Runtimes
 execute WebAssembly Modules (Wasm), which are most often binaries with a `.wasm`
 extension.
 
-The Wasm Binding allows you to invoke a program compiled to wasm, by passing
+The Wasm Binding allows you to invoke a program compiled to Wasm by passing
 commandline args or environment variables to it, similar to how you would with
 a normal subprocess. For example, you can satisfy an invocation using Python
 even though Dapr is written in go and running on a platform that doesn't have

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -26,7 +26,7 @@ an interpreter you use to run inlined scripts, such as Python.
 Minimally, you must specify a Wasm binary compiled with the canonical WASI
 version `wasi_snapshot_preview1` (a.k.a. `wasip1`), often abbreviated to `wasi`.
 
-If compiling yourself in Go 1.21+, this is `GOOS=wasip1 GOARCH=wasm`, whereas
+> **Note:** If compiling in Go 1.21+, this is `GOOS=wasip1 GOARCH=wasm`. In TinyGo, Rust, and Zig, this is the target `wasm32-wasi`.
 in TinyGo, Rust and Zig, this is the target `wasm32-wasi`.
 
 You can also re-use an existing binary. For example, [Wasm Language Runtimes](https://github.com/vmware-labs/webassembly-language-runtimes)

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -80,8 +80,9 @@ pass metadata properties with each request:
 
 - `args` any CLI arguments, comma-separated. This excludes the program name.
 
-For example, if your Wasm binary is `ruby.wasm`, the following request would
-have the response data "Hello, salaboy":
+For example, if the binding `url` was a Ruby interpreter, such as from
+[webassembly-language-runtimes](https://github.com/vmware-labs/webassembly-language-runtimes/releases/tag/ruby%2F3.2.0%2B20230215-1349da9),
+the following request would respond back with "Hello, salaboy":
 
 ```json
 {

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/wasm.md
@@ -33,7 +33,7 @@ distributes interpreters (including PHP, Python, and Ruby) already compiled to
 WASI.
 
 Wasm binaries are loaded from a URL. For example, the URL `file://rewrite.wasm`
-loads "rewrite.wasm" from the current directory of the process. On Kubernetes,
+loads `rewrite.wasm` from the current directory of the process. On Kubernetes,
 see [mounting volumes to the Dapr sidecar]({{< ref kubernetes-volume-mounts.md >}})
 to configure a filesystem mount that can contain Wasm binaries.
 

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -1,8 +1,8 @@
 ---
 type: docs
-title: "WASM"
-linkTitle: "WASM"
-description: "Use WASM middleware in your HTTP pipeline"
+title: "Wasm"
+linkTitle: "Wasm"
+description: "Use Wasm middleware in your HTTP pipeline"
 aliases:
 - /developing-applications/middleware/supported-middleware/middleware-wasm/
 ---

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -142,3 +142,11 @@
   features:
     input: true
     output: true
+- component: Wasm
+  link: wasm
+  state: Alpha
+  version: v1
+  since: "1.11"
+  features:
+    input: false
+    output: true

--- a/daprdocs/data/components/middleware/http.yaml
+++ b/daprdocs/data/components/middleware/http.yaml
@@ -43,8 +43,8 @@
   state: Stable
   version: v1
   description: Converts the body of the request to uppercase letters (demo)
-- component: WASM
+- component: Wasm
   link: /reference/components-reference/supported-middleware/middleware-wasm
   state: Alpha
   version: v1
-  description: Use WASM middleware in your HTTP pipeline
+  description: Use Wasm middleware in your HTTP pipeline


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [n/a] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [n/a] Images use HTML style and have alternative text
- [n/a] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This adds missing documentation for the WebAssembly a.k.a. Wasm output binding. Note: this also corrects case format, as in WebAssembly, when capitalized it is Wasm, not WASM.

## Issue reference

this PR will close: #3358
