### PR TITLE
Remove dashboard references

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-kind.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/cluster/setup-kind.md
@@ -101,17 +101,8 @@ If you are using Docker Desktop, verify that you have [the recommended settings]
      dapr-sentry            dapr-system  True     Running  1         1.5.1    53s  2021-12-10 09:27.17
      dapr-operator          dapr-system  True     Running  1         1.5.1    53s  2021-12-10 09:27.17
      dapr-sidecar-injector  dapr-system  True     Running  1         1.5.1    53s  2021-12-10 09:27.17
-     dapr-dashboard         dapr-system  True     Running  1         0.9.0    53s  2021-12-10 09:27.17
      dapr-placement-server  dapr-system  True     Running  1         1.5.1    52s  2021-12-10 09:27.18
    ```
-
-1. Forward a port to [Dapr dashboard](https://docs.dapr.io/reference/cli/dapr-dashboard/):
-
-   ```bash
-   dapr dashboard -k -p 9999
-   ```
-
-1. Navigate to `http://localhost:9999` to validate a successful setup.
 
 ## Install metrics-server on the Kind Kubernetes Cluster
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Remove Dapr dashboard references from KIND cluster set up steps

## Issue reference
Issue #3735 
**Keep in mind there's still an open comment in such issue.**