### PR TITLE
Added example for retrieving bulk deserialized items in dotnet-sdk repo

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
@@ -566,6 +566,33 @@ To launch a Dapr sidecar for the above example application, run a command simila
 dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 dotnet run
 ```
 
+The above example will return a `BulkStateItem` with the serialized format of the value you saved to state. If you would prefer that the value be deserialized by the SDK across each of your bulk response items, you can instead use the following:
+
+```csharp
+//dependencies
+using Dapr.Client;
+//code
+namespace EventService
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            string DAPR_STORE_NAME = "statestore";
+            //Using Dapr SDK to retrieve multiple states
+            using var client = new DaprClientBuilder().Build();
+            IReadOnlyList<BulkStateItem<Widget>> mulitpleStateResult = await client.GetBulkStateAsync<Widget>(DAPR_STORE_NAME, new List<string> { "widget_1", "widget_2" }, parallelism: 1);
+        }
+    }
+
+    class Widget
+    {
+        string Size { get; set; }
+        string Color { get; set; }        
+    }
+}
+```
+
 {{% /codetab %}}
 
 {{% codetab %}}

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
@@ -566,7 +566,7 @@ To launch a Dapr sidecar for the above example application, run a command simila
 dapr run --app-id orderprocessing --app-port 6001 --dapr-http-port 3601 --dapr-grpc-port 60001 dotnet run
 ```
 
-The above example will return a `BulkStateItem` with the serialized format of the value you saved to state. If you would prefer that the value be deserialized by the SDK across each of your bulk response items, you can instead use the following:
+The above example returns a `BulkStateItem` with the serialized format of the value you saved to state. If you prefer that the value be deserialized by the SDK across each of your bulk response items, you can instead use the following:
 
 ```csharp
 //dependencies


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added example to .NET documentation demonstrating changes implemented for [https://github.com/dapr/dotnet-sdk/issues/1172](https://github.com/dapr/dotnet-sdk/issues/1172) alongside existing example. Really just copied/pasted the first example, added the Widget seen in the unit tests and tweaked to accommodate, so not a major change.

## Issue reference

[https://github.com/dapr/dotnet-sdk/issues/1172](https://github.com/dapr/dotnet-sdk/issues/1172)
