### PR TITLE
Troubleshoot port conflicts during `dapr init` on Windows

### DIFF
--- a/daprdocs/content/en/operations/troubleshooting/common_issues.md
+++ b/daprdocs/content/en/operations/troubleshooting/common_issues.md
@@ -291,3 +291,21 @@ kubectl config get-users
 ```
 
 You may learn more about webhooks [here](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
+
+## Ports not available during `dapr init`
+You might encounter the following error on Windows after attempting to execute `dapr init`:
+
+> PS C:\Users\You> dapr init
+Making the jump to hyperspace...
+Container images will be pulled from Docker Hub
+Installing runtime version 1.14.4
+Downloading binaries and setting up components...
+docker: Error response from daemon: Ports are not available: exposing port TCP 0.0.0.0:52379 -> 0.0.0.0:0: listen tcp4 0.0.0.0:52379: bind: An attempt was made to access a socket in a way forbidden by its access permissions.
+
+To resolve this error, open a command prompt in an elevated terminal and run:
+
+```bash
+nat stop winnat
+dapr init
+net start winnat
+```


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [X] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added troubleshooting step to resolve port conflicts during `dapr init` on Windows

## Issue reference

Please reference the issue this PR will close: [https://github.com/dapr/cli/issues/1464](https://github.com/dapr/cli/issues/1464)
