### PR TITLE
Update self-hosted-with-docker.md - make `scheduler` running

### DIFF
--- a/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
+++ b/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
@@ -141,15 +141,12 @@ services:
 
   scheduler:
     image: "daprio/dapr"
-    command: ["./scheduler", "--port", "50007"]
+    command: ["./scheduler", "--port", "50007", "--etcd-data-dir", "/data"]
     ports:
       - "50007:50007"
-    # WARNING - This is a tmpfs volume, your state will not be persisted across restarts
+    user: root
     volumes:
-    - type: tmpfs
-      target: /data
-      tmpfs:
-        size: "64m"
+    - "./dapr-etcd-data/:/data"
   
   networks:
     hello-dapr: null

--- a/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
+++ b/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
@@ -135,13 +135,13 @@ services:
   ... # Deploy other daprized services and components (i.e. Redis)
 
   placement:
-    image: "daprio/dapr"
+    image: "daprio/placement"
     command: ["./placement", "--port", "50006"]
     ports:
       - "50006:50006"
 
   scheduler:
-    image: "daprio/dapr"
+    image: "daprio/scheduler"
     command: ["./scheduler", "--port", "50007", "--etcd-data-dir", "/data"]
     ports:
       - "50007:50007"

--- a/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
+++ b/daprdocs/content/en/operations/hosting/self-hosted/self-hosted-with-docker.md
@@ -123,6 +123,7 @@ services:
      "--app-id", "nodeapp",
      "--app-port", "3000",
      "--placement-host-address", "placement:50006", # Dapr's placement service can be reach via the docker DNS entry
+     "--scheduler-host-address", "scheduler:50007", # Dapr's scheduler service can be reach via the docker DNS entry
      "--resources-path", "./components"
      ]
     volumes:


### PR DESCRIPTION
Issue found while trying to deploy `scheduler` via Docker Compose, like discussed there: https://github.com/dapr/dapr/issues/8604#issuecomment-2752469527.

Also, `--scheduler-host-address` was required on the Sidecar to make a Dapr Workflow working.

Also using smaller and dedicated container images for `scheduler` and `placement`. Reducing container images size uncompressed on disk (Saving 437-44.1-56.6=336.3 MB):
```
ghcr.io/dapr/placement  latest          a68b826f3920  2 weeks ago  44.1 MB
ghcr.io/dapr/scheduler  latest          7fa8825f4275  2 weeks ago  56.6 MB
ghcr.io/dapr/dapr       latest          9f2f74136c57  2 weeks ago  437 MB
```