### PR TITLE
Document deprecation of Workflows API Alpha1 in breaking changes

### DIFF
--- a/daprdocs/content/en/operations/support/breaking-changes-and-deprecations.md
+++ b/daprdocs/content/en/operations/support/breaking-changes-and-deprecations.md
@@ -68,6 +68,7 @@ After announcing a future breaking change, the change will happen in 2 releases 
 | Hazelcast PubSub Component | 1.9.0 | 1.11.0 |
 | Twitter Binding Component | 1.10.0 | 1.11.0 |
 | NATS Streaming PubSub Component | 1.11.0 | 1.13.0 |
+| Workflows API Alpha1 `/v1.0-alpha1/workflows` being deprecated in favor of Workflow Client | 1.15.0 | 1.17.0 |
 
 ## Related links
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

The change was made in: 
- https://github.com/dapr/dapr/pull/8299
