### PR TITLE
Adding docs for template based processing in k8s name resolution

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-name-resolution/nr-kubernetes.md
+++ b/daprdocs/content/en/reference/components-reference/supported-name-resolution/nr-kubernetes.md
@@ -20,8 +20,8 @@ spec:
   nameResolution:
     component: "kubernetes"
     configuration:
-      "clusterDomain": "cluster.local"  # Mutually exclusive with the template field
-      "template": "{{.ID}}-{{.Data.region}}.internal:{{.Port}}" # Mutually exclusive with the clusterDomain field
+      clusterDomain: "cluster.local"  # Mutually exclusive with the template field
+      template: "{{.ID}}-{{.Data.region}}.internal:{{.Port}}" # Mutually exclusive with the clusterDomain field
 ```
 
 ## Behaviour

--- a/daprdocs/content/en/reference/components-reference/supported-name-resolution/nr-kubernetes.md
+++ b/daprdocs/content/en/reference/components-reference/supported-name-resolution/nr-kubernetes.md
@@ -7,9 +7,9 @@ description: Detailed information on the Kubernetes DNS name resolution componen
 
 ## Configuration format
 
-Generally, Kubernetes DNS name resolution is configured automatically in [Kubernetes mode]({{< ref kubernetes >}}) by Dapr. There is no configuration needed to use Kubernetes DNS as your name resolution provider unless there are some overrides necessary for the Kubernetes name resolution component.
+Generally, Kubernetes DNS name resolution is configured automatically in [Kubernetes mode]({{< ref kubernetes >}}) by Dapr. There is no configuration needed to use Kubernetes DNS as your name resolution provider unless some overrides are necessary for the Kubernetes name resolution component.
 
-In the scenario that an override is required, within a [Dapr Configuration]({{< ref configuration-overview.md >}}) CRD, add a `nameResolution` spec and set the `component` field set to `"kubernetes"`. Then other configuration fields can be set as needed in a `configuration` map as seen below.
+In the scenario that an override is required, within a [Dapr Configuration]({{< ref configuration-overview.md >}}) CRD, add a `nameResolution` spec and set the `component` field to `"kubernetes"`. The other configuration fields can be set as needed in a `configuration` map, as seen below.
 
 ```yaml
 apiVersion: dapr.io/v1alpha1

--- a/daprdocs/content/en/reference/components-reference/supported-name-resolution/nr-kubernetes.md
+++ b/daprdocs/content/en/reference/components-reference/supported-name-resolution/nr-kubernetes.md
@@ -7,7 +7,22 @@ description: Detailed information on the Kubernetes DNS name resolution componen
 
 ## Configuration format
 
-Kubernetes DNS name resolution is configured automatically in [Kubernetes mode]({{< ref kubernetes >}}) by Dapr. There is no configuration needed to use Kubernetes DNS as your name resolution provider.
+Generally, Kubernetes DNS name resolution is configured automatically in [Kubernetes mode]({{< ref kubernetes >}}) by Dapr. There is no configuration needed to use Kubernetes DNS as your name resolution provider unless there are some overrides necessary for the Kubernetes name resolution component.
+
+In the scenario that an override is required, within a [Dapr Configuration]({{< ref configuration-overview.md >}}) CRD, add a `nameResolution` spec and set the `component` field set to `"kubernetes"`. Then other configuration fields can be set as needed in a `configuration` map as seen below.
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: appconfig
+spec:
+  nameResolution:
+    component: "kubernetes"
+    configuration:
+      "clusterDomain": "cluster.local"  # Mutually exclusive with the template field
+      "template": "{{.ID}}-{{.Data.region}}.internal:{{.Port}}" # Mutually exclusive with the clusterDomain field
+```
 
 ## Behaviour
 
@@ -15,7 +30,13 @@ The component resolves target apps by using the Kubernetes cluster's DNS provide
 
 ## Spec configuration fields
 
-Not applicable, as Kubernetes DNS is configured by Dapr when running in Kubernetes mode.
+The configuration spec is fixed to v1.3.0 of the Consul API
+
+| Field        | Required | Type | Details  | Examples |
+|--------------|:--------:|-----:|:---------|----------|
+| clusterDomain       | N        | `string` | The cluster domain to be used for resolved addresses. This field is mutually exclusive with the `template` file.| `cluster.local`
+| template | N        | `string` | A template string to be parsed when addresses are resolved using [text/template](https://pkg.go.dev/text/template#Template) . The template will be populated by the fields in the [ResolveRequest](https://github.com/dapr/components-contrib/blob/v1.12.0-rc.3/nameresolution/requests.go#L20) struct. This field is mutually exclusive with `clusterDomain` field. | `{{.ID}}-{{.Data.region}}.{{.Namespace}}.internal:{{.Port}}`
+
 
 ## Related links
 

--- a/daprdocs/content/en/reference/components-reference/supported-name-resolution/nr-kubernetes.md
+++ b/daprdocs/content/en/reference/components-reference/supported-name-resolution/nr-kubernetes.md
@@ -35,7 +35,7 @@ The configuration spec is fixed to v1.3.0 of the Consul API
 | Field        | Required | Type | Details  | Examples |
 |--------------|:--------:|-----:|:---------|----------|
 | clusterDomain       | N        | `string` | The cluster domain to be used for resolved addresses. This field is mutually exclusive with the `template` file.| `cluster.local`
-| template | N        | `string` | A template string to be parsed when addresses are resolved using [text/template](https://pkg.go.dev/text/template#Template) . The template will be populated by the fields in the [ResolveRequest](https://github.com/dapr/components-contrib/blob/v1.12.0-rc.3/nameresolution/requests.go#L20) struct. This field is mutually exclusive with `clusterDomain` field. | `{{.ID}}-{{.Data.region}}.{{.Namespace}}.internal:{{.Port}}`
+| template | N        | `string` | A template string to be parsed when addresses are resolved using [text/template](https://pkg.go.dev/text/template#Template) . The template will be populated by the fields in the [ResolveRequest](https://github.com/dapr/components-contrib/blob/release-{{% dapr-latest-version short="true" %}}/nameresolution/requests.go#L20) struct. This field is mutually exclusive with `clusterDomain` field. | `{{.ID}}-{{.Data.region}}.{{.Namespace}}.internal:{{.Port}}`
 
 
 ## Related links


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Cluster Domain related to https://github.com/dapr/components-contrib/blob/master/nameresolution/kubernetes/kubernetes.go#L63

Template related to https://github.com/dapr/components-contrib/pull/2883

## Issue reference

Will close #3556 
