### PR TITLE
Document that `||` is a reserved string that cannot be used in state keys.

### DIFF
--- a/daprdocs/content/en/reference/api/state_api.md
+++ b/daprdocs/content/en/reference/api/state_api.md
@@ -68,7 +68,7 @@ POST http://localhost:3500/v1.0/state/myStore?metadata.contentType=application/j
 ```
 > All URL parameters are case-sensitive.
 
-> Since `||` is a reserved character it cannot be used in the `<state key>`
+> Since `||` is a reserved string it cannot be used in the `<state key>`
 > field.
 
 #### Request Body

--- a/daprdocs/content/en/reference/api/state_api.md
+++ b/daprdocs/content/en/reference/api/state_api.md
@@ -68,6 +68,9 @@ POST http://localhost:3500/v1.0/state/myStore?metadata.contentType=application/j
 ```
 > All URL parameters are case-sensitive.
 
+> Since `||` is a reserved character it cannot be used in the `<state key>`
+> field.
+
 #### Request Body
 
 A JSON array of state objects. Each state object is comprised with the following fields:


### PR DESCRIPTION
Found when fuzz testing APIs.