### PR TITLE
Mention Dapr Agents slide deck on presentations page

### DIFF
--- a/daprdocs/content/en/contributing/presentations.md
+++ b/daprdocs/content/en/contributing/presentations.md
@@ -9,9 +9,10 @@ description: How to give a presentation on Dapr and examples
 We encourage community members to give presentations on Dapr. To get you started quickly, we offer two PowerPoint files:
 
 - *dapr-slidedeck.pptx*, this is a 150+ page slide deck and contains; an overview of Dapr, all of its building block APIs, cross-cutting concerns, hosting options, and assets to create your own architecture diagrams.
-- *dapr-workflow.pptx*, this is a dedicated slide deck about Dapr workflow and contains; durable execution concept, workflow authoring, workflow patterns, workflow management, and challenges & tips.
+- *dapr-workflow-slidedeck.pptx*, this is a dedicated slide deck about Dapr Workflow and contains; durable execution concept, workflow authoring, workflow patterns, workflow management, and challenges & tips.
+- *dapr-agents-slidedeck.pptx*, this is a dedicated slide deck about Dapr Agents and contains; AI agents explanation, Dapr Agent types, multi-agent systems, and agentic patterns.
 
-There is a downloadable zip file contains both slide decks.
+There is a downloadable zip file that contains all slide decks.
 
 {{< button text="Download the Dapr Presentation Decks" link="/presentations/dapr-slidedecks.zip" >}}
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The Dapr Agents slidedeck is already merged [with PR 4741](https://github.com/dapr/docs/pull/4741).  This PR only updates the presentation page.

## Issue reference

#4759
