### PR TITLE
Fix typo in net command

### DIFF
--- a/daprdocs/content/en/operations/troubleshooting/common_issues.md
+++ b/daprdocs/content/en/operations/troubleshooting/common_issues.md
@@ -305,7 +305,7 @@ docker: Error response from daemon: Ports are not available: exposing port TCP 0
 To resolve this error, open a command prompt in an elevated terminal and run:
 
 ```bash
-nat stop winnat
+net stop winnat
 dapr init
 net start winnat
 ```


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixed a small typo `nat` -> `net`
