### PR TITLE
[Bindings] Update bindings docs to include `direction` metadata

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/bindings-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/bindings-overview.md
@@ -59,14 +59,14 @@ Read the [Use output bindings to interface with external resources guide]({{< re
 
 ## Binding directions (optional)
 
-You can provide information via the `direction` metadata field to indicate the direction supported by the binding component. With one of the following metadata values, the Dapr sidecar avoids the `"wait for the app to become ready"` state:
+You can provide the `direction` metadata field to indicate the direction(s) supported by the binding component. In doing so, the Dapr sidecar avoids the `"wait for the app to become ready"` state reducing the lifecycle dependency between the Dapr sidecar and the application:
 
 - `"input"`
 - `"output"`
 - `"input, output"`
 
 {{% alert title="Note" color="primary" %}}
-All bindings should include the `direction` property.
+It is highly recommended that all bindings should include the `direction` property.
 {{% /alert %}}
 
 [See a full example of the bindings `direction` metadata.]({{< ref "bindings_api.md#binding-direction-optional" >}})

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/bindings-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/bindings-overview.md
@@ -57,6 +57,20 @@ To invoke an output binding:
 
 Read the [Use output bindings to interface with external resources guide]({{< ref howto-bindings.md >}}) to get started with output bindings.
 
+## Binding directions (optional)
+
+You can provide information via the `direction` metadata field to indicate the direction supported by the binding component. With one of the following metadata values, the Dapr sidecar avoids the `"wait for the app to become ready"` state:
+
+- `"input"`
+- `"output"`
+- `"input, output"`
+
+{{% alert title="Note" color="primary" %}}
+All bindings should include the `direction` property.
+{{% /alert %}}
+
+[See a full example of the bindings `direction` metadata.]({{< ref "bindings_api.md#binding-direction-optional" >}})
+
 ## Try out bindings
 
 ### Quickstarts and tutorials

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
@@ -32,6 +32,8 @@ Create a new binding component named `checkout`. Within the `metadata` section, 
 - The topic to which you'll publish the message
 - The broker
 
+When creating the binding component, [specify the supported `direction` of the binding]({{< ref "bindings_api.md#binding-direction-optional" >}}). 
+
 {{< tabs "Self-Hosted (CLI)" Kubernetes >}}
 
 {{% codetab %}}
@@ -60,6 +62,8 @@ spec:
     value: sample
   - name: authRequired
     value: "false"
+  - name: direction
+    value: output
 ```
 
 {{% /codetab %}}
@@ -90,6 +94,8 @@ spec:
     value: sample
   - name: authRequired
     value: "false"
+  - name: direction
+    value: output
 ```
 
 {{% /codetab %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
@@ -61,7 +61,7 @@ spec:
   - name: publishTopic
     value: sample
   - name: authRequired
-    value: "false"
+    value: false
   - name: direction
     value: output
 ```
@@ -93,7 +93,7 @@ spec:
   - name: publishTopic
     value: sample
   - name: authRequired
-    value: "false"
+    value: false
   - name: direction
     value: output
 ```

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
@@ -66,7 +66,7 @@ spec:
   - name: publishTopic
     value: sample
   - name: authRequired
-    value: "false"
+    value: false
   - name: direction
     value: input
 ```
@@ -98,7 +98,7 @@ spec:
   - name: publishTopic
     value: sample
   - name: authRequired
-    value: "false"
+    value: false
   - name: direction
     value: input
 ```

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
@@ -37,6 +37,8 @@ Create a new binding component named `checkout`. Within the `metadata` section, 
 - The topic to which you'll publish the message
 - The broker
 
+When creating the binding component, [specify the supported `direction` of the binding]({{< ref "bindings_api.md#binding-direction-optional" >}}). 
+
 {{< tabs "Self-Hosted (CLI)" Kubernetes >}}
 
 {{% codetab %}}
@@ -65,6 +67,8 @@ spec:
     value: sample
   - name: authRequired
     value: "false"
+  - name: direction
+    value: input
 ```
 
 {{% /codetab %}}
@@ -95,6 +99,8 @@ spec:
     value: sample
   - name: authRequired
     value: "false"
+  - name: direction
+    value: input
 ```
 
 {{% /codetab %}}
@@ -256,15 +262,15 @@ async function start() {
 
 {{< /tabs >}}
 
-### ACK-ing an event
+### ACK an event
 
 Tell Dapr you've successfully processed an event in your application by returning a `200 OK` response from your HTTP handler.
 
-### Rejecting an event
+### Reject an event
 
 Tell Dapr the event was not processed correctly in your application and schedule it for redelivery by returning any response other than `200 OK`. For example, a `500 Error`.
 
-### Specifying a custom route
+### Specify a custom route
 
 By default, incoming events will be sent to an HTTP endpoint that corresponds to the name of the input binding. You can override this by setting the following metadata property in `binding.yaml`:
 

--- a/daprdocs/content/en/reference/api/bindings_api.md
+++ b/daprdocs/content/en/reference/api/bindings_api.md
@@ -41,7 +41,7 @@ If running on kubernetes apply the component to your cluster.
 
 In some scenarios, it would be useful to provide additional information to Dapr to indicate the direction supported by the binding component. 
 
-Providing the supported binding direction helps the Dapr sidecar avoid the `"wait for the app to become ready"` state, where it waits indefinitely for the application to become available.
+Providing the binding `direction` helps the Dapr sidecar avoid the `"wait for the app to become ready"` state, where it waits indefinitely for the application to become available. This decouples the lifecycle dependency between the Dapr sidecar and the application.
 
 You can specify the `direction` field as part of the component's metadata. The valid values for this field are: 
 - `"input"`
@@ -49,7 +49,7 @@ You can specify the `direction` field as part of the component's metadata. The v
 - `"input, output"`
 
 {{% alert title="Note" color="primary" %}}
-All bindings should include the `direction` property.
+It is highly recommended that all bindings should include the `direction` property.
 {{% /alert %}}
 
 Here a few scenarios when the `"direction"` metadata field could help:

--- a/daprdocs/content/en/reference/api/bindings_api.md
+++ b/daprdocs/content/en/reference/api/bindings_api.md
@@ -40,12 +40,17 @@ If running on kubernetes apply the component to your cluster.
 ### Binding direction (optional)
 
 In some scenarios, it would be useful to provide additional information to Dapr to indicate the direction supported by the binding component. 
+
 Providing the supported binding direction helps the Dapr sidecar avoid the `"wait for the app to become ready"` state, where it waits indefinitely for the application to become available.
 
 You can specify the `direction` field as part of the component's metadata. The valid values for this field are: 
 - `"input"`
 - `"output"`
 - `"input, output"`
+
+{{% alert title="Note" color="primary" %}}
+All bindings should include the `direction` property.
+{{% /alert %}}
 
 Here a few scenarios when the `"direction"` metadata field could help:
 


### PR DESCRIPTION
## Description
pt 2 to #3646 

Update how-tos and overview with 
- `direction` metadata in examples
- Instructions for specifying the direction metadata
- Cross-linking

## Issue reference

PR will close: #3592 
