### PR TITLE
update to use the default kafka version to avoid uneccessary errors

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kafka.md
@@ -46,7 +46,7 @@ spec:
   - name: maxMessageBytes # Optional.
     value: "1024"
   - name: version # Optional.
-    value: "1.0.0"
+    value: "2.0.0"
   - name: direction
     value: "input, output"
 ```

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -46,7 +46,7 @@ spec:
   - name: consumeRetryInterval # Optional.
     value: 200ms
   - name: version # Optional.
-    value: 0.10.2.0
+    value: 2.0.0
   - name: disableTls # Optional. Disable TLS. This is not safe for production!! You should read the `Mutual TLS` section for how to use TLS.
     value: "true"
 ```


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

When copying the component metadata verbatim, this generates an error under certain conditions which is not great for users who are new to the component and just want to get started with the example provided.

I've changed to use the current default version to avoid this error.

## Issue reference

https://github.com/dapr/components-contrib/issues/3171
