### PR TITLE
Add Kafka AWS IAM support for authenication

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -285,7 +285,9 @@ spec:
 #### AWS IAM
 
 Authenticating with AWS IAM is supported with AWS Managed Streaming for Apache Kafka (MSK). Setting `authType` to `awsiam` uses AWS SDK to generate auth tokens to authenticate.
-Note the only required metadata field is `awsRegion`, if no `awsAccessKey` and `awsSecretKey` are provided you can use AWS IAM roles for service accounts to have passwordless authentication to your Kafka cluster.
+{{% alert title="Note" color="primary" %}}
+The only required metadata field is `awsRegion`. If no `awsAccessKey` and `awsSecretKey` are provided, you can use AWS IAM roles for service accounts to have password-less authentication to your Kafka cluster.
+{{% /alert %}}
 
 ```yaml
 apiVersion: dapr.io/v1alpha1

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -294,7 +294,7 @@ spec:
 
 #### AWS IAM
 
-Authenticating with AWS IAM is supported with AWS Managed Streaming for Apache Kafka (MSK). Setting `authType` to `awsiam` uses AWS SDK to generate auth tokens to authenticate.
+Authenticating with AWS IAM is supported with MSK. Setting `authType` to `awsiam` uses AWS SDK to generate auth tokens to authenticate.
 {{% alert title="Note" color="primary" %}}
 The only required metadata field is `awsRegion`. If no `awsAccessKey` and `awsSecretKey` are provided, you can use AWS IAM roles for service accounts to have password-less authentication to your Kafka cluster.
 {{% /alert %}}

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -96,7 +96,7 @@ spec:
 | awsAccessKey | N  | AWS access key associated with an IAM account. | `"accessKey"`
 | awsSecretKey | N  | The secret key associated with the access key. | `"secretKey"`
 | awsSessionToken | N  | AWS session token to use. A session token is only required if you are using temporary security credentials. | `"sessionToken"`
-| awsIamRoleArn | N  | IAM role that has access to MSK. This is another option to authenticate with MSK aside from the AWS Credentials. | `"arn:aws:iam::123456789:role/mskRole"`
+| awsIamRoleArn | N  | IAM role that has access to AWS Managed Streaming for Apache Kafka (MSK). This is another option to authenticate with MSK aside from the AWS Credentials. | `"arn:aws:iam::123456789:role/mskRole"`
 | awsStsSessionName | N  | Represents the session name for assuming a role. | `"MSKSASLDefaultSession"`
 | schemaRegistryURL | N | Required when using Schema Registry Avro serialization/deserialization. The Schema Registry URL. | `http://localhost:8081` |
 | schemaRegistryAPIKey | N | When using Schema Registry Avro serialization/deserialization. The Schema Registry credentials API Key. | `XYAXXAZ` |

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -113,7 +113,17 @@ The metadata `version` must be set to `1.0.0` when using Azure EventHubs with Ka
 
 Kafka supports a variety of authentication schemes and Dapr supports several: SASL password, mTLS, OIDC/OAuth2. With the added authentication methods, the `authRequired` field has
 been deprecated from the v1.6 release and instead the `authType` field should be used. If `authRequired` is set to `true`, Dapr will attempt to configure `authType` correctly
-based on the value of `saslPassword`. This are the valid values for `authType`: `none`, `password`, `certificate`, `mtls`, `oidc` and `awsiam`. Note this is authentication only; authorization is still configured within Kafka except for `awsiam` which can also drive authorization decisions configured in AWS IAM.
+based on the value of `saslPassword`. The valid values for `authType` are: 
+- `none`
+- `password`
+- `certificate`
+- `mtls`
+- `oidc` 
+- `awsiam`
+
+{{% alert title="Note" color="primary" %}}
+`authType` is _authentication_ only. _Authorization_ is still configured within Kafka, except for `awsiam`, which can also drive authorization decisions configured in AWS IAM.
+{{% /alert %}}
 
 #### None
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

Adding missing docs for kafka AWS IAM auth feature

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference
Closes https://github.com/dapr/docs/issues/3994
<!--Please reference the issue this PR will close: #[issue number]-->
https://github.com/dapr/components-contrib/issues/3239