### PR TITLE
update self-hosted-with-docker docs

### DIFF
--- a/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
+++ b/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
@@ -149,7 +149,7 @@ services:
     - type: tmpfs
       target: /data
       tmpfs:
-        size: "10000"
+        size: "64m"
   
   networks:
     hello-dapr: null


### PR DESCRIPTION
Fix scheduler arguments to prevent "no space left on device" error

## Description

~Adding the `--etcd-data-dir=/var/lock/dapr/scheduler` argument for the scheduler service in the `docker-compose` example.~

_Edit 20250211:_ Increase the `tmpfs` size from 10000 bytes to `64m`. Ealier change setting `--etcd-data-dir` was only a workaround.

Very simple change to resolve https://github.com/dapr/dapr/issues/8207

## Issue reference

https://github.com/dapr/dapr/issues/8207