### PR TITLE
Fixed yaml syntax for Subscription v2alpha1 spec example

### DIFF
--- a/daprdocs/content/en/reference/resource-specs/subscription-schema.md
+++ b/daprdocs/content/en/reference/resource-specs/subscription-schema.md
@@ -23,15 +23,15 @@ metadata:
 spec:
   topic: <REPLACE-WITH-TOPIC-NAME> # Required
   routes: # Required
-  - rules:
-    - match: <REPLACE-WITH-CEL-FILTER>
-      path: <REPLACE-WITH-PATH>
+    rules:
+      - match: <REPLACE-WITH-CEL-FILTER>
+        path: <REPLACE-WITH-PATH>
   pubsubname: <REPLACE-WITH-PUBSUB-NAME> # Required
   deadLetterTopic: <REPLACE-WITH-DEADLETTERTOPIC-NAME> # Optional
   bulkSubscribe: # Optional
-  - enabled: <REPLACE-WITH-BOOLEAN-VALUE>
-  - maxMessagesCount: <REPLACE-WITH-VALUE>
-  - maxAwaitDurationMs: <REPLACE-WITH-VALUE>
+    enabled: <REPLACE-WITH-BOOLEAN-VALUE>
+    maxMessagesCount: <REPLACE-WITH-VALUE>
+    maxAwaitDurationMs: <REPLACE-WITH-VALUE>
 scopes:
 - <REPLACE-WITH-SCOPED-APPIDS>
 ```


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
- Fixed the v2alpha1 example's `spec.routes` to be an object instead of array.
- Fixed `spec.bulkSubscribe`'s members to not be array values since the parent is not an array.

## Issue reference

