### PR TITLE
Actors do not support gRPC today

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/actors/actors-features-concepts.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/actors/actors-features-concepts.md
@@ -57,7 +57,7 @@ This simplifies some choices, but also carries some consideration:
 
 ## Actor communication
 
-You can interact with Dapr to invoke the actor method by calling HTTP/gRPC endpoint.
+You can interact with Dapr to invoke the actor method by calling the HTTP endpoint.
 
 ```bash
 POST/GET/PUT/DELETE http://localhost:3500/v1.0/actors/<actorType>/<actorId>/<method/state/timers/reminders>


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Actors don't currently support gRPC, but the docs say they do. This updates the offending line to make clear that actors use HTTP (today).

## Issue reference
N/A
