### PR TITLE
Remove unnecessary whitespace in docs

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services.md
@@ -24,7 +24,7 @@ Dapr allows you to assign a global, unique ID for your app. This ID encapsulates
 {{% codetab %}}
 
 ```bash
-dapr run  --app-id checkout --app-protocol http --dapr-http-port 3500 -- python3 checkout/app.py
+dapr run --app-id checkout --app-protocol http --dapr-http-port 3500 -- python3 checkout/app.py
 
 dapr run --app-id order-processor --app-port 8001  --app-protocol http --dapr-http-port 3501 -- python3 order-processor/app.py
 ```
@@ -32,7 +32,7 @@ dapr run --app-id order-processor --app-port 8001  --app-protocol http --dapr-ht
 If your app uses a TLS, you can tell Dapr to invoke your app over a TLS connection by setting `--app-protocol https`:
 
 ```bash
-dapr run  --app-id checkout --app-protocol https --dapr-http-port 3500 -- python3 checkout/app.py
+dapr run --app-id checkout --app-protocol https --dapr-http-port 3500 -- python3 checkout/app.py
 
 dapr run --app-id order-processor --app-port 8001 --app-protocol https --dapr-http-port 3501 -- python3 order-processor/app.py
 ```
@@ -42,7 +42,7 @@ dapr run --app-id order-processor --app-port 8001 --app-protocol https --dapr-ht
 {{% codetab %}}
 
 ```bash
-dapr run  --app-id checkout --app-protocol http --dapr-http-port 3500 -- npm start
+dapr run --app-id checkout --app-protocol http --dapr-http-port 3500 -- npm start
 
 dapr run --app-id order-processor --app-port 5001  --app-protocol http --dapr-http-port 3501 -- npm start
 ```
@@ -50,7 +50,7 @@ dapr run --app-id order-processor --app-port 5001  --app-protocol http --dapr-ht
 If your app uses a TLS, you can tell Dapr to invoke your app over a TLS connection by setting `--app-protocol https`:
 
 ```bash
-dapr run  --app-id checkout --dapr-http-port 3500 --app-protocol https -- npm start
+dapr run --app-id checkout --dapr-http-port 3500 --app-protocol https -- npm start
 
 dapr run --app-id order-processor --app-port 5001 --dapr-http-port 3501 --app-protocol https -- npm start
 ```
@@ -60,7 +60,7 @@ dapr run --app-id order-processor --app-port 5001 --dapr-http-port 3501 --app-pr
 {{% codetab %}}
 
 ```bash
-dapr run  --app-id checkout --app-protocol http --dapr-http-port 3500 -- dotnet run
+dapr run --app-id checkout --app-protocol http --dapr-http-port 3500 -- dotnet run
 
 dapr run --app-id order-processor --app-port 7001 --app-protocol http --dapr-http-port 3501 -- dotnet run
 ```
@@ -68,7 +68,7 @@ dapr run --app-id order-processor --app-port 7001 --app-protocol http --dapr-htt
 If your app uses a TLS, you can tell Dapr to invoke your app over a TLS connection by setting `--app-protocol https`:
 
 ```bash
-dapr run  --app-id checkout --dapr-http-port 3500 --app-protocol https -- dotnet run
+dapr run --app-id checkout --dapr-http-port 3500 --app-protocol https -- dotnet run
 
 dapr run --app-id order-processor --app-port 7001 --dapr-http-port 3501 --app-protocol https -- dotnet run
 ```

--- a/daprdocs/content/en/getting-started/quickstarts/resiliency/resiliency-serviceinvo-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/resiliency/resiliency-serviceinvo-quickstart.md
@@ -55,7 +55,7 @@ pip3 install -r requirements.txt
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-port 8001 --app-id order-processor  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- python3 app.py
+dapr run --app-port 8001 --app-id order-processor --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- python3 app.py
 ```
 
 ### Step 3: Run the `checkout` service application 
@@ -75,7 +75,7 @@ pip3 install -r requirements.txt
 Run the `checkout` service alongside a Dapr sidecar. 
 
 ```bash
