### PR TITLE
Added s3 tags metadata exmaple

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/s3.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/s3.md
@@ -170,15 +170,16 @@ To perform a create operation, invoke the AWS S3 binding with a `POST` method an
   "operation": "create",
   "data": "YOUR_CONTENT",
   "metadata": { 
-    "storageClass": "STANDARD_IA"
+    "storageClass": "STANDARD_IA",
+    "tags": "env=dev,owner=user123"
   }
 }
 ```
 
-For example you can provide a storage class while using the `create` operation with a Linux curl command
+For example you can provide a storage class or tags while using the `create` operation with a Linux curl command
 
 ```bash
-curl -d '{ "operation": "create", "data": "YOUR_BASE_64_CONTENT", "metadata": { "storageClass": "STANDARD_IA" } }' /
+curl -d '{ "operation": "create", "data": "YOUR_BASE_64_CONTENT", "metadata": { "storageClass": "STANDARD_IA", "tags": "project=sashimi,year=2024" } }' /
 http://localhost:<dapr-port>/v1.0/bindings/<binding-name>
 ```
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added documentation for the new tags metadata field in the S3 output binding.
This allows users to specify AWS S3 object tags when creating or uploading objects through Dapr.
An example is included to show how to format the tags string in the metadata when invoking the binding.

## Issue reference

<!--Please reference the issue this PR will close: #4633 -->
