### PR TITLE
Clarify that MySQL components work with MariaDB too

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/mysql.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/mysql.md
@@ -1,7 +1,7 @@
 ---
 type: docs
-title: "MySQL binding spec"
-linkTitle: "MySQL"
+title: "MySQL & MariaDB binding spec"
+linkTitle: "MySQL & MariaDB"
 description: "Detailed documentation on the MySQL binding component"
 aliases:
   - "/operations/components/setup-bindings/supported-bindings/mysql/"
@@ -9,7 +9,9 @@ aliases:
 
 ## Component format
 
-To setup MySQL binding create a component of type `bindings.mysql`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.
+The MySQL binding allows connecting to both MySQL and MariaDB databases. In this document, we refer to "MySQL" to indicate both databases.
+
+To setup a MySQL binding create a component of type `bindings.mysql`. See [this guide]({{< ref "howto-bindings.md#1-create-a-binding" >}}) on how to create and apply a binding configuration.
 
 The MySQL binding uses [Go-MySQL-Driver](https://github.com/go-sql-driver/mysql) internally.
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mysql.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mysql.md
@@ -1,13 +1,15 @@
 ---
 type: docs
-title: "MySQL"
-linkTitle: "MySQL"
+title: "MySQL & MariaDB"
+linkTitle: "MySQL & MariaDB"
 description: Detailed information on the MySQL state store component
 aliases:
   - "/operations/components/setup-state-store/supported-state-stores/setup-mysql/"
 ---
 
 ## Component format
+
+The MySQL state store components allows connecting to both MySQL and MariaDB databases. In this document, we refer to "MySQL" to indicate both databases.
 
 To setup MySQL state store create a component of type `state.mysql`. See [this guide]({{< ref "howto-get-save-state.md#step-1-setup-a-state-store" >}}) on how to create and apply a state store configuration.
 

--- a/daprdocs/data/components/bindings/generic.yaml
+++ b/daprdocs/data/components/bindings/generic.yaml
@@ -62,7 +62,7 @@
   features:
     input: true
     output: true
-- component: MySQL
+- component: MySQL & MariaDB
   link: mysql
   state: Alpha
   version: v1


### PR DESCRIPTION
Following a conversation I had on Discord with a user, clarifying that the MySQL components (binding and state store) work with MariaDB too.