-dapr run  --app-id checkout --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- python3 app.py
+dapr run --app-id checkout --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- python3 app.py
 ```
 
 The Dapr sidecar then loads the resiliency spec located in the resources directory:
@@ -262,7 +262,7 @@ npm install
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-port 5001 --app-id order-processor  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- npm start
+dapr run --app-port 5001 --app-id order-processor --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- npm start
 ```
 
 ### Step 3: Run the `checkout` service application 
@@ -283,7 +283,7 @@ npm install
 Run the `checkout` service alongside a Dapr sidecar. 
 
 ```bash
-dapr run --app-id checkout  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- npm start
+dapr run --app-id checkout --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- npm start
 ```
 
 The Dapr sidecar then loads the resiliency spec located in the resources directory:
@@ -426,7 +426,7 @@ Once you restart the `order-processor` service, the application will recover sea
 In the `order-processor` service terminal, restart the application:
 
 ```bash
-dapr run --app-port 5001 --app-id order-processor  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- npm start
+dapr run --app-port 5001 --app-id order-processor --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- npm start
 ```
 
 `checkout` service output:
@@ -494,7 +494,7 @@ dotnet build
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-port 7001 --app-id order-processor  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- dotnet run
+dapr run --app-port 7001 --app-id order-processor --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- dotnet run
 ```
 
 ### Step 3: Run the `checkout` service application 
@@ -516,7 +516,7 @@ dotnet build
 Run the `checkout` service alongside a Dapr sidecar. 
 
 ```bash
-dapr run  --app-id checkout  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- dotnet run
+dapr run --app-id checkout --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- dotnet run
 ```
 
 The Dapr sidecar then loads the resiliency spec located in the resources directory:
@@ -727,7 +727,7 @@ mvn clean install
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-id order-processor  --resources-path ../../../resources/ --app-port 9001 --app-protocol http --dapr-http-port 3501 -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
+dapr run --app-id order-processor --resources-path ../../../resources/ --app-port 9001 --app-protocol http --dapr-http-port 3501 -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
 ```
 
 ### Step 3: Run the `checkout` service application 
@@ -748,7 +748,7 @@ mvn clean install
 Run the `checkout` service alongside a Dapr sidecar. 
 
 ```bash
-dapr run --app-id checkout  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- java -jar target/CheckoutService-0.0.1-SNAPSHOT.jar
+dapr run --app-id checkout --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- java -jar target/CheckoutService-0.0.1-SNAPSHOT.jar
 ```
 
 The Dapr sidecar then loads the resiliency spec located in the resources directory:
@@ -891,7 +891,7 @@ Once you restart the `order-processor` service, the application will recover sea
 In the `order-processor` service terminal, restart the application:
 
 ```bash
-dapr run --app-id order-processor  --resources-path ../../../resources/ --app-port 9001 --app-protocol http --dapr-http-port 3501 -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
+dapr run --app-id order-processor --resources-path ../../../resources/ --app-port 9001 --app-protocol http --dapr-http-port 3501 -- java -jar target/OrderProcessingService-0.0.1-SNAPSHOT.jar
 ```
 
 `checkout` service output:
@@ -957,7 +957,7 @@ go build .
 Run the `order-processor` service alongside a Dapr sidecar.
 
 ```bash
-dapr run --app-port 6001 --app-id order-processor  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- go run .
+dapr run --app-port 6001 --app-id order-processor --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- go run .
 ```
 
 ### Step 3: Run the `checkout` service application 
@@ -978,7 +978,7 @@ go build .
 Run the `checkout` service alongside a Dapr sidecar. 
 
 ```bash
-dapr run  --app-id checkout  --resources-path ../../../resources/  --app-protocol http --dapr-http-port 3500 -- go run .
+dapr run --app-id checkout --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3500 -- go run .
 ```
 
 The Dapr sidecar then loads the resiliency spec located in the resources directory:
@@ -1121,7 +1121,7 @@ Once you restart the `order-processor` service, the application will recover sea
 In the `order-processor` service terminal, restart the application:
 
 ```bash
-dapr run --app-port 6001 --app-id order-processor  --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- go run .
+dapr run --app-port 6001 --app-id order-processor --resources-path ../../../resources/ --app-protocol http --dapr-http-port 3501 -- go run .
 ```
 
 `checkout` service output:


### PR DESCRIPTION
There's an unnecessary $ in a .NET example of service invocation.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Remove whitespace in docs.