### PR TITLE
Documentation (Redis state store) : Removed duplicated fields

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
@@ -30,18 +30,14 @@ spec:
     value: <PASSWORD>
   - name: enableTLS
     value: <bool> # Optional. Allowed: true, false.
-  - name: failover
-    value: <bool> # Optional. Allowed: true, false.
-  - name: sentinelMasterName
-    value: <string> # Optional
   - name: maxRetries
     value: # Optional
   - name: maxRetryBackoff
     value: # Optional
   - name: failover
-    value: # Optional
+    value: <bool> # Optional. Allowed: true, false.
   - name: sentinelMasterName
-    value: # Optional
+    value: <string> # Optional
   - name: redeliverInterval
     value: # Optional
   - name: processingTimeout


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

In [Redis state store component configuration example](https://docs.dapr.io/reference/components-reference/supported-state-stores/setup-redis/#component-format), "failover" and "sentinelMasterName" fields were duplicated.

This commit removes these duplicates, keeping the most verbose value (eg: `<bool> # Optional. Allowed: true, false` instead of `# Optional`) and using the same position as the one in the [spec metadata fields](https://docs.dapr.io/reference/components-reference/supported-state-stores/setup-redis/#spec-metadata-fields) part .

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
#3999 