### PR TITLE
Update sidebar GitHub links metadata

### DIFF
--- a/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
+++ b/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
@@ -83,7 +83,7 @@ apps:
     appProtocol: http
     appPort: 8080
     appHealthCheckPath: "/healthz"
-    command: ["python3" "app.py"]
+    command: ["python3", "app.py"]
     appLogDestination: file # (optional), can be file, console or fileAndConsole. default is fileAndConsole.
     daprdLogDestination: file # (optional), can be file, console or fileAndConsole. default is file.
   - appID: backend # optional

--- a/daprdocs/layouts/partials/page-meta-links.html
+++ b/daprdocs/layouts/partials/page-meta-links.html
@@ -1,28 +1,53 @@
-{{ if .Path }}
-{{ $pathFormatted := replace .Path "\\" "/" }}
-{{ $gh_repo := ($.Param "github_repo") }}
-{{ $gh_subdir := ($.Param "github_subdir") }}
-{{ $gh_project_repo := ($.Param "github_project_repo") }}
-{{ $gh_branch := (default "master" ($.Param "github_branch")) }}
-{{ if $gh_repo }}
-<div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted }}
-{{ if and ($gh_subdir) (.Site.Language.Lang) }}
-{{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
-{{ else if .Site.Language.Lang }}
-{{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted }}
-{{ else if $gh_subdir }}
-{{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted }}
-{{ end }}
-{{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
-{{ $createURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
-{{ $issuesURL := printf "%s/issues/new/choose" $gh_repo}}
-{{ $newPageStub := resources.Get "stubs/new-page-template.md" }}
-{{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
-{{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
+{{ if .File }}
+{{ $pathFormatted := replace .File.Path "\\" "/" -}}
+{{ $gh_repo := ($.Param "github_repo") -}}
+{{ $gh_url := ($.Param "github_url") -}}
+{{ $gh_subdir := ($.Param "github_subdir") -}}
+{{ $gh_project_repo := ($.Param "github_project_repo") -}}
+{{ $gh_branch := (default "main" ($.Param "github_branch")) -}}
+<div class="td-page-meta ms-2 pb-1 pt-2 mb-0">
+{{ if $gh_url -}}
+  {{ warnf "Warning: use of `github_url` is deprecated. For details see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
+  <a href="{{ $gh_url }}" target="_blank"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
+{{ else if $gh_repo -}}
+  {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted -}}
+  {{ if and ($gh_subdir) (.Site.Language.Lang) -}}
+    {{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted -}}
+  {{ else if .Site.Language.Lang -}}
+    {{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted -}}
+  {{ else if $gh_subdir -}}
+    {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted -}}
+  {{ end -}}
 
-<a href="{{ $editURL }}" target="_blank" rel="nofollow noopener noreferrer"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
-<a href="{{ $issuesURL }}" target="_blank" rel="nofollow noopener noreferrer"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+  {{/* Adjust $gh_repo_path based on path_base_for_github_subdir */ -}}
+  {{ $ghs_base := $.Param "path_base_for_github_subdir" -}}
+  {{ $ghs_rename := "" -}}
+  {{ if reflect.IsMap $ghs_base -}}
+    {{ $ghs_rename = $ghs_base.to -}}
+    {{ $ghs_base = $ghs_base.from -}}
+  {{ end -}}
+  {{ with $ghs_base -}}
+    {{ $gh_repo_path = replaceRE . $ghs_rename $gh_repo_path -}}
+  {{ end -}}
+
+  {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
+  {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
+  {{ $issuesURL := printf "%s/issues/new/choose" $gh_repo -}}
+  {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}
+  {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
+  {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS -}}
+
+  <a href="{{ $editURL }}" target="_blank" rel="nofollow noopener noreferrer"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+  <a href="{{ $issuesURL }}" target="_blank" rel="nofollow noopener noreferrer"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+
+  {{ with $gh_project_repo -}}
+    {{ $project_issueURL := printf "%s/issues/new/choose" . -}}
+    <a href="{{ $project_issueURL }}" class="td-page-meta--project-issue" target="_blank" rel="noopener"><i class="fab fa-github fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+  {{ end -}}
+
+{{ end -}}
+{{ with .CurrentSection.AlternativeOutputFormats.Get "print" -}}
+  <a id="print" href="{{ .Permalink | safeURL }}"><i class="fa-solid fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
+{{ end }}
 </div>
-{{ end }}
-{{ end }}
+{{ end -}}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This PR updates the template that generates the "edit page" and "open issue" buttons on the right side of the page for every docs page.

Lays the groundwork to edit the SDK repos

## Issue reference

Partially addresses https://github.com/dapr/docs/issues/1895
