### PR TITLE
The dapr run command was listed incorrectly for Powershell users. It now has two different options for both Powershell and non-Powershell environments correctly ends in resources-path ../ (done in the get-started-component.md file),

### DIFF
--- a/daprdocs/content/en/getting-started/tutorials/get-started-component.md
+++ b/daprdocs/content/en/getting-started/tutorials/get-started-component.md
@@ -65,7 +65,7 @@ In the above file definition:
 Launch a Dapr sidecar that will listen on port 3500 for a blank application named `myapp`:
 
 ```bash
-dapr run --app-id myapp --dapr-http-port 3500 --resources-path .
+dapr run --app-id myapp --dapr-http-port 3500 --resources-path ../
 ```
 
 {{% alert title="Tip" color="primary" %}}

--- a/daprdocs/content/en/getting-started/tutorials/get-started-component.md
+++ b/daprdocs/content/en/getting-started/tutorials/get-started-component.md
@@ -64,8 +64,14 @@ In the above file definition:
 
 Launch a Dapr sidecar that will listen on port 3500 for a blank application named `myapp`:
 
+
+PowerShell environment:
 ```bash
 dapr run --app-id myapp --dapr-http-port 3500 --resources-path ../
+```
+non-PowerShell environment:
+```bash
+dapr run --app-id myapp --dapr-http-port 3500 --resources-path .
 ```
 
 {{% alert title="Tip" color="primary" %}}


### PR DESCRIPTION
In Section 3: Run the Dapr Sidecar, the --resources-path flag in the dapr run command was listed incorrectly. It now correctly ends in resources-path ../ for powershell users

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

in the get-started-component.md file, in Step 3: Run the Dapr sidecar,  I added the correct command for PowerShell and non powershell environments. Changed dapr run --app-id myapp --dapr-http-port 3500 --resources-path . to dapr run --app-id myapp --dapr-http-port 3500 --resources-path ../ to make the command correct as Component Tutorial - "--resources-path" flag is incorrect when using Powershell.

## Issue reference

#3858
