### PR TITLE
Add missing arg value in multi-app-template.md

### DIFF
--- a/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
+++ b/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
@@ -93,7 +93,7 @@ Stop the multi-app run template anytime with either of the following commands:
 ```cmd
 # the template file needs to be called `dapr.yaml` by default if a directory path is given
 
-dapr stop -f
+dapr stop -f <dir_path>
 ```
 or:
 

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
@@ -66,7 +66,9 @@ You can then interact with the server using the client port: `localhost:50000`
 {{% /codetab %}}
 
 {{% codetab %}}
+<!-- IGNORE_LINKS -->
 1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/auth/signup](https://account.kubemq.io/auth/signup) and register for a key.
+<!-- END_IGNORE -->
 2. Wait for an email confirmation with your Key
 
 Then Run the following kubectl commands:

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
@@ -51,7 +51,9 @@ This component supports both **input and output** binding interfaces.
 {{< tabs "Self-Hosted" "Kubernetes">}}
 
 {{% codetab %}}
+<!-- IGNORE_LINKS -->
 1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/auth/signup](https://account.kubemq.io/auth/signup) and register for a key.
+<!-- END_IGNORE -->
 2. Wait for an email confirmation with your Key
 
 You can run a KubeMQ broker with Docker:

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kubemq.md
@@ -51,7 +51,7 @@ This component supports both **input and output** binding interfaces.
 {{< tabs "Self-Hosted" "Kubernetes">}}
 
 {{% codetab %}}
-1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/login/register](https://account.kubemq.io/login/register) and register for a key.
+1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/auth/signup](https://account.kubemq.io/auth/signup) and register for a key.
 2. Wait for an email confirmation with your Key
 
 You can run a KubeMQ broker with Docker:
@@ -64,7 +64,7 @@ You can then interact with the server using the client port: `localhost:50000`
 {{% /codetab %}}
 
 {{% codetab %}}
-1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/login/register](https://account.kubemq.io/login/register) and register for a key.
+1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/auth/signup](https://account.kubemq.io/auth/signup) and register for a key.
 2. Wait for an email confirmation with your Key
 
 Then Run the following kubectl commands:

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-kubemq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-kubemq.md
@@ -45,7 +45,7 @@ spec:
 {{< tabs "Self-Hosted" "Kubernetes">}}
 
 {{% codetab %}}
-1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/login/register](https://account.kubemq.io/login/register) and register for a key.
+1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/auth/signup](https://account.kubemq.io/auth/signup) and register for a key.
 2. Wait for an email confirmation with your Key
 
 You can run a KubeMQ broker with Docker:
@@ -58,7 +58,7 @@ You can then interact with the server using the client port: `localhost:50000`
 {{% /codetab %}}
 
 {{% codetab %}}
-1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/login/register](https://account.kubemq.io/login/register) and register for a key.
+1. Obtain KubeMQ Key by visiting [https://account.kubemq.io/auth/signup](https://account.kubemq.io/auth/signup) and register for a key.
 2. Wait for an email confirmation with your Key
 
 Then Run the following kubectl commands:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

Added a missing arg placeholder for `dapr stop -f` example

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
