### PR TITLE
Added clarification that actors always need actorStateStore property set on state component

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/actors/actors-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/actors/actors-overview.md
@@ -104,7 +104,7 @@ The Dapr actor runtime provides a simple turn-based access model for accessing a
 
 ### State
 
-Transactional state stores can be used to store actor state. Regardless of whether you intend to use stateful or stateless actors, you must specify a value for property `actorStateStore` as `true` in the state store component's metadata section. Actors state is stored with a specific scheme in transactional state stores, allowing for consistent querying. Only a single state store component can be used as the state store for all actors. Read the [state API reference]({{< ref state_api.md >}}) and the [actors API reference]({{< ref actors_api.md >}}) to learn more about state stores for actors.
+Transactional state stores can be used to store actor state. Regardless of whether you intend to store any state in your actor, you must specify a value for property `actorStateStore` as `true` in the state store component's metadata section. Actors state is stored with a specific scheme in transactional state stores, allowing for consistent querying. Only a single state store component can be used as the state store for all actors. Read the [state API reference]({{< ref state_api.md >}}) and the [actors API reference]({{< ref actors_api.md >}}) to learn more about state stores for actors.
 
 ### Actor timers and reminders
 

--- a/daprdocs/content/en/developing-applications/building-blocks/actors/actors-overview.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/actors/actors-overview.md
@@ -104,7 +104,7 @@ The Dapr actor runtime provides a simple turn-based access model for accessing a
 
 ### State
 
-Transactional state stores can be used to store actor state. To specify which state store to use for actors, specify value of property `actorStateStore` as `true` in the state store component's metadata section. Actors state is stored with a specific scheme in transactional state stores, allowing for consistent querying. Only a single state store component can be used as the state store for all actors. Read the [state API reference]({{< ref state_api.md >}}) and the [actors API reference]({{< ref actors_api.md >}}) to learn more about state stores for actors.
+Transactional state stores can be used to store actor state. Regardless of whether you intend to use stateful or stateless actors, you must specify a value for property `actorStateStore` as `true` in the state store component's metadata section. Actors state is stored with a specific scheme in transactional state stores, allowing for consistent querying. Only a single state store component can be used as the state store for all actors. Read the [state API reference]({{< ref state_api.md >}}) and the [actors API reference]({{< ref actors_api.md >}}) to learn more about state stores for actors.
 
 ### Actor timers and reminders
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

There was a concern raised [in Discord](https://discord.com/channels/778680217417809931/886835700769644595/1286106434391511160) that the documentation wasn't as clear as it could be that a state store was required for actors regardless of whether any state was actually stored. This is a minor tweak to the documentation that reflects this requirement.

## Issue reference

N/A
