### PR TITLE
Adds TTL documentation to CosmosDB and MySQL

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
@@ -72,7 +72,7 @@ In order to setup Cosmos DB as a state store, you need the following properties
 
 ### TTLs and cleanups
 
-This state store supports [Time-To-Live (TTL)]({{< ref state-store-ttl.md >}}) for records stored with Dapr. When storing data using Dapr, you can set the `ttlInSeconds` metadata property to override the default TTL on the CosmodDB container, indicating when the data should be considered "expired". Note that this value with _only_ take effect if the container's `DefaultTimeToLive` field has a non-NULL value. See the [CosmosDB documentation](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/time-to-live) for more information.
+This state store supports [Time-To-Live (TTL)]({{< ref state-store-ttl.md >}}) for records stored with Dapr. When storing data using Dapr, you can set the `ttlInSeconds` metadata property to override the default TTL on the CosmodDB container, indicating when the data should be considered "expired". Note that this value with _only_ take effect if the container's `DefaultTimeToLive` field has a non-NULL value. See the [CosmosDB documentation](https://docs.microsoft.com/azure/cosmos-db/nosql/time-to-live) for more information.
 
 ## Best Practices for Production Use
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
@@ -72,7 +72,7 @@ In order to setup Cosmos DB as a state store, you need the following properties
 
 ### TTLs and cleanups
 
-This state store supports [Time-To-Live (TTL)]({{< ref state-store-ttl.md >}}) for records stored with Dapr. When storing data using Dapr, you can set the `ttlInSeconds` metadata property to override the default TTL on the CosmodDB container, indicating when the data should be considered "expired". Note that this value with _only_ take effect if the container's `DefaultTimeToLive` field has a non-NULL value. See the [CosmosDB documentation](https://docs.microsoft.com/azure/cosmos-db/nosql/time-to-live) for more information.
+This state store supports [Time-To-Live (TTL)]({{< ref state-store-ttl.md >}}) for records stored with Dapr. When storing data using Dapr, you can set the `ttlInSeconds` metadata property to override the default TTL on the CosmodDB container, indicating when the data should be considered "expired". Note that this value _only_ takes effect if the container's `DefaultTimeToLive` field has a non-NULL value. See the [CosmosDB documentation](https://docs.microsoft.com/azure/cosmos-db/nosql/time-to-live) for more information.
 
 ## Best Practices for Production Use
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-azure-cosmosdb.md
@@ -70,6 +70,10 @@ In order to setup Cosmos DB as a state store, you need the following properties
 - **Database**: The name of the database
 - **Collection**: The name of the collection (or container)
 
+### TTLs and cleanups
+
+This state store supports [Time-To-Live (TTL)]({{< ref state-store-ttl.md >}}) for records stored with Dapr. When storing data using Dapr, you can set the `ttlInSeconds` metadata property to override the default TTL on the CosmodDB container, indicating when the data should be considered "expired". Note that this value with _only_ take effect if the container's `DefaultTimeToLive` field has a non-NULL value. See the [CosmosDB documentation](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/time-to-live) for more information.
+
 ## Best Practices for Production Use
 
 Azure Cosmos DB shares a strict metadata request rate limit across all databases in a single Azure Cosmos DB account. New connections to Azure Cosmos DB assume a large percentage of the allowable request rate limit. (See the [Cosmos DB documentation](https://docs.microsoft.com/azure/cosmos-db/sql/troubleshoot-request-rate-too-large#recommended-solution-3))

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mysql.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-mysql.md
@@ -58,7 +58,7 @@ If you wish to use MySQL as an actor store, append the following to the yaml.
 | `timeoutInSeconds`   | N        | Timeout for all database operations. Defaults to `20` | `30` |
 | `pemPath`            | N        | Full path to the PEM file to use for [enforced SSL Connection](#enforced-ssl-connection) required if pemContents is not provided. Cannot be used in K8s environment | `"/path/to/file.pem"`, `"C:\path\to\file.pem"` |
 | `pemContents`        | N        | Contents of PEM file to use for [enforced SSL Connection](#enforced-ssl-connection) required if pemPath is not provided. Can be used in K8s environment | `"pem value"` |
-| `cleanupIntervalInSeconds` | N | Interval, in seconds, to clean up rows with an expired TTL. Default: `3600` (i.e. 1 hour). Setting this to values <=0 disables the periodic cleanup. | `1800`, `-1`
+| `cleanupIntervalInSeconds` | N | Interval, in seconds, to clean up rows with an expired TTL. Default: `3600` (that is 1 hour). Setting this to values <=0 disables the periodic cleanup. | `1800`, `-1`
 
 ## Setup MySQL
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-postgresql.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-postgresql.md
@@ -92,7 +92,7 @@ Either the default "postgres" database can be used, or create a new database for
 
 ### TTLs and cleanups
 
-This state store supports [Time-To-Live (TTL)](https://docs.dapr.io/developing-applications/building-blocks/state-management/state-store-ttl/) for records stored with Dapr. When storing data using Dapr, you can set the `ttlInSeconds` metadata property to indicate after how many seconds the data should be considered "expired".
+This state store supports [Time-To-Live (TTL)]({{< ref state-store-ttl.md >}}) for records stored with Dapr. When storing data using Dapr, you can set the `ttlInSeconds` metadata property to indicate after how many seconds the data should be considered "expired".
 
 Because PostgreSQL doesn't have built-in support for TTLs, this is implemented in Dapr by adding a column in the state table indicating when the data is to be considered "expired". Records that are "expired" are not returned to the caller, even if they're still physically stored in the database. A background "garbage collector" periodically scans the state table for expired rows and deletes them.
 


### PR DESCRIPTION
Adds documentation for `ttlInSeconds` and `cleanupIntervalInSeconds` for CosmosDB and MySQL which was missing.

Update PostgresSQL doc to use markdown reference, instead of FQ http link.