### PR TITLE
Fixed typo -> "loggings" to "logging"

### DIFF
--- a/daprdocs/content/en/operations/observability/logging/_index.md
+++ b/daprdocs/content/en/operations/observability/logging/_index.md
@@ -3,6 +3,6 @@ type: docs
 title: "Logging"
 linkTitle: "Logging"
 weight: 400
-description: "How to setup loggings for Dapr sidecar, and your application"
+description: "How to setup logging for Dapr sidecar, and your application"
 ---
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixed typo from "loggings" to "logging"

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
