### PR TITLE
Update roadmap.md

### DIFF
--- a/daprdocs/content/en/contributing/roadmap.md
+++ b/daprdocs/content/en/contributing/roadmap.md
@@ -1,14 +1,10 @@
 ---
 type: docs
-title: "Dapr Proposals"
-linkTitle: "Proposals"
-description: "The Dapr Proposals repository is a central location to help with visibility into investments across the Dapr project"
+title: "Dapr Roadmap"
+linkTitle: "Roadmap"
+description: "The Dapr Roadmap gives the community visibility into the different priorities of the projecs"
 weight: 30
 no_list: true
 ---
 
-Dapr encourages the community to help with prioritization. A [dedicated proposals repository exists](https://github.com/dapr/proposals) to foster discussions with the community on all future additions and/or changes to the Dapr project.
-
-Please vote by adding a 👍 on the GitHub issues for the feature capabilities you would most like to see Dapr support. This will help the Dapr maintainers understand which features will provide the most value.
-
-Contributions from the community are always welcomed. If there are features on the proposals repo that you are interested in contributing to, please comment on the GitHub issue and include your solution proposal.
+See [this document](https://github.com/dapr/community/blob/master/roadmap.md) to view the Dapr project's roadmap.

--- a/daprdocs/content/en/contributing/roadmap.md
+++ b/daprdocs/content/en/contributing/roadmap.md
@@ -1,48 +1,14 @@
 ---
 type: docs
-title: "Dapr Roadmap"
-linkTitle: "Roadmap"
-description: "The Dapr Roadmap is a tool to help with visibility into investments across the Dapr project"
+title: "Dapr Proposals"
+linkTitle: "Proposals"
+description: "The Dapr Proposals repository is a central location to help with visibility into investments across the Dapr project"
 weight: 30
 no_list: true
 ---
 
-
-Dapr encourages the community to help with prioritization. A GitHub project board is available to view and provide feedback on proposed issues and track them across development.
-
-[<img src="/images/roadmap.png" alt="Screenshot of the Dapr Roadmap board" width=500 >](https://aka.ms/dapr/roadmap)
-
-{{< button text="View the backlog" link="https://aka.ms/dapr/roadmap" color="primary" >}}
-<br />
+Dapr encourages the community to help with prioritization. A [dedicated proposals repository exists](https://github.com/dapr/proposals) to foster discussions with the community on all future additions and/or changes to the Dapr project.
 
 Please vote by adding a 👍 on the GitHub issues for the feature capabilities you would most like to see Dapr support. This will help the Dapr maintainers understand which features will provide the most value.
 
-Contributions from the community is also welcomed. If there are features on the roadmap that you are interested in contributing to, please comment on the GitHub issue and include your solution proposal.
-
-{{% alert title="Note" color="primary" %}}
-The Dapr roadmap includes issues only from the v1.2 release and onwards. Issues closed and released prior to v1.2 are not included.
-{{% /alert %}}
-
-## Stages
-
-The Dapr Roadmap progresses through the following stages:
-
-{{< cardpane >}}
-{{< card title="**[📄 Backlog](https://github.com/orgs/dapr/projects/52#column-14691591)**" >}}
-  Issues (features) that need 👍 votes from the community to prioritize. Updated by Dapr maintainers.
-{{< /card >}}
-{{< card title="**[⏳ Planned (Committed)](https://github.com/orgs/dapr/projects/52#column-14561691)**" >}}
-  Issues with a proposal and/or targeted release milestone. This is where design proposals are discussed and designed.
-{{< /card >}}
-{{< card title="**[👩‍💻 In Progress (Development)](https://github.com/orgs/dapr/projects/52#column-14561696)**" >}}
- Implementation specifics have been agreed upon and the feature is under active development.
-{{< /card >}}
-{{< /cardpane >}}
-{{< cardpane >}}
-{{< card title="**[☑ Done](https://github.com/orgs/dapr/projects/52#column-14561700)**" >}}
- The feature capability has been completed and is scheduled for an upcoming release.
-{{< /card >}}
-{{< card title="**[✅ Released](https://github.com/orgs/dapr/projects/52#column-14659973)**" >}}
- The feature is released and available for use.
-{{< /card >}}
-{{< /cardpane >}}
+Contributions from the community are always welcomed. If there are features on the proposals repo that you are interested in contributing to, please comment on the GitHub issue and include your solution proposal.


### PR DESCRIPTION
Remove references to the new deprecated Roadmap project in favor of its replacement, the proposals repository.

Closes https://github.com/dapr/dapr/issues/8048
