### PR TITLE
Added .NET streaming subscription example to pubsub page

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/subscription-methods.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/subscription-methods.md
@@ -203,7 +203,7 @@ As messages are sent to the given message handler code, there is no concept of r
 
 The example below shows the different ways to stream subscribe to a topic.
 
-{{< tabs .NET Python Go >}}
+{{< tabs ".NET" Python Go >}}
 
 {{% codetab %}}
 

--- a/daprdocs/content/en/developing-applications/building-blocks/pubsub/subscription-methods.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/pubsub/subscription-methods.md
@@ -203,7 +203,55 @@ As messages are sent to the given message handler code, there is no concept of r
 
 The example below shows the different ways to stream subscribe to a topic.
 
-{{< tabs Python Go >}}
+{{< tabs .NET Python Go >}}
+
+{{% codetab %}}
+
+You can use the `SubscribeAsync` method on the `DaprPublishSubscribeClient` to configure the message handler to use to pull messages from the stream.
+
+```c#
+using System.Text;
+using Dapr.Messaging.PublishSubscribe;
+using Dapr.Messaging.PublishSubscribe.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddDaprPubSubClient();
+var app = builder.Build();
+
+var messagingClient = app.Services.GetRequiredService<DaprPublishSubscribeClient>();
+
+//Create a dynamic streaming subscription and subscribe with a timeout of 30 seconds and 10 seconds for message handling
+var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+var subscription = await messagingClient.SubscribeAsync("pubsub", "myTopic",
+    new DaprSubscriptionOptions(new MessageHandlingPolicy(TimeSpan.FromSeconds(10), TopicResponseAction.Retry)),
+    HandleMessageAsync, cancellationTokenSource.Token);
+
+await Task.Delay(TimeSpan.FromMinutes(1));
+
+//When you're done with the subscription, simply dispose of it
+await subscription.DisposeAsync();
+return;
+
+//Process each message returned from the subscription
+Task<TopicResponseAction> HandleMessageAsync(TopicMessage message, CancellationToken cancellationToken = default)
+{
+    try
+    {
+        //Do something with the message
+        Console.WriteLine(Encoding.UTF8.GetString(message.Data.Span));
+        return Task.FromResult(TopicResponseAction.Success);
+    }
+    catch
+    {
+        return Task.FromResult(TopicResponseAction.Retry);
+    }
+}
+```
+
+[Learn more about streaming subscriptions using the .NET SDK client.]({{< ref "dotnet-messaging-pubsub-howto.md" >}})
+
+{{% /codetab %}}
+
 
 {{% codetab %}}
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The link should point to the docs in the dapr/dotnet-sdk (the name is right at least), but I'm not sure how to validate that it's pointing there correctly locally.

Validated with Hannah about how to do this correctly and it looks like I lucked out and did it the right way the first time.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
