### PR TITLE
Alicejgibbons/remove mem limits in production

### DIFF
--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -1,0 +1,54 @@
+name: Azure Static Web App Root
+
+on:
+  push:
+    branches:
+      - v1.13
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - v1.13
+
+jobs:
+  build_and_deploy_job:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    name: Build and Deploy Job
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Setup Docsy
+        run: cd daprdocs && git submodule update --init --recursive && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v0.0.1-preview
+        env:
+          HUGO_ENV: production
+          HUGO_VERSION: "0.100.2"
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          skip_deploy_on_missing_secrets: true
+          action: "upload"
+          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
+          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
+          app_location: "/daprdocs" # App source code path
+          api_location: "api" # Api source code path - optional
+          output_location: "public" # Built app content directory - optional
+          app_build_command: "hugo"
+          ###### End of Repository/Build Configurations ######
+
+  close_pull_request_job:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: Azure/static-web-apps-deploy@v0.0.1-preview
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E }}
+          skip_deploy_on_missing_secrets: true
+ 

--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -1,6 +1,7 @@
 name: Azure Static Web App Root
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - v1.13
@@ -9,46 +10,101 @@ on:
     branches:
       - v1.13
 
+concurrency:
+  # Cancel the previously triggered build for only PR build.
+  group: website-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    name: Build Hugo Website
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
-    name: Build and Deploy Job
+    env:
+      SWA_BASE: 'proud-bay-0e9e0e81e'
+      HUGO_ENV: production
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout docs repo
+        uses: actions/checkout@v3
         with:
-          submodules: recursive
-          fetch-depth: 0
+          submodules: true
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2.5.0
+        with:
+          hugo-version: 0.102.3
+          extended: true
       - name: Setup Docsy
-        run: cd daprdocs && git submodule update --init --recursive && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli
-      - name: Build And Deploy
-        id: builddeploy
-        uses: Azure/static-web-apps-deploy@v0.0.1-preview
-        env:
-          HUGO_ENV: production
-          HUGO_VERSION: "0.100.2"
+        run: |
+          cd daprdocs
+          git submodule update --init --recursive
+          sudo npm install -D --save autoprefixer
+          sudo npm install -D --save postcss-cli
+      - name: Build Hugo Website
+        run: |
+          cd daprdocs
+          git config --global --add safe.directory /github/workspace
+          if [ $GITHUB_EVENT_NAME == 'pull_request' ]; then
+            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.westus2.azurestaticapps.net/"
+          fi
+          hugo ${STAGING_URL+-b "$STAGING_URL"}
+      - name: Deploy docs site
+        uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          skip_deploy_on_missing_secrets: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/daprdocs" # App source code path
-          api_location: "api" # Api source code path - optional
-          output_location: "public" # Built app content directory - optional
-          app_build_command: "hugo"
-          ###### End of Repository/Build Configurations ######
+          app_location: "daprdocs/public/"
+          api_location: "daprdocs/public/" 
+          output_location: ""
+          skip_app_build: true
+          skip_deploy_on_missing_secrets: true
+      - name: Upload Hugo artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: hugo_build
+          path: ./daprdocs/public/
+          if-no-files-found: error
 
-  close_pull_request_job:
+  close_staging_site:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v0.0.1-preview
+        uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E }}
+          action: "close"
           skip_deploy_on_missing_secrets: true
+
+  algolia_index:
+    name: Index site for Algolia
+    if: github.event_name == 'push'
+    needs: ['build_and_deploy_job']
+    runs-on: ubuntu-latest
+    env:
+      ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+      ALGOLIA_API_WRITE_KEY: ${{ secrets.ALGOLIA_API_WRITE_KEY }}
+      ALGOLIA_INDEX_NAME: daprdocs
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+      - name: Download Hugo artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: hugo_build
+          path: site/
+      - name: Install Python packages
+        run: |
+          pip install --upgrade bs4
+          pip install --upgrade 'algoliasearch>=2.0,<3.0'
+      - name: Index site
+        run: python ./.github/scripts/algolia.py ./site
  

