### PR TITLE
feat: '/assign' can be used with go-sdk repo

### DIFF
--- a/daprdocs/content/en/contributing/daprbot.md
+++ b/daprdocs/content/en/contributing/daprbot.md
@@ -6,7 +6,7 @@ weight: 15
 description: "List of Dapr bot capabilities."
 ---
 
-Dapr bot is a GitHub script that helps with common tasks in the Dapr organization. It is set up individually for each repository ([example](https://github.com/dapr/dapr/blob/master/.github/workflows/dapr-bot.yml)) and can be configured to run on specific events. This reference covers the Dapr bot capabilities from the `dapr` and `components-contrib` repositories only.
+Dapr bot is triggered by a list of commands that helps with common tasks in the Dapr organization. It is set up individually for each repository ([example](https://github.com/dapr/dapr/blob/master/.github/workflows/dapr-bot.yml)) and can be configured to run on specific events. Below is a list of commands and the list of repositories they are implemented on.
 
 ## Command reference
 

--- a/daprdocs/content/en/contributing/daprbot.md
+++ b/daprdocs/content/en/contributing/daprbot.md
@@ -10,20 +10,20 @@ Dapr bot is a GitHub script that helps with common tasks in the Dapr organizatio
 
 ## Command reference
 
-| Command | Target | Description | Who can use | Repository |
-|---------|--------|-------------|-------------|------------|
-| `/assign` | Issue | Assigns an issue to a user or group of users | Anyone | `dapr`, `components-contrib` |
-| `/ok-to-test` | Pull request | `dapr`: trigger end to end tests <br/> `components-contrib`: trigger conformance and certification tests | Users listed in the [bot](https://github.com/dapr/dapr/blob/master/.github/scripts/dapr_bot.js)  | `dapr`, `components-contrib` |
-| `/ok-to-perf` | Pull request | Trigger performance tests. | Users listed in the [bot](https://github.com/dapr/dapr/blob/master/.github/scripts/dapr_bot.js) | `dapr` |
-| `/make-me-laugh` | Issue or pull request | Posts a random joke | Users listed in the [bot](https://github.com/dapr/dapr/blob/master/.github/scripts/dapr_bot.js) | `dapr`, `components-contrib` |
+| Command          | Target                | Description                                                                                              | Who can use                                                                                     | Repository                             |
+| ---------------- | --------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `/assign`        | Issue                 | Assigns an issue to a user or group of users                                                             | Anyone                                                                                          | `dapr`, `components-contrib`, `go-sdk` |
+| `/ok-to-test`    | Pull request          | `dapr`: trigger end to end tests <br/> `components-contrib`: trigger conformance and certification tests | Users listed in the [bot](https://github.com/dapr/dapr/blob/master/.github/scripts/dapr_bot.js) | `dapr`, `components-contrib`           |
+| `/ok-to-perf`    | Pull request          | Trigger performance tests.                                                                               | Users listed in the [bot](https://github.com/dapr/dapr/blob/master/.github/scripts/dapr_bot.js) | `dapr`                                 |
+| `/make-me-laugh` | Issue or pull request | Posts a random joke                                                                                      | Users listed in the [bot](https://github.com/dapr/dapr/blob/master/.github/scripts/dapr_bot.js) | `dapr`, `components-contrib`           |
 
 ## Label reference
 
 You can query issues created by the Dapr bot by using the `created-by/dapr-bot` label ([query](https://github.com/search?q=org%3Adapr%20is%3Aissue%20label%3Acreated-by%2Fdapr-bot%20&type=issues)).
 
-| Label | Target | What does it do? | Repository |
-|-------|--------|------------------|------------|
-| `docs-needed` | Issue | Creates a new issue in `dapr/docs` to track doc work | `dapr` |
-| `sdk-needed` | Issue | Creates new issues across the SDK repos to track SDK work | `dapr` |
-| `documentation required` | Issue or pull request | Creates a new issue in `dapr/docs` to track doc work | `components-contrib` |
-| `new component` | Issue or pull request | Creates a new issue in `dapr/dapr` to register the new component | `components-contrib` |
+| Label                    | Target                | What does it do?                                                 | Repository           |
+| ------------------------ | --------------------- | ---------------------------------------------------------------- | -------------------- |
+| `docs-needed`            | Issue                 | Creates a new issue in `dapr/docs` to track doc work             | `dapr`               |
+| `sdk-needed`             | Issue                 | Creates new issues across the SDK repos to track SDK work        | `dapr`               |
+| `documentation required` | Issue or pull request | Creates a new issue in `dapr/docs` to track doc work             | `components-contrib` |
+| `new component`          | Issue or pull request | Creates a new issue in `dapr/dapr` to register the new component | `components-contrib` |


### PR DESCRIPTION
**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The assign command can now be used in issues on the `go-sdk` repo from the referenced PR.

## Issue reference

Refs: (PR) dapr/go-sdk#460
