### PR TITLE
Add AKS-EE support instructions

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-aks.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-aks.md
@@ -54,7 +54,9 @@ az aks get-credentials -n [your_aks_cluster_name] -g [your_resource_group]
 ## AKS Edge Essentials
 To create a single-machine K8s/K3s Linux-only cluster using Azure Kubernetes Service (AKS) Edge Essentials, you can follow the quickstart guide available at [AKS Edge Essentials quickstart guide](https://learn.microsoft.com/en-us/azure/aks/hybrid/aks-edge-quickstart). 
 
-Note that AKS Edge Essentials does not come with a default storage class, which may cause issues when deploying Dapr. To avoid this, make sure to enable the **local-path-provisioner** storage class on the cluster before deploying Dapr. If you need more information, refer to [Local Path Provisioner on AKS EE](https://learn.microsoft.com/azure/aks/hybrid/aks-edge-howto-use-storage-local-path).
+{{% alert title="Note" color="primary" %}}
+AKS Edge Essentials does not come with a default storage class, which may cause issues when deploying Dapr. To avoid this, make sure to enable the **local-path-provisioner** storage class on the cluster before deploying Dapr. If you need more information, refer to [Local Path Provisioner on AKS EE](https://learn.microsoft.com/azure/aks/hybrid/aks-edge-howto-use-storage-local-path).
+{{% /alert %}}
 
 ## Next steps
 

--- a/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-aks.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-aks.md
@@ -51,6 +51,11 @@ az aks create --resource-group [your_resource_group] --name [your_aks_cluster_na
 az aks get-credentials -n [your_aks_cluster_name] -g [your_resource_group]
 ```
 
+## AKS Edge Essentials
+To create a single-machine K8s/K3s Linux-only cluster using Azure Kubernetes Service (AKS) Edge Essentials, you can follow the quickstart guide available at [AKS Edge Essentials quickstart guide](https://learn.microsoft.com/en-us/azure/aks/hybrid/aks-edge-quickstart). 
+
+Note that AKS Edge Essentials does not come with a default storage class, which may cause issues when deploying Dapr. To avoid this, make sure to enable the **local-path-provisioner** storage class on the cluster before deploying Dapr. If you need more information, refer to [Local Path Provisioner on AKS EE](https://learn.microsoft.com/azure/aks/hybrid/aks-edge-howto-use-storage-local-path).
+
 ## Next steps
 
 {{< button text="Install Dapr using the AKS Dapr extension >>" page="azure-kubernetes-service-extension" >}}


### PR DESCRIPTION
AKS Edge Essentials does not provide a local-path storage that may cause issues with Dapr installation. Adding AKS-EE specific instructions.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Microsoft AKS Edge Essentials does not provide a local-path storage class by default, which may cause issues with Dapr deployments. The PR aims to add AKS-EE specific instructions to get some AKS-EE specific instruction to get Dapr working. 

## Issue reference
-
