### PR TITLE
Update multi-app-template.md

### DIFF
--- a/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
+++ b/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
@@ -83,7 +83,7 @@ apps:
     appProtocol: http
     appPort: 8080
     appHealthCheckPath: "/healthz"
-    command: ["python3" "app.py"]
+    command: ["python3", "app.py"]
     appLogDestination: file # (optional), can be file, console or fileAndConsole. default is fileAndConsole.
     daprdLogDestination: file # (optional), can be file, console or fileAndConsole. default is file.
   - appID: backend # optional


### PR DESCRIPTION
## Description

Added a comma in the comand array, without it an error would be printed in the console after running the following command
```
dapr run -f config.yaml
```
config.yaml content base off of the documentation
```
version: 1

apps:
  - appID: app1
    appDirPath: ./App1.WebApi/
    appProtocol: http
    appPort: 5002
    command: ["dotnet" "run"]
  - appID: app2
    appDirPath: ./App2.WebApi/
    appProtocol: http
    appPort: 5001
    command: ["dotnet" "run"]
```

Error message:
```
Error getting apps from config file: error in parsing the provided app config file: yaml: line 7: did not find expected ',' or ']'
```
