### PR TITLE
Added errorIfNot2XX option to HTTP binding docs

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
@@ -38,7 +38,7 @@ spec:
       key: "mytoken"
   - name: securityTokenHeader
     value: "Authorization: Bearer" # OPTIONAL <header name for the security token>
-  - name: direction
+  - name: direction # OPTIONAL
     value: "output"
   - name: errorIfNot2XX
     value: "false" # OPTIONAL

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
@@ -40,6 +40,8 @@ spec:
     value: "Authorization: Bearer" # OPTIONAL <header name for the security token>
   - name: direction
     value: "output"
+  - name: errorIfNot2XX
+    value: "false" # OPTIONAL
 ```
 
 ## Spec metadata fields
@@ -54,6 +56,7 @@ spec:
 | `securityToken`      | N        | Output |The value of a token to be added to an HTTP request as a header. Used together with `securityTokenHeader` |
 | `securityTokenHeader`| N        | Output |The name of the header for `securityToken` on an HTTP request that | 
 | `direction`| N        | Output |The direction of the binding | `"output"` 
+| `errorIfNot2XX`| N        | Output |If a binding error should be thrown when the response is not in the 2xx range. Defaults to `true` | `false`, `true` 
 
 ### How to configure MTLS related fields in Metadata
 The values for **MTLSRootCA**, **MTLSClientCert** and **MTLSClientKey** can be provided in three ways:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This documents the `errorIfNot2XX` option which has been part of the HTTP binding component since v1.10 or v1.11
See PR: https://github.com/dapr/components-contrib/pull/2321

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
