### PR TITLE
Add link to Docs contributor video and update CodeSpaces page

### DIFF
--- a/daprdocs/content/en/contributing/codespaces.md
+++ b/daprdocs/content/en/contributing/codespaces.md
@@ -30,6 +30,7 @@ If you haven't already forked the repo, creating the Codespace will also create 
 - [dapr/dapr](https://github.com/dapr/dapr)
 - [dapr/components-contrib](https://github.com/dapr/components-contrib)
 - [dapr/cli](https://github.com/dapr/cli)
+- [dapr/docs](https://github.com/dapr/docs)
 - [dapr/python-sdk](https://github.com/dapr/python-sdk)
 
 ## Developing Dapr Components in a Codespace

--- a/daprdocs/content/en/contributing/docs-contrib/contributing-docs.md
+++ b/daprdocs/content/en/contributing/docs-contrib/contributing-docs.md
@@ -8,6 +8,8 @@ description: Get started with contributing to the Dapr docs
 
 In this guide, you'll learn how to contribute to the [Dapr docs repository](https://github.com/dapr/docs). Since Dapr docs are published to [docs.dapr.io](https://docs.dapr.io), you must make sure your contributions compile and publish correctly.
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/uPYuXcaEs-c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ## Prerequisites
 
 Before contributing to the Dapr docs: 


### PR DESCRIPTION
Signed-off-by: Marc Duiker <marcduiker@users.noreply.github.com>

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Update Docs contributors page to include the YouTube video.

Added the dapr/docs repo to the list of repos that support CodeSpaces.

## Issue reference
#3961