### PR TITLE
Fixed typo in links

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/secrets/secrets-scopes.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/secrets/secrets-scopes.md
@@ -69,7 +69,7 @@ spec:
         allowedSecrets: ["secret1", "secret2"]
 ```
 
-The default access to the `vault` secret store is `deny`, while some secrets are accessible by the application, based on the `allowedSecrets` list. [Learn how to apply configuration to the sidecar]]({{< ref configuration-concept.md >}}).
+The default access to the `vault` secret store is `deny`, while some secrets are accessible by the application, based on the `allowedSecrets` list. [Learn how to apply configuration to the sidecar]({{< ref configuration-concept.md >}}).
 
 ## Scenario 3: Deny access to certain sensitive secrets in a secret store
 
@@ -88,7 +88,7 @@ spec:
         deniedSecrets: ["secret1", "secret2"]
 ```
 
-This example configuration explicitly denies access to `secret1` and `secret2` from the secret store named `vault` while allowing access to all other secrets. [Learn how to apply configuration to the sidecar]]({{< ref configuration-concept.md >}}).
+This example configuration explicitly denies access to `secret1` and `secret2` from the secret store named `vault` while allowing access to all other secrets. [Learn how to apply configuration to the sidecar]({{< ref configuration-concept.md >}}).
 
 ## Permission priority
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Links not rendered

## Issue reference

https://github.com/dapr/docs/issues/4266
