### PR TITLE
docs: migrate rust github link to docs

### DIFF
--- a/daprdocs/content/en/developing-applications/sdks/_index.md
+++ b/daprdocs/content/en/developing-applications/sdks/_index.md
@@ -29,7 +29,7 @@ Select your [preferred language below]({{< ref "#sdk-languages" >}}) to learn mo
 | [PHP]({{< ref php >}}) | Stable | ✔ | ✔ | ✔ | |
 | [Javascript]({{< ref js >}}) | Stable| ✔ | | ✔ | ✔  |
 | [C++](https://github.com/dapr/cpp-sdk) | In development | ✔ | | |
-| [Rust](https://github.com/dapr/rust-sdk) | In development | ✔ | | ✔ | |
+| [Rust]({{< ref rust >}}) | In development | ✔ | | ✔ | |
 
 ## Further reading
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Update the rust sdk link from github to the docs

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
