### PR TITLE
Fix Observability YouTube URL timestamp

### DIFF
--- a/daprdocs/content/en/operations/observability/_index.md
+++ b/daprdocs/content/en/operations/observability/_index.md
@@ -6,7 +6,7 @@ weight: 60
 description: See and measure the message calls to components and between networked services
 ---
 
-[The following overview video and demo](https://www.youtube.com/live/0y7ne6teHT4?si=3bmNSSyIEIVSF-Ej&t=9931) demonstrates how observability in Dapr works. 
+[The following overview video and demo](https://www.youtube.com/watch?v=0y7ne6teHT4&t=12652s) demonstrates how observability in Dapr works. 
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/0y7ne6teHT4?si=iURnLk57t2zN-7zP&amp;start=12653" title="YouTube video player" style="padding-bottom:25px;" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- ~[ ] Commands include options for Linux, MacOS, and Windows within codetabs~
- ~[ ] New file and folder names are globally unique~
- ~[ ] Page references use shortcodes instead of markdown or URL links~
- ~[ ] Images use HTML style and have alternative text~
- ~[ ] Places where multiple code/command options are given have codetabs~

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated the timestamp in the YouTube link provided on the observability page to start at the observability demo instead of the secrets management demo.

## Issue reference

#4434
