### PR TITLE
Add html for rendering markdown tables

### DIFF
--- a/daprdocs/layouts/shortcodes/table.html
+++ b/daprdocs/layouts/shortcodes/table.html
@@ -1,0 +1,6 @@
+{{ $htmlTable := .Inner | markdownify }}
+{{ $class := .Get 0 | default "" }}
+{{ $old := "<table>" }}
+{{ $new := printf "<table class=\"%s\">" $class }}
+{{ $htmlTable := replace $htmlTable $old $new }}
+{{ $htmlTable | safeHTML }}


### PR DESCRIPTION
Markdown doesn't render within {{< tabs >}}, so creating a simple html layout file for tables

