### PR TITLE
Added errorIfNot2XX option to HTTP binding docs (#3741)

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/http.md
@@ -40,6 +40,8 @@ spec:
     #    key: "mytoken"
     #- name: securityTokenHeader
     #  value: "Authorization: Bearer" # OPTIONAL <header name for the security token>
+    #- name: errorIfNot2XX
+    #  value: "false" # OPTIONAL
 ```
 
 ## Spec metadata fields
@@ -54,8 +56,8 @@ spec:
 | `MTLSRenegotiation`  | N | Output | Type of mTLS renegotiation to be used | `RenegotiateOnceAsClient`
 | `securityToken`      | N | Output | The value of a token to be added to a HTTP request as a header. Used together with `securityTokenHeader` |
 | `securityTokenHeader` | N | Output | The name of the header for `securityToken` on a HTTP request |
+| `errorIfNot2XX`      | N | Output | If a binding error should be thrown when the response is not in the 2xx range. Defaults to `true` |
 
-### How to configure mTLS-related fields in metadata
 
 The values for **MTLSRootCA**, **MTLSClientCert** and **MTLSClientKey** can be provided in three ways:
 


### PR DESCRIPTION
Cherry-picking lost +PR that was merged into an old branch: https://github.com/dapr/docs/pull/3741

* Added errorIfNot2XX option to HTTP binding docs

* Update daprdocs/content/en/reference/components-reference/supported-bindings/http.md



---------

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
