### PR TITLE
Corrected incorrect value range in Jobs schedule description

### DIFF
--- a/daprdocs/content/en/reference/api/jobs_api.md
+++ b/daprdocs/content/en/reference/api/jobs_api.md
@@ -43,7 +43,7 @@ Parameter | Description
 
 Systemd timer style cron accepts 6 fields:
 seconds | minutes | hours | day of month | month        | day of week
-0-59    | 0-59    | 0-23  | 1-31         | 1-12/jan-dec | 0-7/sun-sat
+0-59    | 0-59    | 0-23  | 1-31         | 1-12/jan-dec | 0-6/sun-sat
 
 "0 30 * * * *" - every hour on the half hour
 "0 15 3 * * *" - every day at 03:15


### PR DESCRIPTION
**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The Jobs documentation reflects some information pulled from the protos about what a valid "day of week" value is and states this accepts "0-7". This is not accurate - this PR mirrors my [tweak to the proto itself](https://github.com/dapr/dapr/pull/8112) and corrects this to reflect a valid value of "0-6" instead.

## Issue reference

None - spotted while working on something else
