### PR TITLE
Adding pluggable secret store doc

### DIFF
--- a/daprdocs/content/en/developing-applications/develop-components/pluggable-components/develop-pluggable.md
+++ b/daprdocs/content/en/developing-applications/develop-components/pluggable-components/develop-pluggable.md
@@ -14,19 +14,21 @@ In order to implement a pluggable component, you need to implement a gRPC servic
 
 ### Find the proto definition file
 
-Proto definitions are provided for each supported service interface (state store, pub/sub, bindings).
+Proto definitions are provided for each supported service interface (state store, pub/sub, bindings, secret stores).
 
 Currently, the following component APIs are supported:
 
 - State stores
 - Pub/sub
 - Bindings
+- Secret stores
 
 |  Component  |    Type    | gRPC definition  |                       Built-in Reference Implementation                        | Docs                                                                                                                                                                  |
 | :---------: | :--------: | :--------------: | :----------------------------------------------------------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| State Store |  `state`   |  [state.proto]   |  [Redis](https://github.com/dapr/components-contrib/tree/master/state/redis)   | [concept]({{< ref "state-management-overview" >}}), [howto]({{< ref "howto-get-save-state" >}}), [api spec]({{< ref "state_api" >}})                                        |
-|   Pub/sub   |  `pubsub`  |  [pubsub.proto]  |  [Redis](https://github.com/dapr/components-contrib/tree/master/pubsub/redis)  | [concept]({{< ref "pubsub-overview" >}}), [howto]({{< ref "howto-publish-subscribe" >}}), [api spec]({{< ref "pubsub_api" >}})                                              |
-|  Bindings   | `bindings` | [bindings.proto] | [Kafka](https://github.com/dapr/components-contrib/tree/master/bindings/kafka) | [concept]({{< ref "bindings-overview" >}}), [input howto]({{< ref "howto-triggers" >}}), [output howto]({{< ref "howto-bindings" >}}), [api spec]({{< ref "bindings_api" >}}) |
+| State Store |  `state`   |  [state.proto](https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/state.proto)   |  [Redis](https://github.com/dapr/components-contrib/tree/master/state/redis)   | [concept]({{< ref "state-management-overview" >}}), [howto]({{< ref "howto-get-save-state" >}}), [api spec]({{< ref "state_api" >}})                                        |
+|   Pub/sub   |  `pubsub`  |  [pubsub.proto](https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/pubsub.proto)  |  [Redis](https://github.com/dapr/components-contrib/tree/master/pubsub/redis)  | [concept]({{< ref "pubsub-overview" >}}), [howto]({{< ref "howto-publish-subscribe" >}}), [api spec]({{< ref "pubsub_api" >}})                                              |
+|  Bindings   | `bindings` | [bindings.proto](https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/bindings.proto) | [Kafka](https://github.com/dapr/components-contrib/tree/master/bindings/kafka) | [concept]({{< ref "bindings-overview" >}}), [input howto]({{< ref "howto-triggers" >}}), [output howto]({{< ref "howto-bindings" >}}), [api spec]({{< ref "bindings_api" >}}) |
+|  Secret Store   | `secretstores` | [secretstore.proto](https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/secretstore.proto) | [Hashicorp/Vault](https://github.com/dapr/components-contrib/blob/master/secretstores/hashicorp/vault/vault.go) | [concept]({{< ref "secrets-overview" >}}), [howto-secrets]({{< ref "howto-secrets" >}}), [api spec]({{< ref "secrets_api" >}}) |
 
 Below is a snippet of the gRPC service definition for pluggable component state stores ([state.proto]):
 
@@ -95,11 +97,15 @@ Provide a concrete implementation of the desired service. Each component has a g
    
 - **Pub/sub**
 
-   Pluggable pub/sub components only have a single core service interface defined ([pubsub.proto]). They have no optional service interfaces.
+   Pluggable pub/sub components only have a single core service interface defined [pubsub.proto](https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/pubsub.proto). They have no optional service interfaces.
  
 - **Bindings**
 
-   Pluggable input and output bindings have a single core service definition on [bindings.proto]. They have no optional service interfaces.
+   Pluggable input and output bindings have a single core service definition on [bindings.proto](https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/bindings.proto). They have no optional service interfaces.
+
+- **Secret Store**
+
+   Pluggable Secret store have a single core service definition on [secretstore.proto](https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/secretstore.proto). They have no optional service interfaces.
 
 After generating the above state store example's service scaffolding code using gRPC and protocol buffers tools, you can define concrete implementations for the 9 methods defined under `service StateStore`, along with code to initialize and communicate with your dependencies.
 

--- a/daprdocs/content/en/developing-applications/develop-components/pluggable-components/pluggable-components-overview.md
+++ b/daprdocs/content/en/developing-applications/develop-components/pluggable-components/pluggable-components-overview.md
@@ -63,7 +63,3 @@ In contrast, pluggable components require additional steps before they can commu
 
 - [Implement a pluggable component]({{< ref develop-pluggable.md >}})
 - [Pluggable component registration]({{< ref "pluggable-components-registration" >}})
-
-[state.proto]: https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/state.proto
-[pubsub.proto]: https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/pubsub.proto
-[bindings.proto]: https://github.com/dapr/dapr/blob/master/dapr/proto/components/v1/bindings.proto


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added Pluggable component secret store documentation.

## Issue reference 

closes #3783 

<!--Please reference the issue this PR will close: #[issue number]-->
