### PR TITLE
Jaeger otlp update

### DIFF
--- a/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
+++ b/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
@@ -74,7 +74,7 @@ To push traces to your Jaeger instance, install the OpenTelemetry Collector on y
 
 1. Download and inspect the [`open-telemetry-collector-jaeger.yaml`](/docs/open-telemetry-collector/open-telemetry-collector-jaeger.yaml) file.
 
-1. In the data section of the `otel-collector-conf` ConfigMap, update the `jaeger.endpoint` value to reflect the endpoint of your Jaeger collector Kubernetes service object.
+1. In the data section of the `otel-collector-conf` ConfigMap, update the `otlp/jaeger.endpoint` value to reflect the endpoint of your Jaeger collector Kubernetes service object.
 
 1. Deploy the OpenTelemetry Collector into the same namespace where your Dapr-enabled applications are running:
 

--- a/daprdocs/static/docs/open-telemetry-collector/open-telemetry-collector-jaeger.yaml
+++ b/daprdocs/static/docs/open-telemetry-collector/open-telemetry-collector-jaeger.yaml
@@ -30,8 +30,8 @@ data:
       # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter
       # for full lists of trace exporters that you can use, and how to
       # configure them.
-      jaeger:
-        endpoint: "jaeger-collector.observability.svc.cluster.local:14250"
+      otlp/jaeger:
+        endpoint: "jaeger-collector.observability.svc.cluster.local:4317"
         tls:
           insecure: true
     service:
@@ -40,7 +40,7 @@ data:
         traces:
           receivers: [otlp]
           # List your exporter here.
-          exporters: [jaeger,logging]
+          exporters: [otlp/jaeger,logging]
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description

Update to the Jaeger Otel collector tracing docs to accommodate for the newest changes made in the jaeger exporter: https://opentelemetry.io/docs/collector/configuration/#exporters

The Otel exporter is now `jaeger/otlp` instead of just `jaeger`.