### PR TITLE
Add memory clarification for components

### DIFF
--- a/daprdocs/content/en/concepts/components-concept.md
+++ b/daprdocs/content/en/concepts/components-concept.md
@@ -19,7 +19,9 @@ As another example, the [pub/sub]({{< ref "pubsub-overview.md" >}}) building blo
 
 You can get a list of current components available in the hosting environment using the `dapr components` CLI command.
 
-*Note: For any component that returns data to the app, it is recommended to set the memory capacity of the Dapr process/container accordingly to avoid potential OOM panics*
+{{% alert title="Note" color="primary" %}} 
+For any component that returns data to the app, it is recommended to set the memory capacity of the Dapr process/container accordingly to avoid potential OOM panics.*
+{{% /alert %}}
 
 ## Component specification
 

--- a/daprdocs/content/en/concepts/components-concept.md
+++ b/daprdocs/content/en/concepts/components-concept.md
@@ -19,7 +19,7 @@ As another example, the [pub/sub]({{< ref "pubsub-overview.md" >}}) building blo
 
 You can get a list of current components available in the hosting environment using the `dapr components` CLI command.
 
-*Note: for components that read data, it is recommended to set the memory capacity of the Dapr process/container accordingly to avoid potential OOM panics*
+*Note: For any component that returns data to the app, it is recommended to set the memory capacity of the Dapr process/container accordingly to avoid potential OOM panics*
 
 ## Component specification
 

--- a/daprdocs/content/en/concepts/components-concept.md
+++ b/daprdocs/content/en/concepts/components-concept.md
@@ -20,7 +20,7 @@ As another example, the [pub/sub]({{< ref "pubsub-overview.md" >}}) building blo
 You can get a list of current components available in the hosting environment using the `dapr components` CLI command.
 
 {{% alert title="Note" color="primary" %}} 
-For any component that returns data to the app, it is recommended to set the memory capacity of the Dapr process/container accordingly to avoid potential OOM panics. For example in Docker use the `--memory` option. For Kubernetes, use the `dapr.io/sidecar-memory-limit` annotation. For processes this depends on the OS and/or process orchestration tools.*
+For any component that returns data to the app, it is recommended to set the memory capacity of the Dapr sidecar accordingly (process or container) to avoid potential OOM panics. For example in Docker use the `--memory` option. For Kubernetes, use the `dapr.io/sidecar-memory-limit` annotation. For processes this depends on the OS and/or process orchestration tools.*
 {{% /alert %}}
 
 ## Component specification

--- a/daprdocs/content/en/concepts/components-concept.md
+++ b/daprdocs/content/en/concepts/components-concept.md
@@ -19,6 +19,8 @@ As another example, the [pub/sub]({{< ref "pubsub-overview.md" >}}) building blo
 
 You can get a list of current components available in the hosting environment using the `dapr components` CLI command.
 
+*Note: for components that read data, it is recommended to set the memory capacity of the Dapr process/container accordingly to avoid potential OOM panics*
+
 ## Component specification
 
 Each component has a specification (or spec) that it conforms to. Components are configured at design-time with a YAML file which is stored in either:

--- a/daprdocs/content/en/concepts/components-concept.md
+++ b/daprdocs/content/en/concepts/components-concept.md
@@ -20,7 +20,7 @@ As another example, the [pub/sub]({{< ref "pubsub-overview.md" >}}) building blo
 You can get a list of current components available in the hosting environment using the `dapr components` CLI command.
 
 {{% alert title="Note" color="primary" %}} 
-For any component that returns data to the app, it is recommended to set the memory capacity of the Dapr process/container accordingly to avoid potential OOM panics.*
+For any component that returns data to the app, it is recommended to set the memory capacity of the Dapr process/container accordingly to avoid potential OOM panics. For example in Docker use the `--memory` option. For Kubernetes, use the `dapr.io/sidecar-memory-limit` annotation. For processes this depends on the OS and/or process orchestration tools.*
 {{% /alert %}}
 
 ## Component specification


### PR DESCRIPTION
Let users know it's recommended to set the memory capacity for Dapr for components that read data.
