### PR TITLE
Fixes for: Wrong instructions in How to: Use the Multi-App Run template file #4153

### DIFF
--- a/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
+++ b/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
@@ -1,6 +1,6 @@
 ---
 type: docs
-title: "q"
+title: "How to: Use the Multi-App Run template file"
 linkTitle: "How to: Use the Multi-App Run template"
 weight: 2000
 description: Unpack the Multi-App Run template file and its properties

--- a/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
+++ b/daprdocs/content/en/developing-applications/local-development/multi-app-dapr-run/multi-app-template.md
@@ -1,6 +1,6 @@
 ---
 type: docs
-title: "How to: Use the Multi-App Run template file"
+title: "q"
 linkTitle: "How to: Use the Multi-App Run template"
 weight: 2000
 description: Unpack the Multi-App Run template file and its properties
@@ -42,7 +42,7 @@ dapr run -f <dir_path>
 <!--kubernetes-->
 
 ```cmd
-dapr run -f -k <dir_path>
+dapr run -f <dir_path> -k 
 ```
 {{% /codetab %}}
 
@@ -67,7 +67,7 @@ dapr run -f ./path/to/<your-preferred-file-name>.yaml
 <!--kubernetes-->
 
 ```cmd
-dapr run -f -k ./path/to/<your-preferred-file-name>.yaml
+dapr run -f ./path/to/<your-preferred-file-name>.yaml -k 
 ```
 {{% /codetab %}}
 
@@ -77,9 +77,26 @@ dapr run -f -k ./path/to/<your-preferred-file-name>.yaml
 
 Once the multi-app template is running, you can view the started applications with the following command:
 
+{{< tabs Self-hosted Kubernetes>}}
+
+{{% codetab %}}
+<!--selfhosted-->
+
 ```cmd
 dapr list
 ```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+<!--kubernetes-->
+
+```cmd
+dapr list -k 
+```
+{{% /codetab %}}
+
+{{< /tabs >}}
 
 ## Stop the multi-app template
 
@@ -109,12 +126,12 @@ dapr stop -f ./path/to/<your-preferred-file-name>.yaml
 ```cmd
 # the template file needs to be called `dapr.yaml` by default if a directory path is given
 
-dapr stop -f -k
+dapr stop -f <dir_path> -k
 ```
 or:
 
 ```cmd
-dapr stop -f -k ./path/to/<your-preferred-file-name>.yaml
+dapr stop -f ./path/to/<your-preferred-file-name>.yaml -k 
 ```
 
 {{% /codetab %}}


### PR DESCRIPTION

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixed multi-app run commands to work with kubernetes 

## Issue reference

https://github.com/dapr/docs/issues/4153