### PR TITLE
Manually build website and upload artifacts

### DIFF
--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -1,4 +1,4 @@
-name: Dapr Root Website
+name: Azure Static Web App Root
 
 on:
   workflow_dispatch:
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build_and_deploy_job:
     name: Build Hugo Website
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
@@ -51,34 +51,22 @@ jobs:
             STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.westus2.azurestaticapps.net/"
           fi
           hugo ${STAGING_URL+-b "$STAGING_URL"}
+      - name: Deploy docs site
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "daprdocs/public/"
+          api_location: "daprdocs/public/" 
+          output_location: ""
+          skip_app_build: true
       - name: Upload Hugo artifacts
         uses: actions/upload-artifact@v3
         with:
           name: hugo_build
           path: ./daprdocs/public/
           if-no-files-found: error
-
-  deploy:
-    name: Deploy website
-    needs: ['build']
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Hugo artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: hugo_build
-          path: site/
-      - name: Deploy staging site
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: "upload"
-          app_location: "site/"
-          api_location: "site/" 
-          output_location: ""
-          skip_app_build: true
 
   close_staging_site:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: hugo_build
-          path: ./docs/public/
+          path: ./daprdocs/public/
           if-no-files-found: error
 
   deploy:

--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - v1.11
 
+concurrency:
+  # Cancel the previously triggered build for only PR build.
+  group: website-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Hugo Website

--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -1,6 +1,7 @@
-name: Azure Static Web App Root
+name: Dapr Root Website
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - v1.11
@@ -10,34 +11,71 @@ on:
       - v1.11
 
 jobs:
-  build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+  build:
+    name: Build Hugo Website
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
-    name: Build and Deploy Job
+    env:
+      SWA_BASE: 'proud-bay-0e9e0e81e'
+      HUGO_ENV: production
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout docs repo
+        uses: actions/checkout@v3
         with:
-          submodules: recursive
-          fetch-depth: 0
+          submodules: true
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2.5.0
+        with:
+          hugo-version: 0.102.3
+          extended: true
       - name: Setup Docsy
-        run: cd daprdocs && git submodule update --init --recursive && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli
-      - name: Build And Deploy
-        id: builddeploy
+        run: |
+          cd daprdocs
+          git submodule update --init --recursive
+          sudo npm install -D --save autoprefixer
+          sudo npm install -D --save postcss-cli
+      - name: Build Hugo Website
+        run: |
+          cd daprdocs
+          git config --global --add safe.directory /github/workspace
+          if [ $GITHUB_EVENT_NAME == 'pull_request' ]; then
+            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.westus2.azurestaticapps.net/"
+          fi
+          hugo ${STAGING_URL+-b "$STAGING_URL"}
+      - name: Upload Hugo artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: hugo_build
+          path: ./docs/public/
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy website
+    needs: ['build']
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Hugo artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: hugo_build
+          path: site/
+      - name: Deploy staging site
         uses: Azure/static-web-apps-deploy@v1
-        env:
-          HUGO_ENV: production
-          HUGO_VERSION: "0.100.2"
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E }}
-          skip_deploy_on_missing_secrets: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "/daprdocs"
-          app_build_command: "git config --global --add safe.directory /github/workspace && hugo"
-          output_location: "public"
-          skip_api_build: true
+          app_location: "site/"
+          api_location: "site/" 
+          output_location: ""
+          skip_app_build: true
 
-  close_pull_request_job:
+  close_staging_site:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-cloudevents.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-cloudevents.md
@@ -92,7 +92,7 @@ You can add additional fields to a custom CloudEvent that are not part of the of
 Publish a CloudEvent to the `orders` topic:
 
 ```bash
-dapr publish --publish-app-id orderprocessing --pubsub order-pub-sub --topic orders --data '{"specversion" : "1.0", "type" : "com.dapr.cloudevent.sent", "source" : "testcloudeventspubsub", "subject" : "Cloud Events Test", "id" : "someCloudEventId", "time" : "2021-08-02T09:00:00Z", "datacontenttype" : "application/cloudevents+json", "data" : {"orderId": "100"}}'
+dapr publish --publish-app-id orderprocessing --pubsub order-pub-sub --topic orders --data '{\"orderId\": \"100\"}'
 ```
 
 {{% /codetab %}}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This PR:
- Manually builds the hugo site and deploys to the Azure SWA instead of using SWA's Onyx builder
- Uploads the assets for later review

Why?
- Future PRs can leverage the uploaded package for indexing or other processing
- Errors can be better isolated to an individual step
- Can add caching in a future PR

This PR lays the groundwork for a couple other PRs I have coming in

## Issue reference

N/A
