### PR TITLE
Crypto is still in alpha, so the URLs shouldn't point to v1.0 values

### DIFF
--- a/daprdocs/content/en/reference/api/cryptography_api.md
+++ b/daprdocs/content/en/reference/api/cryptography_api.md
@@ -20,7 +20,7 @@ This endpoint lets you encrypt a value provided as a byte array using a specifie
 ### HTTP Request
 
 ```
-PUT http://localhost:<daprPort>/v1.0/crypto/<crypto-store-name>/encrypt
+PUT http://localhost:<daprPort>/v1.0-alpha1/crypto/<crypto-store-name>/encrypt
 ```
 
 #### URL Parameters
@@ -59,7 +59,7 @@ returns an array of bytes with the encrypted payload.
 
 ### Examples
 ```shell
-curl http://localhost:3500/v1.0/crypto/myAzureKeyVault/encrypt \
+curl http://localhost:3500/v1.0-alpha1/crypto/myAzureKeyVault/encrypt \
     -X PUT \
     -H "dapr-key-name: myCryptoKey" \
     -H "dapr-key-wrap-algorithm: aes-gcm" \ 
@@ -81,7 +81,7 @@ This endpoint lets you decrypt a value provided as a byte array using a specifie
 #### HTTP Request
 
 ```
-PUT curl http://localhost:3500/v1.0/crypto/<crypto-store-name>/decrypt
+PUT curl http://localhost:3500/v1.0-alpha1/crypto/<crypto-store-name>/decrypt
 ```
 
 #### URL Parameters
@@ -116,7 +116,7 @@ returns an array of bytes representing the decrypted payload.
 
 ### Examples
 ```bash
-curl http://localhost:3500/v1.0/crypto/myAzureKeyVault/decrypt \
+curl http://localhost:3500/v1.0-alpha1/crypto/myAzureKeyVault/decrypt \
     -X PUT
     -H "dapr-key-name: myCryptoKey"\
     -H "Content-Type: application/octet-stream" \


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Per a comment in Discord, the URLs in the Crypto API documentation are incorrect. The Cryptography API is still in alpha, so the various URLs should reflect the alpha variations. This PR corrects this.

## Issue reference

Issue brought up in [Discord](https://discord.com/channels/778680217417809931/1133104673558114439/1314481766316376157).
