### PR TITLE
Adds a new component config option for Redis PubSub

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
@@ -69,7 +69,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | failover           | N         | Property to enabled failover configuration. Needs sentinalMasterName to be set. Defaults to `"false"` | `"true"`, `"false"`
 | sentinelMasterName | N         | The sentinel master name. See [Redis Sentinel Documentation](https://redis.io/docs/manual/sentinel/) | `""`,  `"127.0.0.1:6379"`
 | maxLenApprox        | N        | Maximum number of items inside a stream.The old entries are automatically evicted when the specified length is reached, so that the stream is left at a constant size. Defaults to unlimited. | `"10000"`
-| minIDApprox        | N        | Minimum ID threshold for the stream. Entries with IDs smaller than the specified threshold are evicted, keeping the stream trimmed to only contain entries with IDs greater than or equal to this value. This can be used for time-based eviction since Redis stream IDs are in the format {timestamp-sequence}, where timestamp is in milliseconds since epoch. Defaults to none. | `"1742397526022-0"`
+| streamTTL        | N        | TTL duration for stream entries. Entries older than this duration will be evicted. This is an approximate value, as it's implemented using Redis stream's `MINID` trimming with the '~' modifier. The actual retention may include slightly more entries than strictly defined by the TTL, as Redis optimizes the trimming operation for efficiency by potentially keeping some additional entries. | `"30d"`
 
 ## Create a Redis instance
 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
@@ -69,6 +69,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | failover           | N         | Property to enabled failover configuration. Needs sentinalMasterName to be set. Defaults to `"false"` | `"true"`, `"false"`
 | sentinelMasterName | N         | The sentinel master name. See [Redis Sentinel Documentation](https://redis.io/docs/manual/sentinel/) | `""`,  `"127.0.0.1:6379"`
 | maxLenApprox        | N        | Maximum number of items inside a stream.The old entries are automatically evicted when the specified length is reached, so that the stream is left at a constant size. Defaults to unlimited. | `"10000"`
+| minIDApprox        | N        | Minimum ID threshold for the stream. Entries with IDs smaller than the specified threshold are evicted, keeping the stream trimmed to only contain entries with IDs greater than or equal to this value. This can be used for time-based eviction since Redis stream IDs are in the format {timestamp-sequence}, where timestamp is in milliseconds since epoch. Defaults to none. | `"1742397526022-0"`
 
 ## Create a Redis instance
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The change is related to this PR: https://github.com/dapr/components-contrib/pull/3710

Adding the option to trim Redis streams based on timestamp. When `minIDApprox` is specified in the component file entries with IDs smaller than the specified threshold are evicted, keeping the stream trimmed to only contain entries with IDs greater than or equal to this value. 
This can be used for time-based eviction since Redis stream IDs are in the format {timestamp-sequence}, where timestamp is in milliseconds since epoch. 

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
