### PR TITLE
Add `skip_deploy_on_missing_secrets` config

### DIFF
--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -61,6 +61,7 @@ jobs:
           api_location: "daprdocs/public/" 
           output_location: ""
           skip_app_build: true
+          skip_deploy_on_missing_secretsL: true
       - name: Upload Hugo artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -61,7 +61,7 @@ jobs:
           api_location: "daprdocs/public/" 
           output_location: ""
           skip_app_build: true
-          skip_deploy_on_missing_secretsL: true
+          skip_deploy_on_missing_secrets: true
       - name: Upload Hugo artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

#3559 introduced a new build step that builds the Dapr docs outside of the Azure Static Web App step. This reconfigured the SWA step and accidentally removed `skip_deploy_on_missing_secrets`.

`skip_deploy_on_missing_secrets` is needed because when PRs are created from forked repos Actions doesn't inject the SWA token, so we want to skip deployment and proceed without a staging site.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
