### PR TITLE
Adds Warning that Actor Reminder Partition is not relevant by default

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/actors/actors-runtime-config.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/actors/actors-runtime-config.md
@@ -195,10 +195,6 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 
 {{< /tabs >}}
 
-## Next steps
-
-{{< button text="Enable actor reminder partitioning >>" page="howto-actors-partitioning.md" >}}
-
 ## Related links
 
 - Refer to the [Dapr SDK documentation and examples]({{< ref "developing-applications/sdks/#sdk-languages" >}}).

--- a/daprdocs/content/en/developing-applications/building-blocks/actors/howto-actors-partitioning.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/actors/howto-actors-partitioning.md
@@ -8,6 +8,13 @@ aliases:
   - "/developing-applications/building-blocks/actors/actors-background"
 ---
 
+{{% alert title="Warning" color="warning" %}}
+This feature is only relevant when using State Store Actor reminders, no longer enabled by default.
+As of v1.15, Dapr uses the far more performant [Scheduler Actor Reminders]({{< ref "scheduler.md#actor-reminders" >}}) by default.
+This page is only relevant if you are using the legacy State Store Actor reminders, enabled via setting the [`SchedulerReminders` feature flag]({{< ref "support-preview-features.md#current-preview-features" >}}) to false.
+It is highly recommended you continue using the Scheduler Actor Reminders feature.
+{{% /alert %}}
+
 [Actor reminders]({{< ref "actors-timers-reminders.md#actor-reminders" >}}) are persisted and continue to be triggered after sidecar restarts. Applications with multiple reminders registered can experience the following issues:
 
 - Low throughput on reminders registration and de-registration

--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-persisting-scheduler.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-persisting-scheduler.md
@@ -12,7 +12,7 @@ This means that there is no additional parameter required to run the scheduler s
 
 {{% alert title="Warning" color="warning" %}}
 The default storage size for the Scheduler is `1Gi`, which is likely not sufficient for most production deployments.
-Remember that the Scheduler is used for [Actor Reminders]({{< ref actors-timers-reminders.md >}}) & [Workflows]({{< ref workflow-overview.md >}}) when the [SchedulerReminders]({{< ref support-preview-features.md >}}) preview feature is enabled, and the [Jobs API]({{< ref jobs_api.md >}}).
+Remember that the Scheduler is used for [Actor Reminders]({{< ref actors-timers-reminders.md >}}) & [Workflows]({{< ref workflow-overview.md >}}), and the [Jobs API]({{< ref jobs_api.md >}}).
 You may want to consider reinstalling Dapr with a larger Scheduler storage of at least `16Gi` or more.
 For more information, see the [ETCD Storage Disk Size](#etcd-storage-disk-size) section below.
 {{% /alert %}}
@@ -30,8 +30,8 @@ error running scheduler: etcdserver: mvcc: database space exceeded
 ```
 
 Knowing the safe upper bound for your storage size is not an exact science, and relies heavily on the number, persistence, and the data payload size of your application jobs.
-The [Job API]({{< ref jobs_api.md >}}) and [Actor Reminders]({{< ref actors-timers-reminders.md >}}) (with the [SchedulerReminders]({{< ref support-preview-features.md >}}) preview feature enabled) transparently maps one to one to the usage of your applications.
-Workflows (when the [SchedulerReminders]({{< ref support-preview-features.md >}}) preview feature is enabled) create a large number of jobs as Actor Reminders, however these jobs are short lived- matching the lifecycle of each workflow execution.
+The [Job API]({{< ref jobs_api.md >}}) and [Actor Reminders]({{< ref actors-timers-reminders.md >}}) transparently maps one to one to the usage of your applications.
+Workflows preview feature is enabled) create a large number of jobs as Actor Reminders, however these jobs are short lived- matching the lifecycle of each workflow execution.
 The data payload of jobs created by Workflows is typically empty or small.
 
 The Scheduler uses Etcd as its storage backend database.


### PR DESCRIPTION
Updates the Actor Reminder Partition config page with a Warning that the feature is only relevant when using state store Actor Reminders which are no longer used by default. De-references this page from the actor rutime config page to softly hide it. Updates some verbiage around using Scheduler reminders & the feature gate as it's on by default.

This should be merged in dapr/docs@v1.15.