### PR TITLE
use correct qutoes for apiType in OpenAi converastion api

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-conversation/openai.md
+++ b/daprdocs/content/en/reference/components-reference/supported-conversation/openai.md
@@ -26,7 +26,7 @@ spec:
   - name: cacheTTL
     value: 10m
   # - name: apiType # Optional
-  #   value: `azure`
+  #   value: 'azure'
   # - name: apiVersion # Optional
   #   value: '2025-01-01-preview'
 ```


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Use the correct single quotes for the `apiType` example 

## Issue reference
#4827 
