### PR TITLE
Service invocation supports passing of query strings/fragments in URL

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services.md
@@ -408,6 +408,12 @@ Using CLI:
 dapr invoke --app-id checkout --method checkout/100
 ```
 
+You can also append a query string or a fragment to the end of the URL and Dapr will pass it through unchanged. This means that if you need to passsome additional arguments in your service invocation that aren't part of a payload or the path, you can do so by appending a `?` to the end of the URL followed by the key/value pairs separated by `=` signs and delimited by `&` as in the following example:
+
+```bash
+curl 'http://dapr-app-id:checkout@localhost:3602/checkout/100?basket=1234&key=abc` -X POST
+```
+
 ### Namespaces
 
 When running on [namespace supported platforms]({{< ref "service_invocation_api.md#namespace-supported-platforms" >}}), you include the namespace of the target app in the app ID. For example, following the `<app>.<namespace>` format, use `checkout.production`.

--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services.md
@@ -408,7 +408,7 @@ Using CLI:
 dapr invoke --app-id checkout --method checkout/100
 ```
 
-You can also append a query string or a fragment to the end of the URL and Dapr will pass it through unchanged. This means that if you need to passsome additional arguments in your service invocation that aren't part of a payload or the path, you can do so by appending a `?` to the end of the URL followed by the key/value pairs separated by `=` signs and delimited by `&` as in the following example:
+You can also append a query string or a fragment to the end of the URL and Dapr will pass it through unchanged. This means that if you need to pass some additional arguments in your service invocation that aren't part of a payload or the path, you can do so by appending a `?` to the end of the URL, followed by the key/value pairs separated by `=` signs and delimited by `&`. For example:
 
 ```bash
 curl 'http://dapr-app-id:checkout@localhost:3602/checkout/100?basket=1234&key=abc` -X POST

--- a/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/service-invocation/howto-invoke-discover-services.md
@@ -408,6 +408,8 @@ Using CLI:
 dapr invoke --app-id checkout --method checkout/100
 ```
 
+#### Including a query string in the URL
+
 You can also append a query string or a fragment to the end of the URL and Dapr will pass it through unchanged. This means that if you need to pass some additional arguments in your service invocation that aren't part of a payload or the path, you can do so by appending a `?` to the end of the URL, followed by the key/value pairs separated by `=` signs and delimited by `&`. For example:
 
 ```bash


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [N/A] Commands include options for Linux, MacOS, and Windows within codetabs
- [N/A] New file and folder names are globally unique
- [N/A] Page references use shortcodes instead of markdown or URL links
- [N/A] Images use HTML style and have alternative text
- [N/A] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
This PR seeks to supplement the service invocation documentation to clarify that a query string and fragment can be passed within the URL and Dapr will pass it through unchanged. I couldn't find this documentation otherwise documented anywhere except as a [single test case](https://github.com/dapr/dotnet-sdk/blob/fba9dfd531a0c100ca93f4d4ba66ffcda7bebc8b/test/Dapr.Client.Test/DaprClientTest.InvokeMethodAsync.cs#L506) in the .NET SDK

## Issue reference
[https://github.com/dapr/dotnet-sdk/issues/1303](https://github.com/dapr/dotnet-sdk/issues/1303)
