### PR TITLE
feat(bindings-zeebe-command): Add support for passing variables to throw-error operation. (#3639)

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/zeebe-command.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/zeebe-command.md
@@ -675,7 +675,12 @@ To perform a `throw-error` operation, invoke the Zeebe command binding with a `P
   "data": {
     "jobKey": 2251799813686172,
     "errorCode": "product-fetch-error",
-    "errorMessage": "The product could not be fetched"
+    "errorMessage": "The product could not be fetched",
+    "variables": {
+      "productId": "some-product-id",
+      "productName": "some-product-name",
+      "productKey": "some-product-key"
+    }
   },
   "operation": "throw-error"
 }
@@ -686,6 +691,11 @@ The data parameters are:
 - `jobKey` - the unique job identifier, as obtained when activating the job
 - `errorCode` - the error code that will be matched with an error catch event
 - `errorMessage` - (optional) an error message that provides additional context
+- `variables` - (optional) JSON document that will instantiate the variables at the local scope of the
+	job's associated task; it must be a JSON object, as variables will be mapped in a
+	key-value fashion. e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+	"b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+	valid argument, as the root of the JSON document is an array and not an object.
 
 ##### Response
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This PR adds documentation for passing `variables` as optional data for the `throw-error` operation of the Zeebe Command binding.

## Issue reference

Please reference the issue this PR will close: 
https://github.com/dapr/components-contrib/issues/3639

Related PR: https://github.com/dapr/components-contrib/pull/3640
