### PR TITLE
Fixed spelling mistake in secret-scope.md

### DIFF
--- a/daprdocs/content/en/operations/configuration/secret-scope.md
+++ b/daprdocs/content/en/operations/configuration/secret-scope.md
@@ -7,8 +7,8 @@ description: "Define secret scopes by augmenting the existing configuration reso
 description: "Define secret scopes by augmenting the existing configuration resource with restrictive permissions."
 ---
 
-In addition to [scoping which applications can access a given component]({{< ref "component-scopes.md">}}), you can also scop a named secret store component to one or more secrets for an application. By defining `allowedSecrets` and/or `deniedSecrets` lists, you restrict applications to access only specific secrets.
-In addition to [scoping which applications can access a given component]({{< ref "component-scopes.md">}}), you can also scop a named secret store component to one or more secrets for an application. By defining `allowedSecrets` and/or `deniedSecrets` lists, you restrict applications to access only specific secrets.
+In addition to [scoping which applications can access a given component]({{< ref "component-scopes.md">}}), you can also scope a named secret store component to one or more secrets for an application. By defining `allowedSecrets` and/or `deniedSecrets` lists, you restrict applications to access only specific secrets.
+In addition to [scoping which applications can access a given component]({{< ref "component-scopes.md">}}), you can also scope a named secret store component to one or more secrets for an application. By defining `allowedSecrets` and/or `deniedSecrets` lists, you restrict applications to access only specific secrets.
 
 For more information about configuring a Configuration resource:
 - [Configuration overview]({{< ref configuration-overview.md >}})


### PR DESCRIPTION
"Scop" fixed to "Scope"

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixed a spelling mistake in secret-scope.md by changing two instances of the word "scop" to "scope".

## Issue reference

No issue reference
