### PR TITLE
Update .net code tab on pubsub quickstart

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
@@ -423,7 +423,7 @@ dotnet build
 Run the `checkout` publisher service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id checkout --resources-path ../../../components --app-port 7005 -- dotnet run
+dapr run --app-id checkout --app-port 7006 --resources-path ../../../components -- dotnet run
 ```
 
 In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `orderpubsub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:

--- a/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
@@ -423,7 +423,7 @@ dotnet build
 Run the `checkout` publisher service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id checkout --resources-path ../../../components -- dotnet run
+dapr run --app-id checkout --resources-path ../../../components --app-port 7005 -- dotnet run
 ```
 
 In the `checkout` publisher, we're publishing the orderId message to the Redis instance called `orderpubsub` [(as defined in the `pubsub.yaml` component)]({{< ref "#pubsubyaml-component-file" >}}) and topic `orders`. As soon as the service starts, it publishes in a loop:


### PR DESCRIPTION

**Please follow this checklist before submitting:**
- [? unclear can't read 'learn more' link from inside PR creation window ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [✔️ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [N/A ] Commands include options for Linux, MacOS, and Windows within codetabs
- [N/A ] New file and folder names are globally unique
- [N/A] Page references use shortcodes instead of markdown or URL links
- [N/A ] Images use HTML style and have alternative text
- [N/A ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

updated .net code tab quickstart for pubsub - previously when running the quickstart as is, the 'checkout' will not properly send messages - I believe this is because in the `sdk\order-processor` folder there is a properties and launchSettings.json file with this entry:
```json
"applicationUrl": "http://localhost:7006"
```
when I add `--app-port 7006`  I am then able to see the entries show up on the `order-processor`  tab. however, if I omit the `--app-port` I get a warning on the checkout side: 
`level=warning msg="App channel is not initialized. Did you configure an app-port?"` 
when I do put in matching app-port on checkout side, I get this message instead:
`level=info msg="application discovered on port 7006"`

I'm assuming that this is the correct way to operate and that I'm not accidentally wiring two services together, going against the usual dapr pattern?