### PR TITLE
Add Rabbitmq single active consumer parameter

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-rabbitmq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-rabbitmq.md
@@ -451,6 +451,28 @@ You can set a time-to-live (TTL) value at either the message or component level.
 If you set both component-level and message-level TTL, the default component-level TTL is ignored in favor of the message-level TTL.
 {{% /alert %}}
 
+## Single Active Consumer
+
+Enable RabbitMQ [Single Active Consumer](https://www.rabbitmq.com/docs/consumers#single-active-consumer) parameter on queues.
+
+```yml
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: pubsub
+spec:
+  topic: orders
+  routes:
+    default: /orders
+  pubsubname: order-pub-sub
+  metadata:
+    singleActiveConsumer: "true"
+```
+
+{{% alert title="Note" color="primary" %}}
+The Dapr runtime acts as the single active consumer from RabbitMQ's perspective. To allow another application instance to take over in case of failure, Dapr must [probe the application's health]({{< ref "app-health.md" >}}) and unsubscribe from pub/sub component.
+{{% /alert %}}
+
 ## Related links
 
 - [Basic schema for a Dapr component]({{< ref component-schema >}}) in the Related links section

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-rabbitmq.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-rabbitmq.md
@@ -453,7 +453,13 @@ If you set both component-level and message-level TTL, the default component-lev
 
 ## Single Active Consumer
 
-Enable RabbitMQ [Single Active Consumer](https://www.rabbitmq.com/docs/consumers#single-active-consumer) parameter on queues.
+The RabbitMQ [Single Active Consumer](https://www.rabbitmq.com/docs/consumers#single-active-consumer) setup ensures that only one consumer at a time processes messages from a queue and switches to another registered consumer if the active one is canceled or fails. This approach might be required when it is crucial for messages to be consumed in the exact order they arrive in the queue and if distributed processing with multiple instances is not supported.
+When this option is enabled on a queue by Dapr, an instance of the Dapr runtime will be the single active consumer. To allow another application instance to take over in case of failure, Dapr runtime must [probe the application's health]({{< ref "app-health.md" >}}) and unsubscribe from the pub/sub component.
+
+{{% alert title="Note" color="primary" %}}
+This pattern will prevent the application to scale as only one instance can process the load. While it might be interesting for Dapr integration with legacy or sensible applications, you should consider a design allowing distributed processing if you need scalability.
+{{% /alert %}}
+
 
 ```yml
 apiVersion: dapr.io/v2alpha1
@@ -468,10 +474,6 @@ spec:
   metadata:
     singleActiveConsumer: "true"
 ```
-
-{{% alert title="Note" color="primary" %}}
-The Dapr runtime acts as the single active consumer from RabbitMQ's perspective. To allow another application instance to take over in case of failure, Dapr must [probe the application's health]({{< ref "app-health.md" >}}) and unsubscribe from pub/sub component.
-{{% /alert %}}
 
 ## Related links
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add Rabbitmq single active consumer parameter


## Issue reference

#4226 
