### PR TITLE
Update workflow-quickstart.md regarding using Redis in production

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/workflow-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/workflow-quickstart.md
@@ -11,7 +11,7 @@ Dapr Workflow is currently in beta. [See known limitations for {{% dapr-latest-v
 {{% /alert %}}
 
 {{% alert title="Note" color="primary" %}}
-Redis is currently used as the state store component for Workflows in out Quickstarts. However, Redis does not support transaction rollbacks and should not be used in production as an actor state store.
+Redis is currently used as the state store component for Workflows in the Quickstarts. However, Redis does not support transaction rollbacks and should not be used in production as an actor state store.
 {{% /alert %}}
 
 Let's take a look at the Dapr [Workflow building block]({{< ref workflow-overview.md >}}). In this Quickstart, you'll create a simple console application to demonstrate Dapr's workflow programming model and the workflow management APIs.

--- a/daprdocs/content/en/getting-started/quickstarts/workflow-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/workflow-quickstart.md
@@ -10,6 +10,10 @@ description: Get started with the Dapr Workflow building block
 Dapr Workflow is currently in beta. [See known limitations for {{% dapr-latest-version cli="true" %}}]({{< ref "workflow-overview.md#limitations" >}}).
 {{% /alert %}}
 
+{{% alert title="Note" color="primary" %}}
+Redis is currently used as the state store component for Workflows in out Quickstarts. However, Redis does not support transaction rollbacks and should not be used in production as an actor state store.
+{{% /alert %}}
+
 Let's take a look at the Dapr [Workflow building block]({{< ref workflow-overview.md >}}). In this Quickstart, you'll create a simple console application to demonstrate Dapr's workflow programming model and the workflow management APIs.
 
 In this guide, you'll:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Redis is used in the Workflows Quickstarts, but Redis isn't recommended for use in production (for Workflows). Added a note to the Quickstarts page to highlight this. I've raised this in response to discussions with Oli and Whit on Discord.

