### PR TITLE
Update docs for using Azure AD.

### DIFF
--- a/daprdocs/content/en/developing-applications/integrations/Azure/azure-authentication/_index.md
+++ b/daprdocs/content/en/developing-applications/integrations/Azure/azure-authentication/_index.md
@@ -3,5 +3,5 @@ type: docs
 title: "Authenticate to Azure"
 linkTitle: "Authenticate to Azure"
 weight: 1600
-description: "Learn about authenticating Azure components using Azure Active Directory or Managed Service Identities"
+description: "Learn about authenticating Azure components using Azure Active Directory or Managed Identities"
 ---

--- a/daprdocs/content/en/developing-applications/integrations/Azure/azure-authentication/howto-aad.md
+++ b/daprdocs/content/en/developing-applications/integrations/Azure/azure-authentication/howto-aad.md
@@ -62,6 +62,7 @@ Save the output values returned; you'll need them for Dapr to authenticate with 
 ```
 
 When adding the returned values to your Dapr component's metadata:
+
 - `appId` is the value for `azureClientId`
 - `password` is the value for `azureClientSecret` (this was randomly-generated)
 - `tenant` is the value for `azureTenantId`
@@ -93,11 +94,12 @@ Save the output values returned; you'll need them for Dapr to authenticate with 
 ```
 
 When adding the returned values to your Dapr component's metadata:
+
 - `appId` is the value for `azureClientId`
 - `tenant` is the value for `azureTenantId`
 - `fileWithCertAndPrivateKey` indicates the location of the self-signed PFX certificate and private key. Use the contents of that file as `azureCertificate` (or write it to a file on the server and use `azureCertificateFile`)
 
