### PR TITLE
Deficiencies in the steps updated with the multi-app run feature that comes with v12

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/pubsub-quickstart.md
@@ -60,6 +60,8 @@ With the following command, simultaneously run the following services alongside 
 ```bash
 dapr run -f .
 ```
+> **Note**: Since Python3.exe is not defined in Windows, you may need to change  `python3` to `python` in the  [`dapr.yaml`]({{< ref "#dapryaml-multi-app-run-template-file" >}}) file before running `dapr run -f .`
+
 
 **Expected output**
 

--- a/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/serviceinvocation-quickstart.md
@@ -57,6 +57,7 @@ With the following command, simultaneously run the following services alongside 
 ```bash
 dapr run -f .
 ```
+> **Note**: Since Python3.exe is not defined in Windows, you may need to change  `python3` to `python` in the  [`dapr.yaml`]({{< ref "#dapryaml-multi-app-run-template-file" >}}) file before running `dapr run -f .`
 
 **Expected output**
 

--- a/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
@@ -51,8 +51,9 @@ cd state_management/python/sdk/order-processor
 Run the `order-processor` service alongside a Dapr sidecar using [Multi-App Run]({{< ref multi-app-dapr-run >}}).
 
 ```bash
-dapr run -f
+dapr run -f .
 ```
+> **Note**: Since Python3.exe is not defined in Windows, you may need to change  `python3` to `python` in the  [`dapr.yaml`]({{< ref "#dapryaml-multi-app-run-template-file" >}}) file before running `dapr run -f .`
 
 The `order-processor` service writes, reads, and deletes an `orderId` key/value pair to the `statestore` instance [defined in the `statestore.yaml` component]({{< ref "#statestoreyaml-component-file" >}}). As soon as the service starts, it performs a loop.
 
@@ -173,7 +174,7 @@ cd state_management/javascript/sdk/order-processor
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run -f
+dapr run -f .
 ```
 
 The `order-processor` service writes, reads, and deletes an `orderId` key/value pair to the `statestore` instance [defined in the `statestore.yaml` component]({{< ref "#statestoreyaml-component-file" >}}). As soon as the service starts, it performs a loop.
@@ -299,7 +300,7 @@ cd state_management/csharp/sdk/order-processor
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run -f
+dapr run -f .
 ```
 
 The `order-processor` service writes, reads, and deletes an `orderId` key/value pair to the `statestore` instance [defined in the `statestore.yaml` component]({{< ref "#statestoreyaml-component-file" >}}). As soon as the service starts, it performs a loop.
@@ -423,10 +424,16 @@ In a terminal window, navigate to the `order-processor` directory.
 cd state_management/java/sdk/order-processor
 ```
 
+Install the dependencies:
+
+```bash
+mvn clean install
+```
+
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run -f
+dapr run -f .
 ```
 
 The `order-processor` service writes, reads, and deletes an `orderId` key/value pair to the `statestore` instance [defined in the `statestore.yaml` component]({{< ref "#statestoreyaml-component-file" >}}). As soon as the service starts, it performs a loop.
@@ -553,7 +560,7 @@ cd state_management/go/sdk/order-processor
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run -f
+dapr run -f .
 ```
 
 The `order-processor` service writes, reads, and deletes an `orderId` key/value pair to the `statestore` instance [defined in the `statestore.yaml` component]({{< ref "#statestoreyaml-component-file" >}}). As soon as the service starts, it performs a loop.


### PR DESCRIPTION
## Description
As mentioned in the Issue #3860 , there were deficiencies in the steps of the newly added multi-app run feature. Generally, the step of installing dependencies in the state-management header was skipped. In this PR, I added this step to the relevant points.  

In addition, I made an extra note for the python3 problem in windows environments and informed the developers who will follow the document. 

## Issue reference
#3860 
<!--Please reference the issue this PR will close: #[3860]-->
