### PR TITLE
Remove memory limits in production

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-production.md
@@ -10,15 +10,14 @@ description: "Best practices for deploying Dapr to a Kubernetes cluster in a pro
 
 Dapr support for Kubernetes is aligned with [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/). 
 
-Use the following resource settings as a starting point. Requirements vary depending on cluster size, number of pods, and other factors. Perform individual testing to find the right values for your environment.
+Use the following resource settings as a starting point. Requirements vary depending on cluster size, number of pods, and other factors. Perform individual testing to find the right values for your environment. In production, it's recommended to not add memory limits to the Dapr control plane components to avoid `OOMKilled` pod statuses.
 
 | Deployment  | CPU | Memory
 |-------------|-----|-------
-| **Operator**  | Limit: 1, Request: 100m | Limit: 200Mi, Request: 100Mi
-| **Sidecar Injector** | Limit: 1, Request: 100m  | Limit: 200Mi, Request: 30Mi
-| **Sentry**    | Limit: 1, Request: 100m  | Limit: 200Mi, Request: 30Mi
-| **Placement** | Limit: 1, Request: 250m  | Limit: 150Mi, Request: 75Mi
-| **Dashboard** | Limit: 200m, Request: 50m  | Limit: 200Mi, Request: 20Mi
+| **Operator**  | Limit: 1, Request: 100m | Request: 100Mi
+| **Sidecar Injector** | Limit: 1, Request: 100m  | Request: 30Mi
+| **Sentry**    | Limit: 1, Request: 100m  | Request: 30Mi
+| **Placement** | Limit: 1, Request: 250m  | Request: 75Mi
 
 {{% alert title="Note" color="primary" %}}
 For more information, refer to the Kubernetes documentation on [CPU and Memory resource units and their meaning](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

In Dapr 1.12+ the memory usage for the Sentry service in many production deployments of Dapr is often higher than the limits here. For all the control plane components, we should remove the memory limits entirely to avoid users hitting OOMKilled pod status errors.


## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
