### PR TITLE
Clarify that disabling kubernetes built in secret store can only be d…

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/secrets/secrets-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/secrets/secrets-overview.md
@@ -41,7 +41,7 @@ Applications can also use the secrets API to access secrets from a Kubernetes se
 - The Helm defaults, or
 - `dapr init -k`
 
-If you are using another secret store, you can disable (not configure) the Dapr Kubernetes secret store by setting `disable-builtin-k8s-secret-store` to `true` through the Helm settings. The default is `false`.
+If you are using another secret store, you can disable (not configure) the Dapr Kubernetes secret store by adding the annotation `dapr.io/disable-builtin-k8s-secret-store: "true"` to the deployment.yaml file. The default is `false`.
 
 In the example below, the application retrieves the same secret "mysecret" from a Kubernetes secret store.
 


### PR DESCRIPTION
…one with an annotation, not by setting a helm argument

Clarify that disabling kubernetes built in secret store can only be done with an annotation, not by setting a helm argument

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Clarify that disabling kubernetes built in secret store can only be done with an annotation, not by setting a helm argument

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
