### PR TITLE
Add instructions to open the .dapr folder in the user profile on Windows

### DIFF
--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -137,7 +137,7 @@ ls $HOME/.dapr
 {{% codetab %}}
 You can verify using either PowerShell or command line. If using PowerShell, run:
 ```powershell
-explorer "$env:USERPROFILE.dapr"
+explorer "$env:USERPROFILE\.dapr"
 ```
 
 If using command line, run: 

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -135,7 +135,7 @@ ls $HOME/.dapr
 {{% /codetab %}}
 
 {{% codetab %}}
-Powershell
+You can verify using either PowerShell or command line. If using PowerShell, run:
 ```powershell
 explorer "$env:USERPROFILE.dapr"
 ```

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -142,7 +142,7 @@ explorer "$env:USERPROFILE\.dapr"
 
 If using command line, run: 
 ```cmd
-explorer "%USERPROFILE%.dapr"
+explorer "%USERPROFILE%\.dapr"
 ```
 
 **Result:**

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -135,9 +135,13 @@ ls $HOME/.dapr
 {{% /codetab %}}
 
 {{% codetab %}}
-
+Powershell
 ```powershell
-explorer "%USERPROFILE%\.dapr\"
+explorer "$env:USERPROFILE.dapr"
+```
+command line
+```cmd
+explorer "%USERPROFILE%.dapr"
 ```
 
 **Result:**

--- a/daprdocs/content/en/getting-started/install-dapr-selfhost.md
+++ b/daprdocs/content/en/getting-started/install-dapr-selfhost.md
@@ -139,7 +139,8 @@ You can verify using either PowerShell or command line. If using PowerShell, run
 ```powershell
 explorer "$env:USERPROFILE.dapr"
 ```
-command line
+
+If using command line, run: 
 ```cmd
 explorer "%USERPROFILE%.dapr"
 ```


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference
Fixes #3939
<!--Please reference the issue this PR will close: #[issue number]-->
