### PR TITLE
change app insights example from key to connection string

### DIFF
--- a/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-appinsights.md
+++ b/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-appinsights.md
@@ -11,7 +11,7 @@ Dapr integrates with [OpenTelemetry (OTEL) Collector](https://github.com/open-te
 ## Prerequisites
 
 - [Install Dapr on Kubernetes]({{< ref kubernetes >}})
-- [Set up an App Insights resource](https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource) and make note of your App Insights instrumentation key.
+- [Set up an App Insights resource](https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource) and make note of your App Insights connection string.
 
 ## Set up OTEL Collector to push to your App Insights instance
 
@@ -19,7 +19,7 @@ To push events to your App Insights instance, install the OTEL Collector to your
 
 1. Check out the [`open-telemetry-collector-appinsights.yaml`](/docs/open-telemetry-collector/open-telemetry-collector-appinsights.yaml) file. 
 
-1. Replace the `<INSTRUMENTATION-KEY>` placeholder with your App Insights instrumentation key.
+1. Replace the `<CONNECTION_STRING>` placeholder with your App Insights connection string.
 
 1. Apply the configuration with: 
 

--- a/daprdocs/static/docs/open-telemetry-collector/open-telemetry-collector-appinsights.yaml
+++ b/daprdocs/static/docs/open-telemetry-collector/open-telemetry-collector-appinsights.yaml
@@ -20,8 +20,7 @@ data:
       debug:
         verbosity: basic
       azuremonitor:
-        endpoint: "https://dc.services.visualstudio.com/v2/track"
-        instrumentation_key: "<INSTRUMENTATION-KEY>"
+        connection_string: "<CONNECTION_STRING>"
         # maxbatchsize is the maximum number of items that can be
         # queued before calling to the configured endpoint
         maxbatchsize: 100


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Changes the application insights otel collector example from insights key to connection string

## Issue reference
#4594 