### PR TITLE
docs(bindings/aws.kinesis): document new  metadata for custom endpoin…

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kinesis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kinesis.md
@@ -57,7 +57,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | `secretKey`          | Y        | Output | The AWS Secret Access Key to access this resource                       | `"secretAccessKey"` |
 | `sessionToken`       | N        | Output | The AWS session token to use                                            | `"sessionToken"`    |
 | `direction`       | N        | Input/Output | The direction of the binding                                            | `"input"`, `"output"`, `"input, output"`    |
-| `endpoint`        | N           | Input | Custom endpoint for Kinesis and DynamoDB (e.g., for LocalStack support) | `"http://localhost:4566"` |
+| `endpoint`        | N        | Input | Custom endpoint for Kinesis and DynamoDB (e.g., for LocalStack support) | `"http://localhost:4566"` |
 
 
 {{% alert title="Important" color="warning" %}}

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kinesis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kinesis.md
@@ -57,7 +57,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | `secretKey`          | Y        | Output | The AWS Secret Access Key to access this resource                       | `"secretAccessKey"` |
 | `sessionToken`       | N        | Output | The AWS session token to use                                            | `"sessionToken"`    |
 | `direction`       | N        | Input/Output | The direction of the binding                                            | `"input"`, `"output"`, `"input, output"`    |
-| `endpoint`        | N        | Input | Custom endpoint for Kinesis and DynamoDB (e.g., for LocalStack support) | `"http://localhost:4566"` |
+| `endpoint`        | N        | Input | Custom endpoint for Kinesis and DynamoDB (for example to enable AWS LocalStack support) | `"http://localhost:4566"` |
 
 
 {{% alert title="Important" color="warning" %}}

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kinesis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kinesis.md
@@ -38,6 +38,8 @@ spec:
     value: "*****************"
   - name: direction
     value: "input, output"
+  - name: endpoint
+    value: "http://localhost:4566" # Optional: Custom endpoint (e.g. for LocalStack)  
 ```
 {{% alert title="Warning" color="warning" %}}
 The above example uses secrets as plain strings. It is recommended to use a secret store for the secrets as described [here]({{< ref component-secrets.md >}}).
@@ -55,6 +57,8 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | `secretKey`          | Y        | Output | The AWS Secret Access Key to access this resource                       | `"secretAccessKey"` |
 | `sessionToken`       | N        | Output | The AWS session token to use                                            | `"sessionToken"`    |
 | `direction`       | N        | Input/Output | The direction of the binding                                            | `"input"`, `"output"`, `"input, output"`    |
+| `endpoint`        | N           | Input | Custom endpoint for Kinesis and DynamoDB (e.g., for LocalStack support) | `"http://localhost:4566"` |
+
 
 {{% alert title="Important" color="warning" %}}
 When running the Dapr sidecar (daprd) with your application on EKS (AWS Kubernetes), if you're using a node/pod that has already been attached to an IAM policy defining access to AWS resources, you **must not** provide AWS access-key, secret-key, and tokens in the definition of the component spec you're using.  


### PR DESCRIPTION
…t support e.g. LocalStack (see components-contrib#3931)

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added documentation for the endpoint metadata property in the AWS Kinesis binding component, which allows overriding the default AWS endpoint. This is particularly useful for testing locally with tools like LocalStack.

This aligns with the code changes made in [components-contrib#3931](https://github.com/dapr/components-contrib/pull/3931), which introduced endpoint support in the Kinesis binding.

## Issue reference

Linked to components-contrib PR: [dapr/components-contrib#3931](https://github.com/dapr/components-contrib/pull/3931)
