### PR TITLE
add note that low app health probe timeout can cause problems if response time degrades

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/observability/app-health.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/observability/app-health.md
@@ -71,6 +71,10 @@ Additionally, app health checks are impacted by the protocol used for the app ch
 | ----------------------------- | ----------------------------------- | ----------- | ------------- |
 | [`--app-protocol`]({{< ref "app-health.md#health-check-paths" >}})   | `dapr.io/app-protocol`   | Protocol used for the app channel. supported values are `http`, `grpc`, `https`, `grpcs`, and `h2c` (HTTP/2 Cleartext). | `http`  |
 
+{{% alert title="Note" color="primary" %}}
+A low app health probe timeout can classify an application as unhealthy if it experiences a sudden high load, causing the response time to degrade.
+{{% /alert %}}
+
 ### Health check paths
 
 #### HTTP

--- a/daprdocs/content/en/developing-applications/building-blocks/observability/app-health.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/observability/app-health.md
@@ -72,7 +72,7 @@ Additionally, app health checks are impacted by the protocol used for the app ch
 | [`--app-protocol`]({{< ref "app-health.md#health-check-paths" >}})   | `dapr.io/app-protocol`   | Protocol used for the app channel. supported values are `http`, `grpc`, `https`, `grpcs`, and `h2c` (HTTP/2 Cleartext). | `http`  |
 
 {{% alert title="Note" color="primary" %}}
-A low app health probe timeout can classify an application as unhealthy if it experiences a sudden high load, causing the response time to degrade.
+A low app health probe timeout value can classify an application as unhealthy if it experiences a sudden high load, causing the response time to degrade. If this happens, increase the `dapr.io/app-health-probe-timeout` value.
 {{% /alert %}}
 
 ### Health check paths


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Add the information that a low app health probe timeout can during high load mark an application as unhealthy if the response time degrades.

This can cause an unexpected application behavior.

## Issue reference
#3623 
