### PR TITLE
Added local echo conversation component

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-conversation/local-echo.md
+++ b/daprdocs/content/en/reference/components-reference/supported-conversation/local-echo.md
@@ -1,0 +1,29 @@
+﻿---
+type: docs
+title: "Local Testing"
+linkTitle: "Echo"
+description: Detailed information on the echo conversation component used for local testing
+---
+
+## Component format
+
+A Dapr `conversation.yaml` component file has the following structure:
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: echo
+spec:
+  type: conversation.echo
+  version: v1
+```
+
+{{% alert title="Information" color="warning" %}}
+This component is only meant for local validation and testing of a Conversation implementation and does not
+actually send the data to any LLM endpoints to perform evaluation.
+{{% /alert %}}
+
+## Related links
+
+- [Conversation API overview]({{< ref conversation-overview.md >}})

--- a/daprdocs/content/en/reference/components-reference/supported-conversation/local-echo.md
+++ b/daprdocs/content/en/reference/components-reference/supported-conversation/local-echo.md
@@ -20,7 +20,7 @@ spec:
 ```
 
 {{% alert title="Information" color="warning" %}}
-This component is only meant for local validation and testing of a Conversation implementation and does not
+This component is only meant for local validation and testing of a Conversation component implementation. It does not actually send the data to any LLM but rather echos the input back directly.
 actually send the data to any LLM endpoints to perform evaluation.
 {{% /alert %}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-conversation/local-echo.md
+++ b/daprdocs/content/en/reference/components-reference/supported-conversation/local-echo.md
@@ -21,7 +21,6 @@ spec:
 
 {{% alert title="Information" color="warning" %}}
 This component is only meant for local validation and testing of a Conversation component implementation. It does not actually send the data to any LLM but rather echos the input back directly.
-actually send the data to any LLM endpoints to perform evaluation.
 {{% /alert %}}
 
 ## Related links

--- a/daprdocs/data/components/conversation/generic.yaml
+++ b/daprdocs/data/components/conversation/generic.yaml
@@ -25,6 +25,6 @@
   since: "1.15"
 - component: Local echo
   link: local-echo
-  state: Alpha
+  state: Stable
   version: v1
   since: "1.15"

--- a/daprdocs/data/components/conversation/generic.yaml
+++ b/daprdocs/data/components/conversation/generic.yaml
@@ -23,3 +23,8 @@
   state: Alpha
   version: v1
   since: "1.15"
+- component: Local echo
+  link: local-echo
+  state: Alpha
+  version: v1
+  since: "1.15"


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Answered a question for a contributor about the Conversation local echo component and realized it was lacking a page in the reference documentation. In fact, it appears to only be mentioned in passing [here](https://docs.dapr.io/developing-applications/building-blocks/conversation/howto-conversation-layer/#set-up-the-conversation-component). As it's a created component and useful for local testing, I've gone ahead and adding it to the components references.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
