### PR TITLE
docs: also restart sidecar-injector

### DIFF
--- a/daprdocs/content/en/operations/security/mtls.md
+++ b/daprdocs/content/en/operations/security/mtls.md
@@ -231,6 +231,7 @@ kubectl rollout restart -n <DAPR_NAMESPACE> deployment/dapr-sentry
 ```bash
 kubectl rollout restart deploy/dapr-operator -n <DAPR_NAMESPACE>
 kubectl rollout restart statefulsets/dapr-placement-server -n <DAPR_NAMESPACE>
+kubectl rollout restart deploy/dapr-sidecar-injector -n <DAPR_NAMESPACE>
 ```
 
 4. Restart your Dapr applications to pick up the latest trust bundle.

--- a/daprdocs/content/en/operations/security/mtls.md
+++ b/daprdocs/content/en/operations/security/mtls.md
@@ -232,6 +232,7 @@ kubectl rollout restart -n <DAPR_NAMESPACE> deployment/dapr-sentry
 kubectl rollout restart deploy/dapr-operator -n <DAPR_NAMESPACE>
 kubectl rollout restart statefulsets/dapr-placement-server -n <DAPR_NAMESPACE>
 kubectl rollout restart deploy/dapr-sidecar-injector -n <DAPR_NAMESPACE>
+kubectl rollout restart deploy/dapr-scheduler-server -n <DAPR_NAMESPACE>
 ```
 
 4. Restart your Dapr applications to pick up the latest trust bundle.

--- a/daprdocs/content/en/operations/security/mtls.md
+++ b/daprdocs/content/en/operations/security/mtls.md
@@ -334,12 +334,13 @@ Example:
 dapr status -k
 
   NAME                   NAMESPACE    HEALTHY  STATUS   REPLICAS  VERSION   AGE  CREATED
-  dapr-sentry            dapr-system  True     Running  1         1.7.0     17d  2022-03-15 09:29.45
-  dapr-dashboard         dapr-system  True     Running  1         0.9.0     17d  2022-03-15 09:29.45
-  dapr-sidecar-injector  dapr-system  True     Running  1         1.7.0     17d  2022-03-15 09:29.45
-  dapr-operator          dapr-system  True     Running  1         1.7.0     17d  2022-03-15 09:29.45
-  dapr-placement-server  dapr-system  True     Running  1         1.7.0     17d  2022-03-15 09:29.45
-⚠  Dapr root certificate of your Kubernetes cluster expires in 2 days. Expiry date: Mon, 04 Apr 2022 15:01:03 UTC.
+  dapr-operator          dapr-system  True     Running  1         1.15.0    4m   2025-02-19 17:36.26
+  dapr-placement-server  dapr-system  True     Running  1         1.15.0    4m   2025-02-19 17:36.27
+  dapr-dashboard         dapr-system  True     Running  1         0.15.0    4m   2025-02-19 17:36.27
+  dapr-sentry            dapr-system  True     Running  1         1.15.0    4m   2025-02-19 17:36.26
+  dapr-scheduler-server  dapr-system  True     Running  3         1.15.0    4m   2025-02-19 17:36.27
+  dapr-sidecar-injector  dapr-system  True     Running  1         1.15.0    4m   2025-02-19 17:36.26
+⚠  Dapr root certificate of your Kubernetes cluster expires in 2 days. Expiry date: Mon, 04 Apr 2025 15:01:03 UTC.
  Please see docs.dapr.io for certificate renewal instructions to avoid service interruptions.
 ```
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

I had to [rotate my certificates using `kubectl`](https://docs.dapr.io/operations/security/mtls/#updating-root-or-issuer-certs-using-kubectl) because:
```bash
⌛  Starting certificate rotation
ℹ️  generating fresh certificates
ℹ️  Updating certifcates in your Kubernetes cluster
ℹ️  Dapr control plane version 1.13.0-mariner detected in namespace dapr-system
❌  certificate rotation failed: chart "dapr" version "1.13.0-mariner" not found in https://dapr.github.io/helm-charts repository
```

And I followed the documentation but missed `dapr-sidecar-injector`.  Before I restarted my sidecar injector deployment, I restarted my application and noticed that the sidecar injector did not insert sidecars, so my application broke.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
