### PR TITLE
docs: update gcp firestore docs

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-firestore.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-firestore.md
@@ -23,6 +23,8 @@ spec:
   metadata:
   - name: project_id
     value: <REPLACE-WITH-PROJECT-ID> # Required.
+  - name: type 
+    value: <REPLACE-WITH-CREDENTIALS-TYPE> # Required.
   - name: endpoint # Optional. 
     value: "http://localhost:8432"
   - name: private_key_id
@@ -45,8 +47,6 @@ spec:
     value: <REPLACE-WITH-ENTITY-KIND> # Optional. default: "DaprState"
   - name: noindex
     value: <REPLACE-WITH-BOOLEAN> # Optional. default: "false"
-  - name: type 
-    value: <REPLACE-WITH-CREDENTIALS-TYPE> # Deprecated.
 ```
 
 {{% alert title="Warning" color="warning" %}}
@@ -58,6 +58,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | Field              | Required | Details | Example |
 |--------------------|:--------:|---------|---------|
 | project_id         | Y        | The ID of the GCP project to use | `"project-id"`
+| type                 | Y      | The credentials type | `"service_account"`
 | endpoint       | N  | GCP endpoint for the component to use. Only used for local development with (for example) [GCP Datastore Emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator). The `endpoint` is unnecessary when running against the GCP production API. | `"localhost:8432"`
 | private_key_id     | N        | The ID of the prvate key to use  | `"private-key-id"`
 | privateKey         | N |  If using explicit credentials, this field should contain the `private_key` field from the service account json | `-----BEGIN PRIVATE KEY-----MIIBVgIBADANBgkqhkiG9w0B`
@@ -69,7 +70,6 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | client_x509_cert_url | N      | The client certificate URL | `"https://www.googleapis.com/robot/v1/metadata/x509/x"`
 | entity_kind          | N      | The entity name in Filestore. Defaults to `"DaprState"` | `"DaprState"`
 | noindex              | N      | Whether to disable indexing of state entities. Use this setting if you encounter Firestore index size limitations. Defaults to `"false"` | `"true"`
-| type                 | N       | **DEPRECATED** The credentials type | `"serviceaccount"`
 
 
 ## GCP Credentials


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This pull request updates the documentation for setting up Firestore as a supported state store in Dapr. The key changes include the addition of a new required metadata field for credentials type (`type`) and the deprecation of the previous usage of this field. The documentation now reflects these updates in examples and field descriptions.

## Issue reference

https://github.com/dapr/docs/issues/4711
