### PR TITLE
v1.9: Fix link to podman installation

### DIFF
--- a/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-podman.md
+++ b/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-podman.md
@@ -11,7 +11,7 @@ This article provides guidance on running Dapr with Podman on a Windows/Linux/ma
 ## Prerequisites
 
 - [Dapr CLI]({{< ref install-dapr-cli.md >}})
-- [Podman](https://podman.io/getting-started/installation.html)
+- [Podman](https://podman.io/docs/tutorials/installation)
 
 ## Initialize Dapr environment
 


### PR DESCRIPTION


The current link currently 404s. This changes it to an alternative link.