### PR TITLE
Change Algolia index name from 'daprdocs' to 'crawler_dapr'

### DIFF
--- a/daprdocs/layouts/_partials/hooks/body-end.html
+++ b/daprdocs/layouts/_partials/hooks/body-end.html
@@ -7,7 +7,7 @@
     container: '#docsearch',
     appId: 'O0QLQGNF38',
     apiKey: '54ae43aa28ce8f00c54c8d5f544d29b9',
-    indexName: 'daprdocs',
+    indexName: 'crawler_dapr',
   });
 </script>
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Change the Algolia index to an index that is updated via a crawler every day and does not require running the Python script.

## Issue reference

#4894 
