### PR TITLE
Remove path matching feature from 1.13 (only in 1.14)

### DIFF
--- a/daprdocs/content/en/operations/configuration/configuration-overview.md
+++ b/daprdocs/content/en/operations/configuration/configuration-overview.md
@@ -110,18 +110,7 @@ metrics:
   rules: []
   http:
     increasedCardinality: true
-    pathMatching:
-      - /items
-      - /orders/{orderID}
-      - /orders/{orderID}/items/{itemID}
-      - /payments/{paymentID}
-      - /payments/{paymentID}/status
-      - /payments/{paymentID}/refund
-      - /payments/{paymentID}/details
-    excludeVerbs: false
 ```
-
-In the examples above, the path filter `/orders/{orderID}/items/{itemID}` would return a single metric count matching all the `orderIDs` and all the `itemIDs`, rather than multiple metrics for each `itemID`. For more information, see [HTTP metrics path matching]({{< ref "metrics-overview.md#http-metrics-path-matching" >}}).
 
 The following table lists the properties for metrics:
 
@@ -129,11 +118,9 @@ The following table lists the properties for metrics:
 |--------------|--------|-------------|
 | `enabled` | boolean | When set to true, the default, enables metrics collection and the metrics endpoint. |
 | `rules`   | array | Named rule to filter metrics. Each rule contains a set of `labels` to filter on and a `regex` expression to apply to the metrics path. |
-| `http.increasedCardinality` | boolean | When set to `true` (default), in the Dapr HTTP server, each request path causes the creation of a new "bucket" of metrics. This can cause issues, including excessive memory consumption when there many different requested endpoints (such as when interacting with RESTful APIs).<br> To mitigate high memory usage and egress costs associated with [high cardinality metrics]({{< ref "metrics-overview.md#high-cardinality-metrics" >}}) with the HTTP server, you should set the `metrics.http.increasedCardinality` property to `false`.|
-| `http.pathMatching` | array | Paths used for path matching, allowing users to define matching paths in order to manage cardinality. |
-| `http.excludeVerbs` | boolean | When set to `true` (default is `false`), the Dapr HTTP server ignores each request HTTP verb when building the method metric label. |
+| `http.increasedCardinality` | boolean | When set to true, in the Dapr HTTP server each request path causes the creation of a new "bucket" of metrics. This can cause issues, including excessive memory consumption, when there many different requested endpoints (such as when interacting with RESTful APIs).<br>In Dapr 1.13 the default value is `true` (to preserve the behavior of Dapr <= 1.12), but changes to `false` in Dapr 1.14..|
 
-To further help managing cardinality, path matching allows specified paths matched according to defined patterns, reducing the number of unique metrics paths and thus controlling metric cardinality. This feature is particularly useful for applications with dynamic URLs, ensuring that metrics remain meaningful and manageable without excessive memory consumption. 
+To mitigate high memory usage and egress costs associated with [high cardinality metrics]({{< ref "metrics-overview.md#high-cardinality-metrics" >}}) with the HTTP server, you should set the `metrics.http.increasedCardinality` property to `false`.
 
 Using rules, you can set regular expressions for every metric exposed by the Dapr sidecar. For example:
 

--- a/daprdocs/content/en/operations/observability/metrics/metrics-overview.md
+++ b/daprdocs/content/en/operations/observability/metrics/metrics-overview.md
@@ -70,135 +70,15 @@ spec:
     enabled: false
 ```
 
-## Optimizing HTTP metrics reporting with path matching
+## High cardinality metrics
 
-When invoking Dapr using HTTP, metrics are created for each requested method by default. This can result in a high number of metrics, known as high cardinality, which can impact memory usage and CPU.
+When invoking Dapr using HTTP, the legacy behavior (and current default as of Dapr 1.13) is to create a separate "bucket" for each requested method. When working with RESTful APIs, this can cause very high cardinality, with potential negative impact on memory usage and CPU.
 
-Path matching allows you to manage and control the cardinality of HTTP metrics in Dapr. This is an aggregation of metrics, so rather than having a metric for each event, you can reduce the number of metrics events and report an overall number.  For details on how to set the cardinality in configuration see ({{< ref "configuration-overview.md#metrics" >}})  
+Dapr 1.13 introduces a new option for the Dapr Configuration resource `spec.metrics.http.increasedCardinality`: when set to `false`, it reports metrics for the HTTP server for each "abstract" method (for example, requesting from a state store) instead of creating a "bucket" for each concrete request path.
 
-This configuration is opt-in and is enabled via the Dapr configuration `spec.metrics.http.pathMatching`. When defined, it enables path matching, which standardizes specified paths for both metrics paths. This reduces the number of unique metrics paths, making metrics more manageable and reducing resource consumption in a controlled way.  
+The default value of `spec.metrics.http.increasedCardinality` is `true` in Dapr 1.13, to maintain the same behavior as Dapr 1.12 and older. However, the value will change to `false` (low-cardinality metrics by default) in Dapr 1.14.
 