--- a/daprdocs/config.toml
+++ b/daprdocs/config.toml
@@ -105,37 +105,45 @@ id = "G-60C6Q1ETC1"
     lang = "en"
 
   [[module.mounts]]
-    source = "../translations/docs-zh/content/zh-hans"
+    source = "../translations/docs-zh/translated_content/zh_CN/docs"
     target = "content"
     lang = "zh-hans"
   [[module.mounts]]
-    source = "../translations/docs-zh/content/contributing"
-    target = "content/contributing/docs-contrib/docs-templates"
+    source = "../translations/docs-zh/translated_content/zh_CN/contributing"
+    target = "content/contributing/sdk-contrib/"
     lang = "zh-hans"
   [[module.mounts]]
-    source = "../translations/docs-zh/content/sdks_python"
+    source = "../translations/docs-zh/translated_content/zh_CN/sdks_python"
     target = "content/developing-applications/sdks/python"
     lang = "zh-hans"
   [[module.mounts]]
-    source = "../translations/docs-zh/content/sdks_php"
+    source = "../translations/docs-zh/translated_content/zh_CN/sdks_php"
     target = "content/developing-applications/sdks/php"
     lang = "zh-hans"
   [[module.mounts]]
-    source = "../translations/docs-zh/content/sdks_dotnet"
+    source = "../translations/docs-zh/translated_content/zh_CN/sdks_dotnet"
     target = "content/developing-applications/sdks/dotnet"
     lang = "zh-hans"
   [[module.mounts]]
-    source = "../translations/docs-zh/content/sdks_java"
+    source = "../translations/docs-zh/translated_content/zh_CN/sdks_java"
     target = "content/developing-applications/sdks/java"
     lang = "zh-hans"
   [[module.mounts]]
-    source = "../translations/docs-zh/content/sdks_go"
+    source = "../translations/docs-zh/translated_content/zh_CN/sdks_go"
     target = "content/developing-applications/sdks/go"
     lang = "zh-hans"
   [[module.mounts]]
-    source = "../translations/docs-zh/content/sdks_js"
+    source = "../translations/docs-zh/translated_content/zh_CN/sdks_js"
     target = "content/developing-applications/sdks/js"
     lang = "zh-hans"       
+  [[module.mounts]]
+    source = "../translations/docs-zh/translated_content/zh_CN/pluggable-components/dotnet"
+    target = "content/developing-applications/develop-components/pluggable-components/pluggable-components-sdks/pluggable-components-dotnet"
+    lang = "zh-hans"
+  [[module.mounts]]
+    source = "../translations/docs-zh/translated_content/zh_CN/pluggable-components/go"
+    target = "content/developing-applications/develop-components/pluggable-components/pluggable-components-sdks/pluggable-components-go"
+    lang = "zh-hans"  
 
 # Markdown Engine - Allow inline html
 [markup]

--- a/daprdocs/content/en/developing-applications/building-blocks/secrets/secrets-scopes.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/secrets/secrets-scopes.md
@@ -4,7 +4,6 @@ title: "How To: Use secret scoping"
 linkTitle: "How To: Use secret scoping"
 weight: 3000
 description: "Use scoping to limit the secrets that can be read by your application from secret stores"
-type: docs
 ---
 
 Once you [configure a secret store for your application]({{< ref setup-secret-store >}}), *any* secret defined within that store is accessible by default from the Dapr application. 

--- a/daprdocs/content/en/developing-applications/integrations/gRPC-integration.md
+++ b/daprdocs/content/en/developing-applications/integrations/gRPC-integration.md
@@ -4,7 +4,6 @@ title: "How to: Use the gRPC interface in your Dapr application"
 linkTitle: "How to: gRPC interface"
 weight: 6000
 description: "Use the Dapr gRPC API in your application"
