### PR TITLE
Added the missing `-k` flag in the Kubernetes Deploy docs

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -251,7 +251,7 @@ To use Mariner-based images for Dapr, you need to add `-mariner` to your Docker 
 In the Dapr CLI, you can switch to using Mariner-based images with the `--image-variant` flag.
 
 ```sh
-dapr init --image-variant mariner
+dapr init -k --image-variant mariner
 ```
 
 {{% /codetab %}}


### PR DESCRIPTION
Added the missing `-k` flag in the Kubernetes Deploy docs.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
I was going through the Dapr docs and noticed that a flag was missing. Very small change.

## Issue reference
<!--Please reference the issue this PR will close: #[issue number]-->
