### PR TITLE
Clarify difference between scrubPII in the input request vs the content field

### DIFF
--- a/daprdocs/content/en/reference/api/conversation_api.md
+++ b/daprdocs/content/en/reference/api/conversation_api.md
@@ -32,7 +32,7 @@ POST http://localhost:<daprPort>/v1.0-alpha1/conversation/<llm-name>/converse
 | --------- | ----------- |
 | `inputs` | Inputs for the conversation. Multiple inputs at one time are supported. Required |
 | `cacheTTL` | A time-to-live value for a prompt cache to expire. Uses Golang duration format. Optional |
-| `scrubPII` | A boolean value to enable obfuscation of sensitive information returning from the LLM. Optional |
+| `scrubPII` | A boolean value to enable obfuscation of sensitive information returning from the LLM. Set this value if all PII (across contents) in the request needs to be scrubbed. Optional |
 | `temperature` | A float value to control the temperature of the model. Used to optimize for consistency and creativity. Optional |
 | `metadata` | [Metadata](#metadata) passed to conversation components. Optional |
 
@@ -42,7 +42,7 @@ POST http://localhost:<daprPort>/v1.0-alpha1/conversation/<llm-name>/converse
 | --------- | ----------- |
 | `content` | The message content to send to the LLM. Required |
 | `role` | The role for the LLM to assume. Possible values: 'user', 'tool', 'assistant' |
-| `scrubPII` | A boolean value to enable obfuscation of sensitive information present in the content field. Optional |
+| `scrubPII` | A boolean value to enable obfuscation of sensitive information present in the content field. Set this value if PII for this specific content needs to be scrubbed exclusively. Optional |
 
 ### Request content example
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Provided a bit more clarification about how scrubPII in Input request is different from the scrubPII in the content field

## Issue reference
Please reference the issue this PR will close: #4588
