### PR TITLE
Move and rename SDK serialization doc

### DIFF
--- a/daprdocs/content/en/developing-applications/local-development/sdk-serialization.md
+++ b/daprdocs/content/en/developing-applications/local-development/sdk-serialization.md
@@ -1,9 +1,9 @@
 ---
 type: docs
 title: "Serialization in Dapr's SDKs"
-linkTitle: "Serialization"
+linkTitle: "SDK Serialization"
 description: "How Dapr serializes data within the SDKs"
-weight: 2000
+weight: 400
 aliases:
   - '/developing-applications/sdks/serialization/'
 ---


### PR DESCRIPTION
## Description

- Move SDK serialization doc to "Local Development" section
- Rename in TOC to "SDK serialization"

## Issue reference

PR will close: #4536 
