### PR TITLE
Wasm http middleware outdated content

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-wasm.md
@@ -116,41 +116,6 @@ If using TinyGo, compile as shown below and set the spec metadata field named
 tinygo build -o router.wasm -scheduler=none --no-debug -target=wasi router.go`
 ```
 
-### Generating Wasm
-
-This component allows you to rewrite a request URI with custom logic compiled
-to a Wasm using the waPC protocol. The `rewrite` function receives the request
-URI and returns an update as necessary.
-
-To compile your Wasm, you must compile source using a waPC guest SDK such as
-[TinyGo](https://github.com/wapc/wapc-guest-tinygo).
-
-Here's an example in TinyGo:
-
-```go
-package main
-
-import "github.com/wapc/wapc-guest-tinygo"
-
-func main() {
-	wapc.RegisterFunctions(wapc.Functions{"rewrite": rewrite})
-}
-
-// rewrite returns a new URI if necessary.
-func rewrite(requestURI []byte) ([]byte, error) {
-	if string(requestURI) == "/v1.0/hi" {
-		return []byte("/v1.0/hello"), nil
-	}
-	return requestURI, nil
-}
-```
-
-If using TinyGo, compile as shown below and set the spec metadata field named
-"url" to the location of the output (for example, `file://example.wasm`):
-
-```bash
-tinygo build -o example.wasm -scheduler=none --no-debug -target=wasi example.go
-```
 
 ## Related links
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The wasm middleware is updated and the correct `Generating Wasm` section has been added in pr https://github.com/dapr/docs/pull/2922, but the old one did not delete. So this part of the content is duplicated and outdated. Needs to be deleted.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
