### PR TITLE
add docs for k8s kubeconfig, defaultNamespace

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubernetes-binding.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubernetes-binding.md
@@ -36,6 +36,7 @@ spec:
 | `namespace` | Y | Input  | The Kubernetes namespace to read events from | `"default"` |
 | `resyncPeriodInSec` | N | Input | The period of time to refresh event list from Kubernetes API server. Defaults to `"10"` | `"15"`
 | `direction` | N | Input | The direction of the binding | `"input"`
+| `kubeconfigPath` | N | Input | The path to the kubeconfig file. If not specified, the binding will use the default in-cluster config value | `"/path/to/kubeconfig"`
 
 ## Binding support
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubernetes-binding.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubernetes-binding.md
@@ -36,7 +36,7 @@ spec:
 | `namespace` | Y | Input  | The Kubernetes namespace to read events from | `"default"` |
 | `resyncPeriodInSec` | N | Input | The period of time to refresh event list from Kubernetes API server. Defaults to `"10"` | `"15"`
 | `direction` | N | Input | The direction of the binding | `"input"`
-| `kubeconfigPath` | N | Input | The path to the kubeconfig file. If not specified, the binding will use the default in-cluster config value | `"/path/to/kubeconfig"`
+| `kubeconfigPath` | N | Input | The path to the kubeconfig file. If not specified, the binding uses the default in-cluster config value | `"/path/to/kubeconfig"`
 
 ## Binding support
 

--- a/daprdocs/content/en/reference/components-reference/supported-cryptography/kubernetes-secrets.md
+++ b/daprdocs/content/en/reference/components-reference/supported-cryptography/kubernetes-secrets.md
@@ -33,7 +33,11 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 ## Spec metadata fields
 
-For the Kubernetes secret store component, there are no metadata attributes.
+| Field              | Required |  Details | Example |
+|--------------------|:--------:|------------|-----|---------|
+| `defaultNamespace` | N | Default namespace to retrieve secrets from. If unset, the namespace must be specified for each key, as `namespace/secretName/key` | `"default-ns"` |
+| `kubeconfigPath` | N | The path to the kubeconfig file. If not specified, the binding will use the default in-cluster config value | `"/path/to/kubeconfig"`
+
 
 ## Related links
 [Cryptography building block]({{< ref cryptography >}})

--- a/daprdocs/content/en/reference/components-reference/supported-cryptography/kubernetes-secrets.md
+++ b/daprdocs/content/en/reference/components-reference/supported-cryptography/kubernetes-secrets.md
@@ -36,7 +36,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | Field              | Required |  Details | Example |
 |--------------------|:--------:|------------|-----|---------|
 | `defaultNamespace` | N | Default namespace to retrieve secrets from. If unset, the namespace must be specified for each key, as `namespace/secretName/key` | `"default-ns"` |
-| `kubeconfigPath` | N | The path to the kubeconfig file. If not specified, the binding will use the default in-cluster config value | `"/path/to/kubeconfig"`
+| `kubeconfigPath` | N | The path to the kubeconfig file. If not specified, the component uses the default in-cluster config value | `"/path/to/kubeconfig"`
 
 
 ## Related links

--- a/daprdocs/content/en/reference/components-reference/supported-secret-stores/kubernetes-secret-store.md
+++ b/daprdocs/content/en/reference/components-reference/supported-secret-stores/kubernetes-secret-store.md
@@ -32,7 +32,12 @@ spec:
 ```
 
 ## Spec metadata fields
-For the Kubernetes secret store component, there are no metadata attributes.
+
+| Field              | Required |  Details | Example |
+|--------------------|:--------:|------------|-----|---------|
+| `defaultNamespace` | N | Default namespace to retrieve secrets from | `"default-ns"` |
+| `kubeconfigPath` | N | The path to the kubeconfig file. If not specified, the binding will use the default in-cluster config value | `"/path/to/kubeconfig"`
+
 
 ## Optional per-request metadata properties
 

--- a/daprdocs/content/en/reference/components-reference/supported-secret-stores/kubernetes-secret-store.md
+++ b/daprdocs/content/en/reference/components-reference/supported-secret-stores/kubernetes-secret-store.md
@@ -35,8 +35,8 @@ spec:
 
 | Field              | Required |  Details | Example |
 |--------------------|:--------:|------------|-----|---------|
-| `defaultNamespace` | N | Default namespace to retrieve secrets from | `"default-ns"` |
-| `kubeconfigPath` | N | The path to the kubeconfig file. If not specified, the binding will use the default in-cluster config value | `"/path/to/kubeconfig"`
+| `defaultNamespace` | N | Default namespace to retrieve secrets from. If unset, the `namespace` must be specified in each request metadata or via environment variable `NAMESPACE` | `"default-ns"` |
+| `kubeconfigPath` | N | The path to the kubeconfig file. If not specified, the store uses the default in-cluster config value | `"/path/to/kubeconfig"`
 
 
 ## Optional per-request metadata properties


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Based on PR https://github.com/dapr/components-contrib/pull/3060/

## Issue reference

Closes #3669 
