### PR TITLE
Jobs API: rm escape

### DIFF
--- a/daprdocs/content/en/reference/api/jobs_api.md
+++ b/daprdocs/content/en/reference/api/jobs_api.md
@@ -65,7 +65,7 @@ Entry                  | Description                                | Equivalent
 {
   "data": {
 	  "@type": "type.googleapis.com/google.protobuf.StringValue",
-	  "value": "\"someData\""
+	  "value": "someData"
     },
     "dueTime": "30s"
 }


### PR DESCRIPTION
Fix the json for the Jobs API. [See e2e here where we have this test scenario without the escaping](https://github.com/dapr/dapr/blob/master/tests/e2e/scheduler/scheduler_test.go#L111)

[Followup from this issue](https://github.com/dapr/dapr/issues/8077)