### PR TITLE
Remove specific port number, replace with placeholder

### DIFF
--- a/daprdocs/content/en/reference/api/jobs_api.md
+++ b/daprdocs/content/en/reference/api/jobs_api.md
@@ -20,7 +20,7 @@ With the jobs API, you can schedule jobs and tasks in the future.
 Schedule a job with a name. Jobs are scheduled based on the clock of the server where the Scheduler service is running. The timestamp is not converted to UTC. You can provide the timezone with the timestamp in RFC3339 format to specify which timezone you'd like the job to adhere to. If no timezone is provided, the server's local time is used.
 
 ```
-POST http://localhost:3500/v1.0-alpha1/jobs/<name>
+POST http://localhost:<daprPort>/v1.0-alpha1/jobs/<name>
 ```
 
 ### URL parameters
@@ -100,7 +100,7 @@ $ curl -X POST \
 Get a job from its name.
 
 ```
-GET http://localhost:3500/v1.0-alpha1/jobs/<name>
+GET http://localhost:<daprPort>/v1.0-alpha1/jobs/<name>
 ```
 
 ### URL parameters
@@ -138,7 +138,7 @@ $ curl -X GET http://localhost:3500/v1.0-alpha1/jobs/jobforjabba -H "Content-Typ
 Delete a named job.
 
 ```
-DELETE http://localhost:3500/v1.0-alpha1/jobs/<name>
+DELETE http://localhost:<daprPort>/v1.0-alpha1/jobs/<name>
 ```
 
 ### URL parameters

--- a/daprdocs/content/en/reference/api/workflow_api.md
+++ b/daprdocs/content/en/reference/api/workflow_api.md
@@ -13,7 +13,7 @@ Dapr provides users with the ability to interact with workflows through its buil
 Start a workflow instance with the given name and optionally, an instance ID.
 
 ```
-POST http://localhost:3500/v1.0/workflows/<workflowComponentName>/<workflowName>/start[?instanceID=<instanceID>]
+POST http://localhost:<daprPort>/v1.0/workflows/<workflowComponentName>/<workflowName>/start[?instanceID=<instanceID>]
 ```
 
 Note that workflow instance IDs can only contain alphanumeric characters, underscores, and dashes.
@@ -53,7 +53,7 @@ The API call will provide a response similar to this:
 Terminate a running workflow instance with the given name and instance ID.
 
 ```
-POST http://localhost:3500/v1.0/workflows/<workflowComponentName>/<instanceId>/terminate
+POST http://localhost:<daprPort>/v1.0/workflows/<workflowComponentName>/<instanceId>/terminate
 ```
 
 {{% alert title="Note" color="primary" %}}
@@ -87,7 +87,7 @@ This API does not return any content.
 For workflow components that support subscribing to external events, such as the Dapr Workflow engine, you can use the following "raise event" API to deliver a named event to a specific workflow instance.
 
 ```
-POST http://localhost:3500/v1.0/workflows/<workflowComponentName>/<instanceID>/raiseEvent/<eventName>
+POST http://localhost:<daprPort>/v1.0/workflows/<workflowComponentName>/<instanceID>/raiseEvent/<eventName>
 ```
 
 {{% alert title="Note" color="primary" %}}
@@ -120,7 +120,7 @@ None.
 Pause a running workflow instance.
 
 ```
-POST http://localhost:3500/v1.0/workflows/<workflowComponentName>/<instanceId>/pause
+POST http://localhost:<daprPort>/v1.0/workflows/<workflowComponentName>/<instanceId>/pause
 ```
 
 ### URL parameters
@@ -147,7 +147,7 @@ None.
 Resume a paused workflow instance.
 
 ```
-POST http://localhost:3500/v1.0/workflows/<workflowComponentName>/<instanceId>/resume
+POST http://localhost:<daprPort>/v1.0/workflows/<workflowComponentName>/<instanceId>/resume
 ```
 
 ### URL parameters
@@ -174,7 +174,7 @@ None.
 Purge the workflow state from your state store with the workflow's instance ID.
 
 ```
-POST http://localhost:3500/v1.0/workflows/<workflowComponentName>/<instanceId>/purge
+POST http://localhost:<daprPort>/v1.0/workflows/<workflowComponentName>/<instanceId>/purge
 ```
 
 {{% alert title="Note" color="primary" %}}
@@ -205,7 +205,7 @@ None.
 Get information about a given workflow instance.
 
 ```
-GET http://localhost:3500/v1.0/workflows/<workflowComponentName>/<instanceId>
+GET http://localhost:<daprPort>/v1.0/workflows/<workflowComponentName>/<instanceId>
 ```
 
 ### URL parameters


### PR DESCRIPTION
## Description

HTTP API methods had an example port that was incorrect. Replaced this with `daprPort` placeholder, like other API docs

## Issue reference

PR will close: #4519 
