### PR TITLE
Typo of Deprecation as Depreciation on the release policy

### DIFF
--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -140,7 +140,7 @@ There is a process for applying breaking changes:
 1. The breaking changes are applied two (2) releases after the release in which the deprecation was announced. 
    - For example, feature X is announced to be deprecated in the 1.0.0 release notes and will then be removed in 1.2.0.
 
-### Depreciations
+### Deprecations
 
 Deprecations appear in release notes under a section named “Deprecations”, which indicates:
 


### PR DESCRIPTION
A mistake I know so many people (including) myself have made and a super minor fix.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [*] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [*] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [*] Commands include options for Linux, MacOS, and Windows within codetabs
- [*] New file and folder names are globally unique
- [*] Page references use shortcodes instead of markdown or URL links
- [*] Images use HTML style and have alternative text
- [*] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixed the typo on support release policy where the word Depreciations was used instead of Deprecations.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
