### PR TITLE
[Integrations] Testcontainers, Kubernetes Operator, Kratix

### DIFF
--- a/daprdocs/content/en/developing-applications/integrations/Diagrid/test-containers.md
+++ b/daprdocs/content/en/developing-applications/integrations/Diagrid/test-containers.md
@@ -1,0 +1,21 @@
+---
+type: docs
+title: "How to: Integrate using Diagrid's Testcontainers Dapr Module"
+linkTitle: "Diagrid Testcontainers"
+weight: 3000
+description: "Use the Dapr Testcontainer module from your Java application"
+---
+
+You can use the Testcontainers Dapr Module provided by Diagrid to set up Dapr locally in your Java applications. Simply add the following dependency to your Mave project:
+
+```xml
+<dependency>
+    <groupId>io.diagrid.dapr</groupId>
+	<artifactId>testcontainers-dapr</artifactId>
+	<version>0.10.x</version>
+</dependency>
+```
+
+[If you're using Spring Boot, you can also use the Spring Boot Starter.](https://github.com/diagridio/spring-boot-starter-dapr)  
+
+{{< button text="Use the Testcontainers Dapr Module" link="https://github.com/diagridio/testcontainers-dapr" >}}

--- a/daprdocs/content/en/developing-applications/integrations/Diagrid/test-containers.md
+++ b/daprdocs/content/en/developing-applications/integrations/Diagrid/test-containers.md
@@ -1,12 +1,12 @@
 ---
 type: docs
-title: "How to: Integrate using Diagrid's Testcontainers Dapr Module"
-linkTitle: "Diagrid Testcontainers"
+title: "How to: Integrate using Testcontainers Dapr Module"
+linkTitle: "Dapr Testcontainers"
 weight: 3000
 description: "Use the Dapr Testcontainer module from your Java application"
 ---
 
-You can use the Testcontainers Dapr Module provided by Diagrid to set up Dapr locally in your Java applications. Simply add the following dependency to your Mave project:
+You can use the Testcontainers Dapr Module provided by Diagrid to set up Dapr locally for your Java applications. Simply add the following dependency to your Maven project:
 
 ```xml
 <dependency>

--- a/daprdocs/content/en/developing-applications/integrations/autoscale-keda.md
+++ b/daprdocs/content/en/developing-applications/integrations/autoscale-keda.md
@@ -1,7 +1,7 @@
 ---
 type: docs
 title: "How to: Autoscale a Dapr app with KEDA"
-linkTitle: "How to: Autoscale with KEDA"
+linkTitle: "KEDA"
 description: "How to configure your Dapr application to autoscale using KEDA"
 weight: 3000
 ---

--- a/daprdocs/content/en/developing-applications/integrations/gRPC-integration.md
+++ b/daprdocs/content/en/developing-applications/integrations/gRPC-integration.md
@@ -1,7 +1,7 @@
 ---
 type: docs
 title: "How to: Use the gRPC interface in your Dapr application"
-linkTitle: "How to: gRPC interface"
+linkTitle: "gRPC interface"
 weight: 6000
 description: "Use the Dapr gRPC API in your application"
 ---

--- a/daprdocs/content/en/developing-applications/integrations/github_actions.md
+++ b/daprdocs/content/en/developing-applications/integrations/github_actions.md
@@ -2,7 +2,7 @@
 type: docs
 weight: 5000
 title: "How to: Use the Dapr CLI in a GitHub Actions workflow"
-linkTitle: "How to: GitHub Actions"
+linkTitle: "GitHub Actions"
 description: "Add the Dapr CLI to your GitHub Actions to deploy and manage Dapr in your environments."
 ---
 

--- a/daprdocs/content/en/developing-applications/integrations/kratix-marketplace.md
+++ b/daprdocs/content/en/developing-applications/integrations/kratix-marketplace.md
@@ -12,6 +12,6 @@ As part of the [Kratix Marketplace](https://docs.kratix.io/marketplace), Dapr ca
 The Dapr Helm chart generates static public and private key pairs that are published in the repository. This promise should only be used _locally_ for demo purposes. If you wish to use this promise for more than demo purposes, it's recommended to manually update all the secrets in the promise with keys with your own credentials.
 {{% /alert %}}
 
-Get started by simply installing the Dapr Promise, which installs DApr on all matching clusters. 
+Get started by simply installing the Dapr Promise, which installs Dapr on all matching clusters.
 
 {{< button text="Install the Dapr Promise" link="https://github.com/syntasso/kratix-marketplace/tree/main/dapr" >}}

--- a/daprdocs/content/en/developing-applications/integrations/kratix-marketplace.md
+++ b/daprdocs/content/en/developing-applications/integrations/kratix-marketplace.md
@@ -1,0 +1,17 @@
+---
+type: docs
+title: "How to: Integrate with Kratix"
+linkTitle: "Kratix Marketplace"
+weight: 8000
+description: "Integrate with Kratix using a Dapr promise"
+---
+
+As part of the [Kratix Marketplace](https://docs.kratix.io/marketplace), Dapr can be used to build custom platforms tailored to your needs. 
+
+{{% alert title="Note" color="warning" %}}
+The Dapr Helm chart generates static public and private key pairs that are published in the repository. This promise should only be used _locally_ for demo purposes. If you wish to use this promise for more than demo purposes, it's recommended to manually update all the secrets in the promise with keys with your own credentials.
+{{% /alert %}}
+
+Get started by simply installing the Dapr Promise, which installs DApr on all matching clusters. 
+
+{{< button text="Install the Dapr Promise" link="https://github.com/syntasso/kratix-marketplace/tree/main/dapr" >}}

--- a/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
+++ b/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
@@ -7,9 +7,5 @@ description: "Use the Dapr Kubernetes Operator to manage the Dapr lifecycle"
 ---
 
 The Dapr Kubernetes Operator manages the lifecycle for Dapr and its components. Use the operator to automate the tasks required when oeprating Dapr in Kubernetes mode. 
-
-{{% alert title="Note" color="primary" %}}
-The Dapr Kubernetes Operator is currently a Dapr sandbox project.
-{{% /alert %}}
  
-{{< button text="Install and use the Dapr Kubernetes Operator" link="https://github.com/dapr-sandbox/dapr-kubernetes-operator" >}}
+{{< button text="Install and use the Dapr Kubernetes Operator" link="https://github.com/dapr/dapr-kubernetes-operator" >}}

--- a/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
+++ b/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
@@ -3,7 +3,7 @@ type: docs
 title: "How to: Use the Dapr Kubernetes Operator"
 linkTitle: "Dapr Kubernetes Operator"
 weight: 7000
-description: "Use the Dapr Kubernetes Operator to manage the Dapr lifecycle"
+description: "Use the Dapr Kubernetes Operator to manage the Dapr control plane"
 ---
 
 The Dapr Kubernetes Operator manages the lifecycle for Dapr and its components. Use the operator to automate the tasks required when operating Dapr in Kubernetes mode. 

--- a/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
+++ b/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
@@ -6,6 +6,6 @@ weight: 7000
 description: "Use the Dapr Kubernetes Operator to manage the Dapr lifecycle"
 ---
 
-The Dapr Kubernetes Operator manages the lifecycle for Dapr and its components. Use the operator to automate the tasks required when oeprating Dapr in Kubernetes mode. 
+The Dapr Kubernetes Operator manages the lifecycle for Dapr and its components. Use the operator to automate the tasks required when operating Dapr in Kubernetes mode. 
  
 {{< button text="Install and use the Dapr Kubernetes Operator" link="https://github.com/dapr/dapr-kubernetes-operator" >}}

--- a/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
+++ b/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
@@ -1,0 +1,15 @@
+---
+type: docs
+title: "How to: Use the Dapr Kubernetes Operator"
+linkTitle: "Dapr Kubernetes Operator"
+weight: 7000
+description: "Use the Dapr Kubernetes Operator to manage the Dapr lifecycle"
+---
+
+The Dapr Kubernetes Operator manages the lifecycle for Dapr and its components. Use the operator to automate the tasks required when oeprating Dapr in Kubernetes mode. 
+
+{{% alert title="Note" color="primary" %}}
+The Dapr Kubernetes Operator is currently a Dapr sandbox project.
+{{% /alert %}}
+ 
+{{< button text="Install and use the Dapr Kubernetes Operator" link="https://github.com/dapr-sandbox/dapr-kubernetes-operator" >}}

--- a/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
+++ b/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
@@ -6,6 +6,6 @@ weight: 7000
 description: "Use the Dapr Kubernetes Operator to manage the Dapr control plane"
 ---
 
-The Dapr Kubernetes Operator manages the lifecycle for Dapr and its components. Use the operator to automate the tasks required when operating Dapr in Kubernetes mode. 
+You can use the Dapr Kubernetes Operator to manage the Dapr control plane. Use the operator to automate the tasks required to manage the lifecycle of Dapr control plane in Kubernetes mode. 
  
 {{< button text="Install and use the Dapr Kubernetes Operator" link="https://github.com/dapr/dapr-kubernetes-operator" >}}


### PR DESCRIPTION
## Description

Add 'landing pages' for Dapr Testcontainers module, Dapr Kubernetes Operator, and the Dapr promise in Kratix Marketplace to the Integrations section of docs

## Issue reference

PR will close: #4025
