### PR TITLE
Fixed markdown code in `howto-invoke-non-dapr-endpoints.md`

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-non-dapr-endpoints.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-non-dapr-endpoints.md
@@ -70,7 +70,7 @@ There are two ways to invoke a non-Dapr endpoint when communicating either to Da
     ```
 
 ### Using appId when calling Dapr enabled applications
-AppIDs are always used to call Dapr applications with the `appID` and `my-method``. Read the [How-To: Invoke services using HTTP]({{< ref howto-invoke-discover-services.md >}}) guide for more information. For example:
+AppIDs are always used to call Dapr applications with the `appID` and `my-method`. Read the [How-To: Invoke services using HTTP]({{< ref howto-invoke-discover-services.md >}}) guide for more information. For example:
 
 ```sh
 localhost:3500/v1.0/invoke/<appID>/method/<my-method>


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!


![Screenshot 2024-05-20 at 10 28 58](https://github.com/dapr/docs/assets/2131633/f65acf2a-d1b9-42ed-99d4-25db672c0462)


**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
