### PR TITLE
Link to related docs from building block index pages

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/_index.md
@@ -9,3 +9,4 @@ description: "Dapr capabilities that solve common development challenges for dis
 Get a high-level [overview of Dapr building blocks]({{< ref building-blocks-concept >}}) in the **Concepts** section.
 
 <img src="/images/buildingblocks-overview.png" alt="Diagram showing the different Dapr API building blocks" width=1000>
+

--- a/daprdocs/content/en/developing-applications/building-blocks/actors/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/actors/_index.md
@@ -5,3 +5,10 @@ linkTitle: "Actors"
 weight: 50
 description: Encapsulate code and data in reusable actor objects as a common microservices design pattern
 ---
+
+{{% alert title="More about Dapr Actors" color="primary" %}}
+ Learn more about how to use Dapr Actors:
+ - Try the [Actors quickstart]({{< ref actors-quickstart.md >}}).
+ - Explore actors via any of the [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Actors API reference documentation]({{< ref actors_api.md >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/_index.md
@@ -5,3 +5,12 @@ linkTitle: "Bindings"
 weight: 40
 description: Interface with or be triggered from external systems
 ---
+
+
+{{% alert title="More about Dapr Bindings" color="primary" %}}
+ Learn more about how to use Dapr Bindings:
+ - Try the [Bindings quickstart]({{< ref bindings-quickstart.md >}}).
+ - Explore input and output bindings via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Bindings API reference documentation]({{< ref bindings_api.md >}}).
+ - Browse the supported [input and output bindings component specs]({{< ref supported-bindings >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/configuration/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/configuration/_index.md
@@ -5,3 +5,11 @@ linkTitle: "Configuration"
 weight: 80
 description: Manage and be notified of application configuration changes
 ---
+
+{{% alert title="More about Dapr Configuration" color="primary" %}}
+ Learn more about how to use Dapr Configuration:
+ - Try the [Configuration quickstart]({{< ref configuration-quickstart.md >}}).
+ - Explore configuration via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Configuration API reference documentation]({{< ref configuration_api.md >}}).
+ - Browse the supported [configuration component specs]({{< ref supported-configuration-stores >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/cryptography/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/cryptography/_index.md
@@ -5,3 +5,10 @@ linkTitle: "Cryptography"
 weight: 110
 description: "Perform cryptographic operations without exposing keys to your application"  
 ---
+
+{{% alert title="More about Dapr Cryptography" color="primary" %}}
+ Learn more about how to use Dapr Cryptography:
+ - Try the [Cryptography quickstart]({{< ref cryptography-quickstart.md >}}).
+ - Explore cryptography via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Browse the supported [cryptography component specs]({{< ref supported-cryptography >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/distributed-lock/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/distributed-lock/_index.md
@@ -5,3 +5,10 @@ linkTitle: "Distributed lock"
 weight: 90
 description: Distributed locks provide mutually exclusive access to shared resources from an application.
 ---
+
+{{% alert title="More about Dapr Distributed Lock" color="primary" %}}
+ Learn more about how to use Dapr Distributed Lock:
+ - Explore distributed locks via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Distributed Lock API reference documentation]({{< ref distributed_lock_api.md >}}).
+ - Browse the supported [distributed locks component specs]({{< ref supported-locks >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/observability/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/observability/_index.md
@@ -6,4 +6,10 @@ weight: 60
 description: See and measure the message calls to components and between networked services
 ---
 
-This section includes guides for developers in the context of observability. See other sections for a [general overview of the observability concept]({{< ref observability-concept >}}) in Dapr and for [operations guidance on monitoring]({{< ref monitoring >}}).
+{{% alert title="More about Dapr Observability" color="primary" %}}
+ Learn more about how to use Dapr Observability Lock:
+ - Explore observability via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Observability API reference documentation]({{< ref health_api.md >}}).
+ - Read the [general overview of the observability concept]({{< ref observability-concept >}}) in Dapr.
+ - Learn the [operations perspective and guidance on monitoring]({{< ref monitoring >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/_index.md
@@ -5,3 +5,11 @@ linkTitle: "Publish & subscribe"
 weight: 30
 description: Secure, scalable messaging between services
 ---
+
+{{% alert title="More about Dapr Pub/sub" color="primary" %}}
+ Learn more about how to use Dapr Pub/sub:
+ - Try the [Pub/sub quickstart]({{< ref pubsub-quickstart.md >}}).
+ - Explore pub/sub via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Pub/sub API reference documentation]({{< ref pubsub_api.md >}}).
+ - Browse the supported [pub/sub component specs]({{< ref supported-pubsub >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/secrets/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/secrets/_index.md
@@ -5,3 +5,11 @@ linkTitle: "Secrets management"
 weight: 70
 description: Securely access secrets from your application
 ---
+
+{{% alert title="More about Dapr Secrets" color="primary" %}}
+ Learn more about how to use Dapr Secrets:
+ - Try the [Secrets quickstart]({{< ref secrets-quickstart.md >}}).
+ - Explore secrets via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Secrets API reference documentation]({{< ref secrets_api.md >}}).
+ - Browse the supported [secrets component specs]({{< ref supported-secret-stores >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/_index.md
@@ -5,3 +5,10 @@ linkTitle: "Service invocation"
 weight: 10
 description: Perform direct, secure, service-to-service method calls
 ---
+
+{{% alert title="More about Dapr Service Invocation" color="primary" %}}
+ Learn more about how to use Dapr Service Invocation:
+ - Try the [Service Invocation quickstart]({{< ref serviceinvocation-quickstart.md >}}).
+ - Explore service invocation via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Service Invocation API reference documentation]({{< ref service_invocation_api.md >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/_index.md
@@ -5,3 +5,11 @@ linkTitle: "State management"
 weight: 20
 description: Create long running stateful services
 ---
+
+{{% alert title="More about Dapr State Management" color="primary" %}}
+ Learn more about how to use Dapr State Management:
+ - Try the [State Management quickstart]({{< ref statemanagement-quickstart.md >}}).
+ - Explore state management via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [State Management API reference documentation]({{< ref state_api.md >}}).
+ - Browse the supported [state management component specs]({{< ref supported-state-stores >}}).
+{{% /alert %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/_index.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/_index.md
@@ -5,3 +5,10 @@ linkTitle: "Workflow"
 weight: 100
 description: "Orchestrate logic across various microservices" 
 ---
+
+{{% alert title="More about Dapr Workflow" color="primary" %}}
+ Learn more about how to use Dapr Workflow:
+ - Try the [Workflow quickstart]({{< ref workflow-quickstart.md >}}).
+ - Explore workflow via any of the supporting [Dapr SDKs]({{< ref sdks >}}). 
+ - Review the [Workflow API reference documentation]({{< ref workflow_api.md >}}).
+{{% /alert %}}


### PR DESCRIPTION
## Description

Seeing if linking to SDK docs, API reference docs, quickstarts, etc from building block index pages works

## Issue reference

PR will close: #1549 
