### PR TITLE
[Configuration] Update "keys" to "items" in example for consistency

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/configuration/howto-manage-configuration.md
@@ -263,7 +263,7 @@ using System.Threading.Tasks;
 using Dapr.Client;
 
 const string DAPR_CONFIGURATION_STORE = "configstore";
-var CONFIGURATION_KEYS = new List<string> { "orderId1", "orderId2" };
+var CONFIGURATION_ITEMS = new List<string> { "orderId1", "orderId2" };
 var client = new DaprClientBuilder().Build();
 
 // Subscribe for configuration changes


### PR DESCRIPTION
## Description

Update for consistency - other SDK language examples use 'CONFIGURATION_ITEMS' terminology, updating .NET SDK to use the same.

## Issue reference

PR will close: #4532 
