### PR TITLE
Example in documentation is not correct

### DIFF
--- a/daprdocs/content/en/reference/resource-specs/httpendpoints-schema.md
+++ b/daprdocs/content/en/reference/resource-specs/httpendpoints-schema.md
@@ -18,7 +18,6 @@ kind: HTTPEndpoint
 metadata:
   name: <NAME>  
 spec:
-  version: v1alpha1
   baseUrl: <REPLACE-WITH-BASEURL> # Required. Use "http://" or "https://" prefix.
   headers: # Optional
   - name: <REPLACE-WITH-A-HEADER-NAME>


### PR DESCRIPTION
## Description

field ".spec.version" does not exist in httpendpoint declaration