-When `spec.metrics.http.pathMatching` is combined with the `increasedCardinality` flag set to `false`, non-matched paths are transformed into a catch-all bucket to control and limit cardinality, preventing unbounded path growth. Conversely, when `increasedCardinality` is `true` (the default), non-matched paths are passed through as they normally would be, allowing for potentially higher cardinality but preserving the original path data. 
-
-### Examples of Path Matching in HTTP Metrics
-
-The following examples demonstrate how to use the Path Matching API in Dapr for managing HTTP metrics. On each example, the metrics are collected from 5 HTTP requests to the `/orders` endpoint with different order IDs. By adjusting cardinality and utilizing path matching, you can fine-tune metric granularity to balance detail and resource efficiency.
-
-These examples illustrate the cardinality of the metrics, highlighting that high cardinality configurations result in many entries, which correspond to higher memory usage for handling metrics. For simplicity, the following example focuses on a single metric: `dapr_http_server_request_count`. 
-
-#### Low cardinality with path matching (Recommendation)
-
-Configuration:
-```yaml
-http:
-  increasedCardinality: false
-  pathMatching:
-    - /orders/{orderID}
-```
-
-Metrics generated:
-```
-# matched paths
-dapr_http_server_request_count{app_id="order-service",method="GET",path="/orders/{orderID}",status="200"} 5
-# unmatched paths
-dapr_http_server_request_count{app_id="order-service",method="GET",path="",status="200"} 1
-```
-
-With low cardinality and path matching configured, you get the best of both worlds by grouping the metrics for the important endpoints without compromising the cardinality. This approach helps avoid high memory usage and potential security issues.
-
-#### Low cardinality without path matching
-
-Configuration:
-
-```yaml
-http:
-  increasedCardinality: false
-```
-Metrics generated:
-```
-dapr_http_server_request_count{app_id="order-service",method="GET", path="",status="200"} 5
-```
-
-In low cardinality mode, the path, which is the main source of unbounded cardinality, is dropped. This results in metrics that primarily indicate the number of requests made to the service for a given HTTP method, but without any information about the paths invoked. 
-
-
-#### High cardinality with path matching
-
-Configuration:
-```yaml
-http:
-  increasedCardinality: true
-  pathMatching:
-    - /orders/{orderID}
-```
-
-Metrics generated:
-```
-dapr_http_server_request_count{app_id="order-service",method="GET",path="/orders/{orderID}",status="200"} 5
-```
-
-This example results from the same HTTP requests as the example above, but with path matching configured for the path `/orders/{orderID}`. By using path matching, you achieve reduced cardinality by grouping the metrics based on the matched path.
-
-#### High Cardinality without path matching
-
-Configuration:
-```yaml
-http:
-  increasedCardinality: true
-```
-
-Metrics generated:
-```
-dapr_http_server_request_count{app_id="order-service",method="GET",path="/orders/1",status="200"} 1
-dapr_http_server_request_count{app_id="order-service",method="GET",path="/orders/2",status="200"} 1
-dapr_http_server_request_count{app_id="order-service",method="GET",path="/orders/3",status="200"} 1
-dapr_http_server_request_count{app_id="order-service",method="GET",path="/orders/4",status="200"} 1
-dapr_http_server_request_count{app_id="order-service",method="GET",path="/orders/5",status="200"} 1
-```
-
-For each request, a new metric is created with the request path. This process continues for every request made to a new order ID, resulting in unbounded cardinality since the IDs are ever-growing.
-
-
-### HTTP metrics exclude verbs
-
-The `excludeVerbs` option allows you to exclude specific HTTP verbs from being reported in the metrics. This can be useful in high-performance applications where memory savings are critical.
-
-### Examples of excluding HTTP verbs in metrics
-
-The following examples demonstrate how to exclude HTTP verbs in Dapr for managing HTTP metrics.
-
-#### Default - Include HTTP verbs
-
-Configuration:
-```yaml
-http:
-  excludeVerbs: false
-```
-
-Metrics generated:
-```
-dapr_http_server_request_count{app_id="order-service",method="GET",path="/orders",status="200"} 1
-dapr_http_server_request_count{app_id="order-service",method="POST",path="/orders",status="200"} 1
-```
-
-In this example, the HTTP method is included in the metrics, resulting in a separate metric for each request to the `/orders` endpoint.
-
-#### Exclude HTTP verbs
-
-Configuration:
-```yaml
-http:
-  excludeVerbs: true
-```
-
-Metrics generated:
-```
-dapr_http_server_request_count{app_id="order-service",method="",path="/orders",status="200"} 2
-```
-
-In this example, the HTTP method is excluded from the metrics, resulting in a single metric for all requests to the `/orders` endpoint.
-
-
+Setting `spec.metrics.http.increasedCardinality` to `false` is **recommended** to all Dapr users, to reduce resource consumption. The pre-1.13 behavior, which is used when the option is `true`, is considered legacy and is only maintained for users who have special requirements around backwards-compatibility.
 
 ## Transform metrics with regular expressions
 

--- a/daprdocs/content/en/reference/resource-specs/configuration-schema.md
+++ b/daprdocs/content/en/reference/resource-specs/configuration-schema.md
@@ -38,10 +38,6 @@ spec:
             regex: {}
     http:
       increasedCardinality: <TRUE-OR-FALSE>
-      pathMatching: 
-        - <PATH-A>
-        - <PATH-B>
-      excludeVerbs: <TRUE-OR-FALSE>
   httpPipeline: # for incoming http calls
     handlers:
       - name: <HANDLER-NAME>


### PR DESCRIPTION
## Description

Revert changes made [in this PR](https://github.com/dapr/docs/pull/4155/files) to 1.13, which should've been made for 1.14. These updates have already been brought into the 1.14 branch.
