### PR TITLE
Fix typo in secret-scope.md

### DIFF
--- a/daprdocs/content/en/operations/configuration/secret-scope.md
+++ b/daprdocs/content/en/operations/configuration/secret-scope.md
@@ -44,7 +44,7 @@ The `allowedSecrets` and `deniedSecrets` list values take priorty over the `defa
 |----- | ------- | -----------| ----------| ------------
 | 1 - Only default access  | deny/allow | empty | empty | deny/allow
 | 2 - Default deny with allowed list | deny | ["s1"] | empty | only "s1" can be accessed
-| 3 - Default allow with deneied list | allow | empty | ["s1"] | only "s1" cannot be accessed
+| 3 - Default allow with denied list | allow | empty | ["s1"] | only "s1" cannot be accessed
 | 4 - Default allow with allowed list  | allow | ["s1"] | empty | only "s1" can be accessed
 | 5 - Default deny with denied list  | deny | empty | ["s1"] | deny
 | 6 - Default deny/allow with both lists  | deny/allow | ["s1"] | ["s2"] | only "s1" can be accessed


### PR DESCRIPTION
Fix typo in secret-scope.md

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
