### PR TITLE
Update sidecar.md - Add missing sample argument for Dapr sidecar app port config sample

### DIFF
--- a/daprdocs/content/en/concepts/dapr-services/sidecar.md
+++ b/daprdocs/content/en/concepts/dapr-services/sidecar.md
@@ -52,7 +52,7 @@ For a detailed list of all available arguments run `daprd --help` or see this [t
 1. Specify the port your application is listening to
 
    ```bash
-   daprd --app-id --app-port 5000
+   daprd --app-id myapp --app-port 5000
    ```
 
 1. If you are using several custom resources and want to specify the location of the resource definition files, use the `--resources-path` argument:


### PR DESCRIPTION
Add missing sample argument for Dapr sidecar app port config sample

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

- Add missing sample argument for Dapr sidecar app port config sample

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
