### PR TITLE
workflows: fix description of backoff coefficient

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-features-concepts.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-features-concepts.md
@@ -135,7 +135,7 @@ Because workflow retry policies are configured in code, the exact developer expe
 | --- | --- |
 | **Maximum number of attempts** | The maximum number of times to execute the activity or child workflow. |
 | **First retry interval** | The amount of time to wait before the first retry. |
-| **Backoff coefficient** | The amount of time to wait before each subsequent retry. |
+| **Backoff coefficient** | The coefficient used to determine rate of increase of back-off, i.e a coefficient of 2 will double the wait of each subsequent retry. |
 | **Maximum retry interval** | The maximum amount of time to wait before each subsequent retry. |
 | **Retry timeout** | The overall timeout for retries, regardless of any configured max number of attempts. |
 

--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-features-concepts.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-features-concepts.md
@@ -135,7 +135,7 @@ Because workflow retry policies are configured in code, the exact developer expe
 | --- | --- |
 | **Maximum number of attempts** | The maximum number of times to execute the activity or child workflow. |
 | **First retry interval** | The amount of time to wait before the first retry. |
-| **Backoff coefficient** | The coefficient used to determine rate of increase of back-off, i.e a coefficient of 2 will double the wait of each subsequent retry. |
+| **Backoff coefficient** | The coefficient used to determine the rate of increase of back-off. For example a coefficient of 2 doubles the wait of each subsequent retry. |
 | **Maximum retry interval** | The maximum amount of time to wait before each subsequent retry. |
 | **Retry timeout** | The overall timeout for retries, regardless of any configured max number of attempts. |
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
As discussed here https://discord.com/channels/778680217417809931/1075836407156850698/1296890277033939045

the definition of the backoff coefficient for workflow retries does not adhere to the actual implementation.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
