### PR TITLE
Adjust naming conventions

### DIFF
--- a/daprdocs/content/en/concepts/overview.md
+++ b/daprdocs/content/en/concepts/overview.md
@@ -138,7 +138,7 @@ Dapr can be used from any developer framework. Here are some that have been inte
 | [.NET]({{< ref dotnet >}}) | [ASP.NET Core](https://github.com/dapr/dotnet-sdk/tree/master/examples/AspNetCore) | Brings stateful routing controllers that respond to pub/sub events from other services. Can also take advantage of [ASP.NET Core gRPC Services](https://docs.microsoft.com/aspnet/core/grpc/).
 | [Java]({{< ref java >}}) | [Spring Boot](https://spring.io/) | Build Spring boot applications with Dapr APIs
 | [Python]({{< ref python >}}) | [Flask]({{< ref python-flask.md >}}) | Build Flask applications with Dapr APIs
-| [Javascript](https://github.com/dapr/js-sdk) | [Express](http://expressjs.com/) | Build Express applications with Dapr APIs
+| [JavaScript](https://github.com/dapr/js-sdk) | [Express](http://expressjs.com/) | Build Express applications with Dapr APIs
 | [PHP]({{< ref php >}}) | | You can serve with Apache, Nginx, or Caddyserver.
 
 #### Integrations and extensions

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
@@ -106,7 +106,7 @@ spec:
 
 The code examples below leverage Dapr SDKs to invoke the output bindings endpoint on a running Dapr instance. 
 
-{{< tabs .NET Java Python Go JavaScript>}}
+{{< tabs ".NET" Java Python Go JavaScript>}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-bindings.md
@@ -106,7 +106,7 @@ spec:
 
 The code examples below leverage Dapr SDKs to invoke the output bindings endpoint on a running Dapr instance. 
 
-{{< tabs Dotnet Java Python Go JavaScript>}}
+{{< tabs .NET Java Python Go JavaScript>}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
@@ -115,7 +115,7 @@ Configure your application to receive incoming events. If you're using HTTP, you
 
 Below are code examples that leverage Dapr SDKs to demonstrate an output binding.
 
-{{< tabs .NET Java Python Go JavaScript>}}
+{{< tabs ".NET" Java Python Go JavaScript>}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
@@ -115,7 +115,7 @@ Configure your application to receive incoming events. If you're using HTTP, you
 
 Below are code examples that leverage Dapr SDKs to demonstrate an output binding.
 
-{{< tabs Dotnet Java Python Go JavaScript>}}
+{{< tabs .NET Java Python Go JavaScript>}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
@@ -71,7 +71,7 @@ spec:
 
 The following example shows how to get a saved configuration item using the Dapr Configuration API.
 
-{{< tabs ".NET" Java Python Go Javascript "HTTP API (BASH)" "HTTP API (Powershell)">}}
+{{< tabs ".NET" Java Python Go JavaScript "HTTP API (BASH)" "HTTP API (Powershell)">}}
 
 {{% codetab %}}
 
@@ -252,7 +252,7 @@ Invoke-RestMethod -Uri 'http://localhost:3601/v1.0/configuration/configstore?key
 
 Below are code examples that leverage SDKs to subscribe to keys `[orderId1, orderId2]` using `configstore` store component.
 
-{{< tabs ".NET" "ASP.NET Core" Java Python Go Javascript>}}
+{{< tabs ".NET" "ASP.NET Core" Java Python Go JavaScript>}}
 
 {{% codetab %}}
 
@@ -521,7 +521,7 @@ After you've subscribed to watch configuration items, you will receive updates f
 
 Following are the code examples showing how you can unsubscribe to configuration updates using unsubscribe API.
 
-{{< tabs ".NET" Java Python Go Javascript "HTTP API (BASH)" "HTTP API (Powershell)">}}
+{{< tabs ".NET" Java Python Go JavaScript "HTTP API (BASH)" "HTTP API (Powershell)">}}
 
 {{% codetab %}}
 ```csharp

--- a/daprdocs/content/en/developing-applications/building-blocks/distributed-lock/howto-use-distributed-lock.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/distributed-lock/howto-use-distributed-lock.md
@@ -41,7 +41,7 @@ spec:
 
 ### Acquire lock
 
-{{< tabs HTTP .NET Go >}}
+{{< tabs HTTP ".NET" Go >}}
 
 {{% codetab %}}
 
@@ -122,7 +122,7 @@ func main() {
 
 ### Unlock existing lock
 
-{{< tabs HTTP .NET Go >}}
+{{< tabs HTTP ".NET" Go >}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/distributed-lock/howto-use-distributed-lock.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/distributed-lock/howto-use-distributed-lock.md
@@ -41,7 +41,7 @@ spec:
 
 ### Acquire lock
 
-{{< tabs HTTP Dotnet Go >}}
+{{< tabs HTTP .NET Go >}}
 
 {{% codetab %}}
 
@@ -122,7 +122,7 @@ func main() {
 
 ### Unlock existing lock
 
-{{< tabs HTTP Dotnet Go >}}
+{{< tabs HTTP .NET Go >}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-publish-subscribe.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-publish-subscribe.md
@@ -65,7 +65,7 @@ scopes:
 
 You can override this file with another [pubsub component]({{< ref setup-pubsub >}}) by creating a components directory (in this example, `myComponents`) containing the file and using the flag `--resources-path` with the `dapr run` CLI command.
 
-{{< tabs Dotnet Java Python Go Javascript >}}
+{{< tabs .NET Java Python Go JavaScript >}}
 
 {{% codetab %}}
 
@@ -186,7 +186,7 @@ Place `subscription.yaml` in the same directory as your `pubsub.yaml` component.
 
 Below are code examples that leverage Dapr SDKs to subscribe to the topic you defined in `subscription.yaml`.
 
-{{< tabs Dotnet Java Python Go JavaScript>}}
+{{< tabs .NET Java Python Go JavaScript>}}
 
 {{% codetab %}}
 
@@ -422,7 +422,7 @@ Invoke-RestMethod -Method Post -ContentType 'application/json' -Body '{"orderId"
 
 Below are code examples that leverage Dapr SDKs to publish a topic.
 
-{{< tabs Dotnet Java Python Go Javascript>}}
+{{< tabs .NET Java Python Go JavaScript>}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-publish-subscribe.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/howto-publish-subscribe.md
@@ -65,7 +65,7 @@ scopes:
 
 You can override this file with another [pubsub component]({{< ref setup-pubsub >}}) by creating a components directory (in this example, `myComponents`) containing the file and using the flag `--resources-path` with the `dapr run` CLI command.
 
-{{< tabs .NET Java Python Go JavaScript >}}
+{{< tabs ".NET" Java Python Go JavaScript >}}
 
 {{% codetab %}}
 
@@ -186,7 +186,7 @@ Place `subscription.yaml` in the same directory as your `pubsub.yaml` component.
 
 Below are code examples that leverage Dapr SDKs to subscribe to the topic you defined in `subscription.yaml`.
 
-{{< tabs .NET Java Python Go JavaScript>}}
+{{< tabs ".NET" Java Python Go JavaScript>}}
 
 {{% codetab %}}
 
@@ -422,7 +422,7 @@ Invoke-RestMethod -Method Post -ContentType 'application/json' -Body '{"orderId"
 
 Below are code examples that leverage Dapr SDKs to publish a topic.
 
-{{< tabs .NET Java Python Go JavaScript>}}
+{{< tabs ".NET" Java Python Go JavaScript>}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
@@ -22,7 +22,7 @@ The bulk publish operation also does not guarantee any ordering of messages.
 
 ### Example
 
-{{< tabs Java JavaScript .NET Python Go "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
+{{< tabs Java JavaScript ".NET" Python Go "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/pubsub-bulk.md
@@ -22,7 +22,7 @@ The bulk publish operation also does not guarantee any ordering of messages.
 
 ### Example
 
-{{< tabs Java Javascript Dotnet Python Go "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
+{{< tabs Java JavaScript .NET Python Go "HTTP API (Bash)" "HTTP API (PowerShell)" >}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/secrets/howto-secrets.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/secrets/howto-secrets.md
@@ -71,7 +71,7 @@ See a [full API reference]({{< ref secrets_api.md >}}).
 
 Now that you've set up the local secret store, call Dapr to get the secrets from your application code. Below are code examples that leverage Dapr SDKs for retrieving a secret.
 
-{{< tabs .NET Java Python Go JavaScript>}}
+{{< tabs ".NET" Java Python Go JavaScript>}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/secrets/howto-secrets.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/secrets/howto-secrets.md
@@ -71,7 +71,7 @@ See a [full API reference]({{< ref secrets_api.md >}}).
 
 Now that you've set up the local secret store, call Dapr to get the secrets from your application code. Below are code examples that leverage Dapr SDKs for retrieving a secret.
 
-{{< tabs Dotnet Java Python Go Javascript>}}
+{{< tabs .NET Java Python Go JavaScript>}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-services-grpc.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-services-grpc.md
@@ -126,7 +126,7 @@ ctx = metadata.AppendToOutgoingContext(ctx, "dapr-app-id", "server")
 
 All languages supported by gRPC allow for adding metadata. Here are a few examples:
 
-{{< tabs Java Dotnet Python JavaScript Ruby "C++">}}
+{{< tabs Java .NET Python JavaScript Ruby "C++">}}
 
 {{% codetab %}}
 ```java
@@ -249,7 +249,7 @@ When using Dapr to proxy streaming RPC calls using gRPC, you must set an additio
 
 For example:
 
-{{< tabs Go Java Dotnet Python JavaScript Ruby "C++">}}
+{{< tabs Go Java .NET Python JavaScript Ruby "C++">}}
 
 {{% codetab %}}
 ```go

--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-services-grpc.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-services-grpc.md
@@ -126,7 +126,7 @@ ctx = metadata.AppendToOutgoingContext(ctx, "dapr-app-id", "server")
 
 All languages supported by gRPC allow for adding metadata. Here are a few examples:
 
-{{< tabs Java .NET Python JavaScript Ruby "C++">}}
+{{< tabs Java ".NET" Python JavaScript Ruby "C++">}}
 
 {{% codetab %}}
 ```java
@@ -249,7 +249,7 @@ When using Dapr to proxy streaming RPC calls using gRPC, you must set an additio
 
 For example:
 
-{{< tabs Go Java .NET Python JavaScript Ruby "C++">}}
+{{< tabs Go Java ".NET" Python JavaScript Ruby "C++">}}
 
 {{% codetab %}}
 ```go

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
@@ -68,7 +68,7 @@ Set an `app-id`, as the state keys are prefixed with this value. If you don't se
 
 The following example shows how to save and retrieve a single key/value pair using the Dapr state management API.
 
-{{< tabs .NET Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs ".NET" Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 
@@ -356,7 +356,7 @@ Restart your sidecar and try retrieving state again to observe that state persis
 
 Below are code examples that leverage Dapr SDKs for deleting the state.
 
-{{< tabs .NET Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs ".NET" Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 
@@ -537,7 +537,7 @@ Try getting state again. Note that no value is returned.
 
 Below are code examples that leverage Dapr SDKs for saving and retrieving multiple states.
 
-{{< tabs .NET Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs ".NET" Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 
@@ -788,7 +788,7 @@ State transactions require a state store that supports multi-item transactions. 
 
 Below are code examples that leverage Dapr SDKs for performing state transactions.
 
-{{< tabs .NET Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs ".NET" Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/state-management/howto-get-save-state.md
@@ -68,7 +68,7 @@ Set an `app-id`, as the state keys are prefixed with this value. If you don't se
 
 The following example shows how to save and retrieve a single key/value pair using the Dapr state management API.
 
-{{< tabs Dotnet Java Python Go Javascript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs .NET Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 
@@ -356,7 +356,7 @@ Restart your sidecar and try retrieving state again to observe that state persis
 
 Below are code examples that leverage Dapr SDKs for deleting the state.
 
-{{< tabs Dotnet Java Python Go Javascript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs .NET Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 
@@ -537,7 +537,7 @@ Try getting state again. Note that no value is returned.
 
 Below are code examples that leverage Dapr SDKs for saving and retrieving multiple states.
 
-{{< tabs Dotnet Java Python Go Javascript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs .NET Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 
@@ -788,7 +788,7 @@ State transactions require a state store that supports multi-item transactions. 
 
 Below are code examples that leverage Dapr SDKs for performing state transactions.
 
-{{< tabs Dotnet Java Python Go Javascript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
+{{< tabs .NET Java Python Go JavaScript "HTTP API (Bash)" "HTTP API (PowerShell)">}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/sdks/_index.md
+++ b/daprdocs/content/en/developing-applications/sdks/_index.md
@@ -27,7 +27,7 @@ Select your [preferred language below]({{< ref "#sdk-languages" >}}) to learn mo
 | [Java]({{< ref java >}}) | Stable | ✔ | Spring Boot  <br /> Quarkus| ✔ | ✔ |
 | [Go]({{< ref go >}}) | Stable | ✔ | ✔ | ✔ | ✔ |
 | [PHP]({{< ref php >}}) | Stable | ✔ | ✔ | ✔ | |
-| [Javascript]({{< ref js >}}) | Stable| ✔ | | ✔ | ✔  |
+| [JavaScript]({{< ref js >}}) | Stable| ✔ | | ✔ | ✔  |
 | [C++](https://github.com/dapr/cpp-sdk) | In development | ✔ | | |
 | [Rust](https://github.com/dapr/rust-sdk) | In development | ✔ | | ✔ | |
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
In the docs we have inconsistent naming when it comes to JavaScript and .NET, as you can see next:

https://docs.dapr.io/developing-applications/building-blocks/state-management/howto-get-save-state/#save-and-retrieve-a-single-state
![image](https://github.com/dapr/docs/assets/52082556/e3cadd2d-23c5-44d1-9e6a-4597a3358ffb)

https://docs.dapr.io/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services/#choose-an-id-for-your-service
![image](https://github.com/dapr/docs/assets/52082556/e64d9892-1a7c-43de-9649-3b2edaa053be)

https://docs.dapr.io/developing-applications/building-blocks/pubsub/pubsub-bulk/
![image](https://github.com/dapr/docs/assets/52082556/77c337cc-d5cc-438c-a26a-6aaf372494c8)

The purpose of this PR is to make names uniform according to their "correct" name.