### PR TITLE
Adjust documentation per `rawPayload=true` requirements

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -463,7 +463,7 @@ You can configure pub/sub to publish or consume data encoded using [Avro binary 
 
 {{% alert title="Important" color="warning" %}}
 Currently, only message value serialization/deserialization is supported. Since cloud events are not supported, the `rawPayload=true` metadata must be passed when publishing Avro messages.
-Please note that `rawPayload=true` should NOT be set for consumers as the message value, while properly deserialized into json will be wrapped into a CloudEvent.
+Please note that `rawPayload=true` should NOT be set for consumers, as the message value will be wrapped into a CloudEvent and base64-encoded. Leaving `rawPayload` as default, will send the Avro-decoded message to the application.
 {{% /alert %}}
 
 When configuring the Kafka pub/sub component metadata, you must define:

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -463,7 +463,7 @@ You can configure pub/sub to publish or consume data encoded using [Avro binary 
 
 {{% alert title="Important" color="warning" %}}
 Currently, only message value serialization/deserialization is supported. Since cloud events are not supported, the `rawPayload=true` metadata must be passed when publishing Avro messages.
-Please note that `rawPayload=true` should NOT be set for consumers, as the message value will be wrapped into a CloudEvent and base64-encoded. Leaving `rawPayload` as default, will send the Avro-decoded message to the application.
+Please note that `rawPayload=true` should NOT be set for consumers, as the message value will be wrapped into a CloudEvent and base64-encoded. Leaving `rawPayload` as default (i.e. `false`), will send the Avro-decoded message to the application.
 {{% /alert %}}
 
 When configuring the Kafka pub/sub component metadata, you must define:

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -462,7 +462,8 @@ You can configure pub/sub to publish or consume data encoded using [Avro binary 
 ### Configuration
 
 {{% alert title="Important" color="warning" %}}
-Currently, only message value serialization/deserialization is supported. Since cloud events are not supported, the `rawPayload=true` metadata must be passed.
+Currently, only message value serialization/deserialization is supported. Since cloud events are not supported, the `rawPayload=true` metadata must be passed when publishing Avro messages.
+Please note that `rawPayload=true` should NOT be set for consumers as the message value, while properly deserialized into json will be wrapped into a CloudEvent.
 {{% /alert %}}
 
 When configuring the Kafka pub/sub component metadata, you must define:
@@ -533,7 +534,6 @@ def subscribe():
                       'topic': 'my-topic',
                       'route': 'my_topic_subscriber',
                       'metadata': {
-                          'rawPayload': 'true',
                           'valueSchemaType': 'Avro',
                       } }]
     return subscriptions

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -463,7 +463,7 @@ You can configure pub/sub to publish or consume data encoded using [Avro binary 
 
 {{% alert title="Important" color="warning" %}}
 Currently, only message value serialization/deserialization is supported. Since cloud events are not supported, the `rawPayload=true` metadata must be passed when publishing Avro messages.
-Please note that `rawPayload=true` should NOT be set for consumers, as the message value will be wrapped into a CloudEvent and base64-encoded. Leaving `rawPayload` as default (i.e. `false`), will send the Avro-decoded message to the application.
+Please note that `rawPayload=true` should NOT be set for consumers, as the message value will be wrapped into a CloudEvent and base64-encoded. Leaving `rawPayload` as default (i.e. `false`) will send the Avro-decoded message to the application as a JSON payload.
 {{% /alert %}}
 
 When configuring the Kafka pub/sub component metadata, you must define:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

## Description

The documentation added for kafka-pubsub Avro support was misleading when it comes to `rawPayload` requirements.
Adjusting accordingly

## Issue reference
#4087