### PR TITLE
[Outbox pattern] Add link to transactional state methods for context

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-outbox.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-outbox.md
@@ -28,8 +28,10 @@ The diagram below is an overview of how the outbox feature works:
 
 The outbox feature can be used with using any [transactional state store]({{< ref supported-state-stores >}}) supported by Dapr. All [pub/sub brokers]({{< ref supported-pubsub >}}) are supported with the outbox feature.
 
+[Learn more about the transactional methods you can use.]({{< ref "howto-get-save-state.md#perform-state-transactions" >}})
+
 {{% alert title="Note" color="primary" %}} 
-Message brokers that work with the competing consumer pattern (for example, [Apache Kafka]({{< ref setup-apache-kafka>}}) are encouraged to reduce the chances of duplicate events.
+Message brokers that work with the competing consumer pattern (for example, [Apache Kafka]({{< ref setup-apache-kafka>}})) are encouraged to reduce the chances of duplicate events.
 {{% /alert %}}
 
 ## Usage


### PR DESCRIPTION
## Description

Link to relevant example of transactional methods in the requirements section of the outbox patterns how to.

## Issue reference

PR will close: #4053 
