### PR TITLE
.NET Job example tweak

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/jobs/howto-schedule-and-handle-triggered-jobs.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/jobs/howto-schedule-and-handle-triggered-jobs.md
@@ -78,13 +78,13 @@ var app = builder.Build();
 
 //Registers an endpoint to receive and process triggered jobs
 var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-app.MapDaprScheduledJobHandler((string jobName, DaprJobDetails jobDetails, ILogger logger, CancellationToken cancellationToken) => {
+app.MapDaprScheduledJobHandler((string jobName, ReadOnlyMemory<byte> jobPayload, ILogger logger, CancellationToken cancellationToken) => {
   logger?.LogInformation("Received trigger invocation for job '{jobName}'", jobName);
   switch (jobName)
   {
     case "prod-db-backup":
       // Deserialize the job payload metadata
-      var jobData = JsonSerializer.Deserialize<BackupJobData>(jobDetails.Payload);
+      var jobData = JsonSerializer.Deserialize<BackupJobData>(jobPayload);
       
       // Process the backup operation - we assume this is implemented elsewhere in your code
       await BackupDatabaseAsync(jobData, cancellationToken);


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

With the RC04 release of the Dapr .NET SDK, we've changed the expected signature of the Jobs invocation handler mildly. While the docs in dapr/dotnet-sdk were updated, I realized I needed to make a tweak to this example as well.

## Issue reference

N/A
