### PR TITLE
Update kubernetes-persisting-scheduler.md

### DIFF
--- a/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-persisting-scheduler.md
+++ b/daprdocs/content/en/operations/hosting/kubernetes/kubernetes-persisting-scheduler.md
@@ -69,6 +69,14 @@ helm upgrade --install dapr dapr/dapr \
 {{% /codetab %}}
 {{< /tabs >}}
 
+{{% alert title="Note" color="primary" %}}
+For storage providers that do NOT support dynamic volume expansion: If Dapr has ever been installed on the cluster before, the Scheduler's Persistent Volume Claims must be manually uninstalled in order for new ones with increased storage size to be created.
+```bash
+kubectl delete pvc -n dapr-system dapr-scheduler-data-dir-dapr-scheduler-server-0 dapr-scheduler-data-dir-dapr-scheduler-server-1 dapr-scheduler-data-dir-dapr-scheduler-server-2
+```
+Persistent Volume Claims are not deleted automatically with an [uninstall]({{< ref dapr-uninstall.md >}}). This is a deliberate safety measure to prevent accidental data loss.
+{{% /alert %}}
+
 #### Increase existing Scheduler Storage Size
 
 {{% alert title="Warning" color="warning" %}}


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Using local `rancher.io/local-path` storage provisioner, that didn't support volume expansion, I was receiving this issue when increasing size via helm args:
`Warning  ExternalExpanding  4m31s (x2 over 19m)  volume_expand  waiting for an external controller to expand this PVC`.

I realized I had to manually delete PVCs as they couldn't be expanded, but also don't automatically delete with uninstalling dapr.

## Issue reference

N/A
