### PR TITLE
Fixes kubernetes operator url

### DIFF
--- a/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
+++ b/daprdocs/content/en/developing-applications/integrations/kubernetes-operator.md
@@ -8,4 +8,4 @@ description: "Use the Dapr Kubernetes Operator to manage the Dapr control plane"
 
 You can use the Dapr Kubernetes Operator to manage the Dapr control plane. Use the operator to automate the tasks required to manage the lifecycle of Dapr control plane in Kubernetes mode. 
  
-{{< button text="Install and use the Dapr Kubernetes Operator" link="https://github.com/dapr/dapr-kubernetes-operator" >}}
+{{< button text="Install and use the Dapr Kubernetes Operator" link="https://github.com/dapr/kubernetes-operator" >}}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
Updates the kubernetes operator url to `https://github.com/dapr/kubernetes-operator`

## Issue reference

This PR will close #4213