-type: docs
 ---
 
 Dapr implements both an HTTP and a gRPC API for local calls. [gRPC](https://grpc.io/) is useful for low-latency, high performance scenarios and has language integration using the proto clients.

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-job.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-job.md
@@ -4,7 +4,6 @@ title: "Running Dapr with a Kubernetes Job"
 linkTitle: "Kubernetes Jobs"
 weight: 70000
 description: "Use Dapr API in a Kubernetes Job context"
-type: docs
 ---
 
 The Dapr sidecar is designed to be a long running process. In the context of a [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) this behavior can block your job completion.

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
@@ -10,15 +10,14 @@ description: "Best practices for deploying Dapr to a Kubernetes cluster in a pro
 
 Dapr support for Kubernetes is aligned with [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/). 
 
-Use the following resource settings as a starting point. Requirements vary depending on cluster size, number of pods, and other factors. Perform individual testing to find the right values for your environment.
+Use the following resource settings as a starting point. Requirements vary depending on cluster size, number of pods, and other factors. Perform individual testing to find the right values for your environment. In production, it's recommended to not add memory limits to the Dapr control plane components to avoid `OOMKilled` pod statuses.
 
 | Deployment  | CPU | Memory
 |-------------|-----|-------
-| **Operator**  | Limit: 1, Request: 100m | Limit: 200Mi, Request: 100Mi
-| **Sidecar Injector** | Limit: 1, Request: 100m  | Limit: 200Mi, Request: 30Mi
-| **Sentry**    | Limit: 1, Request: 100m  | Limit: 200Mi, Request: 30Mi
-| **Placement** | Limit: 1, Request: 250m  | Limit: 150Mi, Request: 75Mi
-| **Dashboard** | Limit: 200m, Request: 50m  | Limit: 200Mi, Request: 20Mi
+| **Operator**  | Limit: 1, Request: 100m | Request: 100Mi
+| **Sidecar Injector** | Limit: 1, Request: 100m  | Request: 30Mi
+| **Sentry**    | Limit: 1, Request: 100m  | Request: 30Mi
+| **Placement** | Limit: 1, Request: 250m  | Request: 75Mi
 
 {{% alert title="Note" color="primary" %}}
 For more information, refer to the Kubernetes documentation on [CPU and Memory resource units and their meaning](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).

--- a/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
+++ b/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
@@ -4,7 +4,6 @@ title: "Using OpenTelemetry Collector to collect traces to send to Jaeger"
 linkTitle: "Using the OpenTelemetry for Jaeger"
 weight: 1200
 description: "How to push trace events to Jaeger distributed tracing platform, using the OpenTelemetry Collector."
-type: docs
 ---
 
 While Dapr supports writing traces using OpenTelemetry (OTLP) and Zipkin protocols, Zipkin support for Jaeger has been deprecated in favor of OTLP. Although Jaeger supports OTLP directly, the recommended approach for production is to use the OpenTelemetry Collector to collect traces from Dapr and send them to Jaeger, allowing your application to quickly offload data and take advantage of features like retries, batching, and encryption. For more information, read the Open Telemetry Collector [documentation](https://opentelemetry.io/docs/collector/#when-to-use-a-collector).

--- a/daprdocs/content/en/operations/observability/tracing/zipkin.md
+++ b/daprdocs/content/en/operations/observability/tracing/zipkin.md
@@ -4,7 +4,6 @@ title: "How-To: Set up Zipkin for distributed tracing"
 linkTitle: "Zipkin"
 weight: 4000
 description: "Set up Zipkin for distributed tracing"
-type: docs
 ---
 
 ## Configure self hosted mode

--- a/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-bearer.md
+++ b/daprdocs/content/en/reference/components-reference/supported-middleware/middleware-bearer.md
@@ -3,7 +3,6 @@ type: docs
 title: "Bearer"
 linkTitle: "Bearer"
 description: "Use bearer middleware to secure HTTP endpoints by verifying bearer tokens"
-type: docs
 aliases:
 - /developing-applications/middleware/supported-middleware/middleware-bearer/
 ---


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

In Dapr 1.12+ the memory usage for the Sentry service in many production deployments of Dapr is often higher than the limits here. For all the control plane components, we should remove the memory limits entirely to avoid users hitting OOMKilled pod status errors.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