-> **Note:** While the generated file has the `.pem` extension, it contains a certificate and private key encoded as _PFX (PKCS#12)_.
+> **Note:** While the generated file has the `.pem` extension, it contains a certificate and private key encoded as PFX (PKCS#12).
 
 {{% /codetab %}}
 
@@ -122,26 +124,13 @@ Expected output:
 Service Principal ID: 1d0ccf05-5427-4b5e-8eb4-005ac5f9f163
 ```
 
-The returned value above is the **Service Principal ID**, which is different from the Azure AD application ID (client ID). 
-
-**The Service Principal ID** is:
-- Defined within an Azure tenant
-- Used to grant access to Azure resources to an application
-
+The returned value above is the **Service Principal ID**, which is different from the Azure AD application ID (client ID). The Service Principal ID is defined within an Azure tenant and used to grant access to Azure resources to an application  
 You'll use the Service Principal ID to grant permissions to an application to access Azure resources. 
 
 Meanwhile, **the client ID** is used by your application to authenticate. You'll use the client ID in Dapr manifests to configure authentication with Azure services.
 
 Keep in mind that the Service Principal that was just created does not have access to any Azure resource by default. Access will need to be granted to each resource as needed, as documented in the docs for the components.
 
-{{% alert title="Note" color="primary" %}}
-This step is different from the [official Azure documentation](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli). The short-hand commands included in the official documentation creates a Service Principal that has broad `read-write` access to all Azure resources in your subscription, which:
-
-- Grants your Service Principal more access than you likely desire. 
-- Applies _only_ to the Azure management plane (Azure Resource Manager, or ARM), which is irrelevant for Dapr components, which are designed to interact with the data plane of various services.
-
-{{% /alert %}}
-
 ## Next steps
 
-{{< button text="Use MSI >>" page="howto-msi.md" >}}
+{{< button text="Use Managed Identities >>" page="howto-mi.md" >}}

--- a/daprdocs/content/en/developing-applications/integrations/Azure/azure-authentication/howto-mi.md
+++ b/daprdocs/content/en/developing-applications/integrations/Azure/azure-authentication/howto-mi.md
@@ -1,14 +1,16 @@
 ---
 type: docs
-title: "How to: Use Managed Service Identities"
-linkTitle: "How to: Use MSI"
+title: "How to: Use Managed Identities"
+linkTitle: "How to: Use MI"
 weight: 40000
-description: "Learn how to use Managed Service Identities"
+aliases:
+  - "/developing-applications/integrations/azure/azure-authentication/howto-msi/"
+description: "Learn how to use Managed Identities"
 ---
 
-Using MSI, authentication happens automatically by virtue of your application running on top of an Azure service that has an assigned identity. 
+Using Managed Identities (MI), authentication happens automatically by virtue of your application running on top of an Azure service that has an assigned identity. 
 
-For example, let's say you enable a managed service identity for an Azure VM, Azure Container App, or an Azure Kubernetes Service cluster. When you do, an Azure AD application is created for you and automatically assigned to the service. Your Dapr services can then leverage that identity to authenticate with Azure AD, transparently and without you having to specify any credential.
+For example, let's say you enable a managed service identity for an Azure VM, Azure Container App, or an Azure Kubernetes Service cluster. When you do, an Azure AD application is created for you and automatically assigned to the service. Your Dapr services can then leverage that identity to authenticate with Azure AD, transparently and without you having to specify any credentials.
 
 To get started with managed identities, you need to assign an identity to a new or existing Azure resource. The instructions depend on the service use. Check the following official documentation for the most appropriate instructions:
 
@@ -19,8 +21,9 @@ To get started with managed identities, you need to assign an identity to a new 
 - [Azure Virtual Machines Scale Sets (VMSS)](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/qs-configure-cli-windows-vmss)
 - [Azure Container Instance (ACI)](https://docs.microsoft.com/azure/container-instances/container-instances-managed-identity)
 
+Dapr supports both system-assigned and user-assigned identities.
 
-After assigning a managed identity to your Azure resource, you will have credentials such as:
+After assigning an identity to your Azure resource, you will have credentials such as:
 
 ```json
 {
@@ -31,7 +34,7 @@ After assigning a managed identity to your Azure resource, you will have credent
 }
 ```
 
-From the returned values, take note of **`principalId`**, which is the Service Principal ID that was created. You'll use that to grant access to Azure resources to your Service Principal.
+From the returned values, take note of **`principalId`**, which is the Service Principal ID that was created. You'll use that to grant access to Azure resources to your identity.
 
 ## Next steps
 

--- a/daprdocs/content/en/reference/components-reference/supported-cryptography/azure-key-vault.md
+++ b/daprdocs/content/en/reference/components-reference/supported-cryptography/azure-key-vault.md
@@ -38,7 +38,7 @@ The Azure Key Vault cryptography component supports authentication with Azure AD
 
 1. Read the [Authenticating to Azure]({{< ref "authenticating-azure.md" >}}) document.
 1. Create an [Azure AD application]({{< ref "howto-aad.md" >}}) (also called a Service Principal).
-1. Alternatively, create a [managed identity]({{< ref "howto-msi.md" >}}) for your application platform.
+1. Alternatively, create a [managed identity]({{< ref "howto-mi.md" >}}) for your application platform.
 
 ## Spec metadata fields
 
@@ -48,5 +48,6 @@ The Azure Key Vault cryptography component supports authentication with Azure AD
 | Auth metadata | Y | See [Authenticating to Azure]({{< ref "authenticating-azure.md" >}}) for more information  |  |
 
 ## Related links
+
 - [Cryptography building block]({{< ref cryptography >}})
 - [Authenticating to Azure]({{< ref azure-authentication >}})


### PR DESCRIPTION
Includes:

- Include mentions of Workload Identity support on AKS
- Include mentions of Azure CLI credentials support
- Rename MSI to MI (following official branding)
- Remove Azure Germany as it's not supported anymore
- Remove table with deprecated aliases (that continue to be supported but don't need to be advertised)
- Other clarifications

Many of these changes are new features added in 1.11