### PR TITLE
Update deprecated exporter

### DIFF
--- a/daprdocs/static/docs/open-telemetry-collector/open-telemetry-collector-jaeger.yaml
+++ b/daprdocs/static/docs/open-telemetry-collector/open-telemetry-collector-jaeger.yaml
@@ -19,8 +19,8 @@ data:
       zpages:
         endpoint: :55679
     exporters:
-      logging:
-        loglevel: debug
+      debug:
+        verbosity: detailed
       # Depending on where you want to export your trace, use the
       # correct OpenTelemetry trace exporter here.
       #


### PR DESCRIPTION

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [[learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work)](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [[Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

## Description

This PR updates the `open-telemetry-collector-jaeger.yaml` configuration file to address a deprecation error. The previous configuration used the deprecated `logging` exporter with the `loglevel` property, which has now been replaced with the `debug` exporter and the `verbosity` property.

**Changed:**

_From:_
```yaml
exporters:
  logging:
    loglevel: debug
```

_To:_
```yaml
exporters:
  debug:
    verbosity: detailed
```

This change resolves the error:
```
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

error decoding 'exporters': the logging exporter has been deprecated, use the debug exporter instead
2025/02/15 01:07:03 collector server run finished with error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

error decoding 'exporters': the logging exporter has been deprecated, use the debug exporter instead
```

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
