### PR TITLE
Typo -> "outputs" to "inputs" on Binding input documentation

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/bindings/howto-triggers.md
@@ -113,7 +113,7 @@ Configure your application to receive incoming events. If you're using HTTP, you
 - Listen on a `POST` endpoint with the name of the binding, as specified in `metadata.name` in the `binding.yaml` file. 
 - Verify your application allows Dapr to make an `OPTIONS` request for this endpoint.
 
-Below are code examples that leverage Dapr SDKs to demonstrate an output binding.
+Below are code examples that leverage Dapr SDKs to demonstrate an input binding.
 
 {{< tabs ".NET" Java Python Go JavaScript>}}
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

On the page covering binding inputs (triggers), the text erroneously suggested that the following examples demonstrated output bindings.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
