### PR TITLE
Fixed cron schedule table formatting in Jobs API reference

### DIFF
--- a/daprdocs/content/en/reference/api/jobs_api.md
+++ b/daprdocs/content/en/reference/api/jobs_api.md
@@ -43,9 +43,13 @@ Parameter | Description
 
 Systemd timer style cron accepts 6 fields:
 seconds | minutes | hours | day of month | month        | day of week
+---     | ---     | ---   | ---          | ---          | ---
 0-59    | 0-59    | 0-23  | 1-31         | 1-12/jan-dec | 0-7/sun-sat
 
+##### Example 1
 "0 30 * * * *" - every hour on the half hour
+
+##### Example 2
 "0 15 3 * * *" - every day at 03:15
 
 Period string expressions:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The [Jobs API reference documentation](https://docs.dapr.io/reference/api/jobs_api/) details the fields accepted for the Cron expression, but the table doesn't display correctly because it's malformed. This PR fixes that and places headers over the following examples indicating that they're examples.

## Issue reference

N/A
