### PR TITLE
Tweaked the observability endpoint description and examples to reflect that the protocol may not be necessary

### DIFF
--- a/daprdocs/content/en/operations/configuration/configuration-overview.md
+++ b/daprdocs/content/en/operations/configuration/configuration-overview.md
@@ -88,7 +88,7 @@ tracing:
   otel: 
     endpointAddress: "otelcollector.observability.svc.cluster.local:4317"
   zipkin:
-    endpointAddress: "zipkin.default.svc.cluster.local:9411/api/v2/spans"
+    endpointAddress: "http://zipkin.default.svc.cluster.local:9411/api/v2/spans"
 ```
 
 The following table lists the properties for tracing:
@@ -100,7 +100,7 @@ The following table lists the properties for tracing:
 | `otel.endpointAddress` | string | Set the Open Telemetry (OTEL) server address to send traces to. This may or may not require the https:// or http:// depending on your OTEL provider.
 | `otel.isSecure` | bool | Is the connection to the endpoint address encrypted
 | `otel.protocol` | string | Set to `http` or `grpc` protocol
-| `zipkin.endpointAddress` | string | Set the Zipkin server address to send traces to. This may or may not require the https:// or http:// depending on your Zipkin provider.
+| `zipkin.endpointAddress` | string | Set the Zipkin server address to send traces to. This should include the protocol (http:// or https://) on the endpoint.
 
 ##### `samplingRate`
 

--- a/daprdocs/content/en/operations/configuration/configuration-overview.md
+++ b/daprdocs/content/en/operations/configuration/configuration-overview.md
@@ -86,9 +86,9 @@ The `tracing` section under the `Configuration` spec contains the following prop
 tracing:
   samplingRate: "1"
   otel: 
-    endpointAddress: "https://..."
+    endpointAddress: "otelcollector.observability.svc.cluster.local:4317"
   zipkin:
-    endpointAddress: "http://zipkin.default.svc.cluster.local:9411/api/v2/spans"
+    endpointAddress: "zipkin.default.svc.cluster.local:9411/api/v2/spans"
 ```
 
 The following table lists the properties for tracing:
@@ -97,10 +97,10 @@ The following table lists the properties for tracing:
 |--------------|--------|-------------|
 | `samplingRate` | string | Set sampling rate for tracing to be enabled or disabled.
 | `stdout` | bool | True write more verbose information to the traces
-| `otel.endpointAddress` | string | Set the Open Telemetry (OTEL) server address to send traces to
+| `otel.endpointAddress` | string | Set the Open Telemetry (OTEL) server address to send traces to. This may or may not require the https:// or http:// depending on your OTEL provider.
 | `otel.isSecure` | bool | Is the connection to the endpoint address encrypted
 | `otel.protocol` | string | Set to `http` or `grpc` protocol
-| `zipkin.endpointAddress` | string | Set the Zipkin server address to send traces to
+| `zipkin.endpointAddress` | string | Set the Zipkin server address to send traces to. This may or may not require the https:// or http:// depending on your Zipkin provider.
 
 ##### `samplingRate`
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

There was [feedback in Discord](https://discord.com/channels/778680217417809931/778684392893579267/1284111507839258634) that when 'grpc' was used, they were unable to get the configuration to work when they specified the protocol in the endpoint for their OTEL provider. As such, I've updated the documentation to reflect that it may not be necessary so at least future developers can understand that they may need to play around with it if their provider doesn't explicitly specify this.

Thanks for calling this out @KrylixZA !

## Issue reference
N/A
