### PR TITLE
Added example for limiting workflow concurrency in .NET fan-in/out example

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
@@ -595,28 +595,6 @@ It's possible to go further and limit the degree of concurrency using simple, la
 {{% codetab %}}
 <!-- .NET -->
 ```csharp
-public static class TaskExtensions
-{
-  public static async Task<IEnumerable<T>> WhenAllWithLimitAsync<T>(this IEnumerable<Task<T>>> tasks, string activityName, int maxDegreeOfParallelism)
-  {
-    var results = new List<T>();
-    var inFlight = new HashSet<Task<T>>();
-    foreach (var task in tasks)
-    {
-      if (inFlight.Count > maxParallelism)
-      {
-        var finishedTask = await Task.WhenAny(inFlight);
-        results.Add(finishedTask.Result);
-        inFlight.Remove(finishedTask);
-      }
-
-      inFlight.Add(context.CallActivityAsync<int>(task))
-    }
-
-    //Wait for all the remaining tasks to complete
-    await Task.WhenAll(inFlight);
-  }
-}
 
 //Revisiting the earlier example...
 // Get a list of N work items to process in parallel.

--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
@@ -588,7 +588,7 @@ The key takeaways from this example are:
 
 Furthermore, the execution of the workflow is durable. If a workflow starts 100 parallel task executions and only 40 complete before the process crashes, the workflow restarts itself automatically and only schedules the remaining 60 tasks.
 
-It's possible to go further and limit the degree of concurrency using simple, language-specific constructs.
+It's possible to go further and limit the degree of concurrency using simple, language-specific constructs. The sample code below illustrates how to restrict the degree of fan-out to just 5 concurrent activity executions:
 
 {{< tabs ".NET" >}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
@@ -624,6 +624,8 @@ await context.CallActivityAsync("PostResults", sum);
 
 {{< /tabs >}}
 
+Limiting the degree of concurrency in this way can be useful for limiting contention against shared resources. For example, if the activities need to call into external resources that have their own concurrency limits, like a databases or external APIs, it can be useful to ensure that no more than a specified number of activities call that resource concurrently.
+
 ## Async HTTP APIs
 
 Asynchronous HTTP APIs are typically implemented using the [Asynchronous Request-Reply pattern](https://learn.microsoft.com/azure/architecture/patterns/async-request-reply). Implementing this pattern traditionally involves the following:

--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
@@ -614,6 +614,7 @@ foreach(var workItem in workBatch)
 
   inFlightTasks.Add(context.CallActivityAsync<int>("ProcessWorkItem", workItem));
 }
+results.AddRange(await Task.WhenAll(inFlightTasks));
 
 var sum = results.Sum(t => t);
 await context.CallActivityAsync("PostResults", sum);

--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-patterns.md
@@ -605,7 +605,7 @@ var results = new List<int>();
 var inFlightTasks = new HashSet<Task<int>>();
 foreach(var workItem in workBatch)
 {
-  if (inFlightTasks.Count > MaxParallelism)
+  if (inFlightTasks.Count >= MaxParallelism)
   {
     var finishedTask = await Task.WhenAny(inFlightTasks);
     results.Add(finishedTask.Result);


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

I love rich documentation. It's so satisfying to read something that details a new concept, shares examples and really sets me up to succeed. But I don't like it when said documentation introduces another idea and leaves me to my own devices to figure out how to do it.

Tonight I was reading about the different workflow patterns. In the fan-out/fan-in pattern, it explains how a series of parallel tasks can be completed at once, but then it leaves a note at the end: "While not shown in the example, it's possible to go further and limit the degree of concurrency using simple, language-specific constructs."

As it took me a minute to figure out a worthwhile .NET approach to doing this, I wanted to contribute it back so future me isn't left hanging. I leave it to others to figure out other language equivalents.

Made a few minor tweaks and resubmitting the PR as version 2 of #3986 since I somehow merged a bunch of bits I shouldn't have in there.

## Issue reference

None - saw this in the docs and after determining a solution, wanted to contribute it back.
