### PR TITLE
Fix embed youtube URL in howto-outbox.md

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-outbox.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-outbox.md
@@ -109,4 +109,4 @@ spec:
 Watch [this video for an overview of the outbox pattern](https://youtu.be/rTovKpG0rhY?t=1338):
 
 <div class="embed-responsive embed-responsive-16by9">
-<iframe width="360" height="315" src="https://youtu.be/rTovKpG0rhY?t=1338" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="360" height="315" src="https://www.youtube.com/embed/rTovKpG0rhY?si=1xlS54vcdYnLLtOL&amp;start=1338" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-outbox.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-outbox.md
@@ -109,4 +109,4 @@ spec:
 Watch [this video for an overview of the outbox pattern](https://youtu.be/rTovKpG0rhY?t=1338):
 
 <div class="embed-responsive embed-responsive-16by9">
-<iframe width="360" height="315" src="https://www.youtube.com/embed/rTovKpG0rhY?si=1xlS54vcdYnLLtOL&amp;start=1338" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="360" height="315" src="https://www.youtube-nocookie.com/embed/rTovKpG0rhY?si=1xlS54vcdYnLLtOL&amp;start=1338" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
## Description
Page with yt link not correctly embedded:
https://v1-12.docs.dapr.io/developing-applications/building-blocks/state-management/howto-outbox/

There is an error in the page, the src is wrong as it needs to reference an embed url on yt but it's a short url that references a "watch" url:
![image](https://github.com/dapr/docs/assets/8000532/c21f95b2-981a-4c2b-9038-833b5ed215c9)

## Issue reference

I didn't create an issue.