### PR TITLE
Chore: Typo fixed in docs

### DIFF
--- a/daprdocs/content/en/operations/components/component-secrets.md
+++ b/daprdocs/content/en/operations/components/component-secrets.md
@@ -75,15 +75,14 @@ spec:
   type: bindings.azure.servicebusqueues
   version: v1
   metadata:
-  -name: connectionString
-   secretKeyRef:
+  - name: connectionString
+    secretKeyRef:
       name: asbNsConnString
       key: asbNsConnString
-  -name: queueName
-   value: servicec-inputq
+  - name: queueName
+    value: servicec-inputq
 auth:
   secretStore: <SECRET_STORE_NAME>
-
 ```
 The above "Secret is a string" case yaml tells Dapr to extract a connection string named `asbNsConnstring` from the defined `secretStore` and assign the value to the `connectionString` field in the component since there is no key embedded in the "secret" from the `secretStore` because it is a plain string. This requires the secret `name` and secret `key` to be identical.
 
@@ -95,7 +94,7 @@ The following example shows you how to create a Kubernetes secret to hold the co
 
 1. First, create the Kubernetes secret:
     ```bash
-     kubectl create secret generic eventhubs-secret --from-literal=connectionString=*********
+    kubectl create secret generic eventhubs-secret --from-literal=connectionString=*********
     ```
 
 2. Next, reference the secret in your binding:

--- a/daprdocs/content/en/operations/components/pluggable-components-registration.md
+++ b/daprdocs/content/en/operations/components/pluggable-components-registration.md
@@ -52,7 +52,7 @@ Since you are running Dapr in the same host as the component, verify that this f
 
 ### Component discovery and multiplexing
 
-A pluggable component accessible through a [Unix Domain Socket][UDS] (UDS) can host multiple distinct component APIs . During the components' initial discovery process, Dapr uses reflection to enumerate all the component APIs behind a UDS. The `my-component` pluggable component in the example above can contain both state store (`state`) and a pub/sub (`pubsub`) component APIs.
+A pluggable component accessible through a [Unix Domain Socket][UDS] (UDS) can host multiple distinct component APIs. During the components' initial discovery process, Dapr uses reflection to enumerate all the component APIs behind a UDS. The `my-component` pluggable component in the example above can contain both state store (`state`) and a pub/sub (`pubsub`) component APIs.
 
 Typically, a pluggable component implements a single component API for packaging and deployment. However, at the expense of increasing its dependencies and broadening its security attack surface, a pluggable component can have multiple component APIs implemented. This could be done to ease the deployment and monitoring burden. Best practice for isolation, fault tolerance, and security is a single component API implementation for each pluggable component.
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
This PR fixed small format in docs

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
