### PR TITLE
fix dashboard helm release name conflict

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -201,7 +201,7 @@ helm repo add dapr https://dapr.github.io/helm-charts/
 helm repo update
 kubectl create namespace dapr-system
 # Install the Dapr dashboard
-helm install dapr dapr/dapr-dashboard --namespace dapr-system
+helm install dapr-dashboard dapr/dapr-dashboard --namespace dapr-system
 ```
 
 ### Verify installation


### PR DESCRIPTION
Renames the helm release to dapr-dashboard from dapr

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Changes the documentation for deploying the dashboard using helm, notably only renaming the helm release name from `dapr` to `dapr-dashboard` to both prevent a release from being overwritten/updated.

## Issue reference

Unreferenced issue - highlighted on [discord](https://discord.com/channels/778680217417809931/1159434381992132628).
