### PR TITLE
Alternative analytics tracker

### DIFF
--- a/daprdocs/layouts/partials/footer.html
+++ b/daprdocs/layouts/partials/footer.html
@@ -25,15 +25,13 @@
       </div>
     </div>
   </div>
-  <img referrerpolicy="no-referrer-when-downgrade"
-    src="https://static.scarf.sh/a.png?x-pxid=4848fb3b-3edb-4329-90a9-a9d79afff054" />
+  <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=4848fb3b-3edb-4329-90a9-a9d79afff054" />
   <script> (function (ss, ex) { window.ldfdr = window.ldfdr || function () { (ldfdr._q = ldfdr._q || []).push([].slice.call(arguments)); }; (function (d, s) { fs = d.getElementsByTagName(s)[0]; function ce(src) { var cs = d.createElement(s); cs.src = src; cs.async = 1; fs.parentNode.insertBefore(cs, fs); }; ce('https://sc.lfeeder.com/lftracker_v1_' + ss + (ex ? '_' + ex : '') + '.js'); })(document, 'script'); })('JMvZ8gblPjda2pOd'); </script>
 </footer>
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}"
-    aria-label="{{ .name }}">
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
     <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
       <i class="{{ .icon }}"></i>
     </a>

--- a/daprdocs/layouts/partials/footer.html
+++ b/daprdocs/layouts/partials/footer.html
@@ -5,20 +5,19 @@
       <div class="col-6 col-sm-2 text-xs-center order-sm-2" style="margin-top: 1rem;">
         {{ with $links }}
         {{ with index . "user"}}
-        {{ template "footer-links-block" . }}
+        {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
       </div>
       <div class="col-6 col-sm-2 text-right text-xs-center order-sm-3" style="margin-top: 1rem;">
         {{ with $links }}
         {{ with index . "developer"}}
-        {{ template "footer-links-block" . }}
+        {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
       </div>
       <div class="col-12 col-sm-6 text-center py-2 order-sm-2">
-        {{ with .Site.Params }}<small class="text-white">&copy; {{ now.Year}} {{ .trademark | markdownify }}</small>{{
-        end }}
+        {{ with .Site.Params }}<small class="text-white">&copy; {{ now.Year}} {{ .trademark | markdownify }}</small>{{end }}
         {{ if not .Site.Params.ui.footer_about_disable }}
         {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
         {{ end }}

--- a/daprdocs/layouts/partials/footer.html
+++ b/daprdocs/layouts/partials/footer.html
@@ -17,7 +17,7 @@
         {{ end }}
       </div>
       <div class="col-12 col-sm-6 text-center py-2 order-sm-2">
-        {{ with .Site.Params }}<small class="text-white">&copy; {{ now.Year}} {{ .trademark | markdownify }}</small>{{end }}
+        {{ with .Site.Params }}<small class="text-white">&copy; {{ now.Year}} {{ .trademark | markdownify }}</small>{{ end }}
         {{ if not .Site.Params.ui.footer_about_disable }}
         {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
         {{ end }}

--- a/daprdocs/layouts/partials/footer.html
+++ b/daprdocs/layouts/partials/footer.html
@@ -5,31 +5,35 @@
       <div class="col-6 col-sm-2 text-xs-center order-sm-2" style="margin-top: 1rem;">
         {{ with $links }}
         {{ with index . "user"}}
-        {{ template "footer-links-block"  . }}
+        {{ template "footer-links-block" . }}
         {{ end }}
         {{ end }}
       </div>
       <div class="col-6 col-sm-2 text-right text-xs-center order-sm-3" style="margin-top: 1rem;">
         {{ with $links }}
         {{ with index . "developer"}}
-        {{ template "footer-links-block"  . }}
+        {{ template "footer-links-block" . }}
         {{ end }}
         {{ end }}
       </div>
       <div class="col-12 col-sm-6 text-center py-2 order-sm-2">
-        {{ with .Site.Params }}<small class="text-white">&copy; {{ now.Year}} {{ .trademark | markdownify }}</small>{{ end }}
-  {{ if not .Site.Params.ui.footer_about_disable }}
-		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
-	{{ end }}
+        {{ with .Site.Params }}<small class="text-white">&copy; {{ now.Year}} {{ .trademark | markdownify }}</small>{{
+        end }}
+        {{ if not .Site.Params.ui.footer_about_disable }}
+        {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+        {{ end }}
       </div>
     </div>
   </div>
-  <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=4848fb3b-3edb-4329-90a9-a9d79afff054" />
+  <img referrerpolicy="no-referrer-when-downgrade"
+    src="https://static.scarf.sh/a.png?x-pxid=4848fb3b-3edb-4329-90a9-a9d79afff054" />
+  <script> (function (ss, ex) { window.ldfdr = window.ldfdr || function () { (ldfdr._q = ldfdr._q || []).push([].slice.call(arguments)); }; (function (d, s) { fs = d.getElementsByTagName(s)[0]; function ce(src) { var cs = d.createElement(s); cs.src = src; cs.async = 1; fs.parentNode.insertBefore(cs, fs); }; ce('https://sc.lfeeder.com/lftracker_v1_' + ss + (ex ? '_' + ex : '') + '.js'); })(document, 'script'); })('JMvZ8gblPjda2pOd'); </script>
 </footer>
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}"
+    aria-label="{{ .name }}">
     <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
       <i class="{{ .icon }}"></i>
     </a>


### PR DESCRIPTION
This analytics tracker from https://www.leadfeeder.com/ provides high-level web traffic insights for project maintainers so they can better understand how docs are being read and used. This tracker does not use cookies and is GDPR-compliant. It is an alternative to Scarf to test capabilities