### PR TITLE
Jobs API: rm decoding

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/jobs/howto-schedule-and-handle-triggered-jobs.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/jobs/howto-schedule-and-handle-triggered-jobs.md
@@ -103,11 +103,9 @@ func prodDBBackupHandler(ctx context.Context, job *common.JobEvent) error {
 	if err := json.Unmarshal(job.Data, &jobData); err != nil {
 		// ...
 	}
-	decodedPayload, err := base64.StdEncoding.DecodeString(jobData.Value)
-	// ...
 
 	var jobPayload api.DBBackup
-	if err := json.Unmarshal(decodedPayload, &jobPayload); err != nil {
+	if err := json.Unmarshal(job.Data, &jobPayload); err != nil {
 		// ...
 	}
 	fmt.Printf("job %d received:\n type: %v \n typeurl: %v\n value: %v\n extracted payload: %v\n", jobCount, job.JobType, jobData.TypeURL, jobData.Value, jobPayload)

--- a/daprdocs/content/en/getting-started/quickstarts/jobs-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/jobs-quickstart.md
@@ -273,23 +273,20 @@ func deleteJob(ctx context.Context, in *common.InvocationEvent) (out *common.Con
 
 // Handler that handles job events
 func handleJob(ctx context.Context, job *common.JobEvent) error {
-	var jobData common.Job
-	if err := json.Unmarshal(job.Data, &jobData); err != nil {
-		return fmt.Errorf("failed to unmarshal job: %v", err)
-	}
-	decodedPayload, err := base64.StdEncoding.DecodeString(jobData.Value)
-	if err != nil {
-		return fmt.Errorf("failed to decode job payload: %v", err)
-	}
-	var jobPayload JobData
-	if err := json.Unmarshal(decodedPayload, &jobPayload); err != nil {
-		return fmt.Errorf("failed to unmarshal payload: %v", err)
-	}
+    var jobData common.Job
+    if err := json.Unmarshal(job.Data, &jobData); err != nil {
+        return fmt.Errorf("failed to unmarshal job: %v", err)
+    }
 
-	fmt.Println("Starting droid:", jobPayload.Droid)
-	fmt.Println("Executing maintenance job:", jobPayload.Task)
+    var jobPayload JobData
+    if err := json.Unmarshal(job.Data, &jobPayload); err != nil {
+        return fmt.Errorf("failed to unmarshal payload: %v", err)
+    }
 
-	return nil
+    fmt.Println("Starting droid:", jobPayload.Droid)
+    fmt.Println("Executing maintenance job:", jobPayload.Task)
+
+    return nil
 }
 ```
 


### PR DESCRIPTION
[docs for this PR](https://github.com/dapr/quickstarts/pull/1097) - rm the job decoding which is no longer necessary