### PR TITLE
Fix typo

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-configuration-stores/postgresql-configuration-store.md
+++ b/daprdocs/content/en/reference/components-reference/supported-configuration-stores/postgresql-configuration-store.md
@@ -112,7 +112,7 @@ Authenticating with Azure AD is supported with Azure Database for PostgreSQL. Al
 3. Create a TRIGGER on configuration table. An example function to create a TRIGGER is as follows:
 
    ```sh
-   CREATE OR REPLACE FUNCTION configuration_event() RETURNS TRIGGER AS $$
+   CREATE OR REPLACE FUNCTION notify_event() RETURNS TRIGGER AS $$
        DECLARE 
            data json;
            notification json;


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Postgres trigger function name in the steps is `configuration_event` but the function name used in later steps is `notify_event`. It fixes this. For more details see https://github.com/dapr/components-contrib/issues/3167#issuecomment-1765841021 

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
