### PR TITLE
feat Jaeger v2

### DIFF
--- a/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
+++ b/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
@@ -79,7 +79,7 @@ Jaeger V2 can be deployed using the OpenTelemetry Operator for simplified manage
 
 1. **Install cert-manager** to manage certificates:
    ```bash
-   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml -n cert-manager
+   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.1/cert-manager.yaml -n cert-manager
    ```
    Verify that all resources in the `cert-manager` namespace are ready.
 

--- a/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
+++ b/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
@@ -73,6 +73,8 @@ The following steps show you how to configure Dapr to send distributed tracing d
 
 Jaeger V2 can be deployed using the OpenTelemetry Operator for simplified management and native OTLP support. The following example configures Jaeger V2 with in-memory storage.
 
+> **Note on Storage Backends:** This example uses in-memory storage (`memstore`) for simplicity, suitable for development or testing environments as it stores up to 100,000 traces in memory. For production environments, consider configuring a persistent storage backend like Cassandra or Elasticsearch to ensure trace data durability.
+
 #### Installation
 
 1. **Install cert-manager** to manage certificates:
@@ -132,13 +134,6 @@ Jaeger V2 can be deployed using the OpenTelemetry Operator for simplified manage
    kubectl apply -f jaeger-inmemory.yaml -n observability
    ```
 
-#### Accessing the Jaeger V2 UI
-
-Expose the Jaeger V2 service or deployment to access the UI:
-```bash
-kubectl port-forward service/jaeger-inmemory-instance-collector 8080:16686 -n observability
-```
-Open `http://localhost:8080` in your browser to view the Jaeger V2 UI. Note: Direct UI interaction via the OpenTelemetry Operator is under development.
 
 ### Set up Dapr to send traces to Jaeger V2
 
@@ -198,7 +193,7 @@ To view Dapr sidecar traces, port-forward the Jaeger V2 service and open the UI:
 kubectl port-forward svc/jaeger-inmemory-instance-collector 16686 -n observability
 ```
 
-In your browser, go to `http://localhost:16686` and you will see the Jaeger UI.
+In your browser, go to `http://localhost:16686` to see the Jaeger V2 UI.
 
 ![jaeger](/images/jaeger_ui.png)
 {{% /tab %}}
@@ -207,6 +202,5 @@ In your browser, go to `http://localhost:16686` and you will see the Jaeger UI.
 
 ## References
 
-- [Jaeger Getting Started](https://www.jaegertracing.io/docs/2.11/getting-started/)
-- [Jaeger Kubernetes Operator](https://www.jaegertracing.io/docs/2.11/deployment/kubernetes/#kubernetes-operator)
-
+- [Jaeger V2 Getting Started](https://www.jaegertracing.io/docs/2.11/getting-started/)
+- [Jaeger V2 Kubernetes Operator](https://www.jaegertracing.io/docs/2.11/deployment/kubernetes/#kubernetes-operator)

--- a/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
+++ b/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-jaeger.md
@@ -1,27 +1,30 @@
 ---
 type: docs
-title: "Using OpenTelemetry Collector to collect traces to send to Jaeger"
-linkTitle: "Using the OpenTelemetry for Jaeger"
+title: "Using OpenTelemetry to send traces to Jaeger V2"
+linkTitle: "Using OpenTelemetry for Jaeger V2"
 weight: 1200
-description: "How to push trace events to Jaeger distributed tracing platform, using the OpenTelemetry Collector."
+description: "How to push trace events to Jaeger V2 distributed tracing platform using OpenTelemetry protocol."
 ---
 
-While Dapr supports writing traces using OpenTelemetry (OTLP) and Zipkin protocols, Zipkin support for Jaeger has been deprecated in favor of OTLP. Although Jaeger supports OTLP directly, the recommended approach for production is to use the OpenTelemetry Collector to collect traces from Dapr and send them to Jaeger, allowing your application to quickly offload data and take advantage of features like retries, batching, and encryption. For more information, read the Open Telemetry Collector [documentation](https://opentelemetry.io/docs/collector/#when-to-use-a-collector).
+Dapr supports writing traces using the OpenTelemetry (OTLP) protocol, and Jaeger V2 natively supports OTLP, allowing Dapr to send traces directly to a Jaeger V2 instance. This approach is recommended for production to leverage Jaeger V2's capabilities for distributed tracing.
+
 {{< tabpane text=true >}}
 
 {{% tab "Self-hosted" %}}
-<!-- self-hosted -->
-## Configure Jaeger in self-hosted mode
+## Configure Jaeger V2 in self-hosted mode
 
 ### Local setup
 
 The simplest way to start Jaeger is to run the pre-built, all-in-one Jaeger image published to DockerHub and expose the OTLP port:
 
 ```bash
-docker run -d --name jaeger \
-  -p 4317:4317  \
+docker run --rm --name jaeger \
   -p 16686:16686 \
-  jaegertracing/all-in-one:1.49
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 5778:5778 \
+  -p 9411:9411 \
+  cr.jaegertracing.io/jaegertracing/jaeger:2.11.0
 ```
 
 Next, create the following `config.yaml` file locally:
@@ -58,41 +61,108 @@ To view traces in your browser, go to `http://localhost:16686` to see the Jaeger
 
 {{% tab "Kubernetes" %}}
 <!-- kubernetes -->
-## Configure Jaeger on Kubernetes with the OpenTelemetry Collector
+## Configure Jaeger V2 on Kubernetes
 
-The following steps show you how to configure Dapr to send distributed tracing data to the OpenTelemetry Collector which, in turn, sends the traces to Jaeger.
+The following steps show you how to configure Dapr to send distributed tracing data directly to a Jaeger V2 instance deployed using the OpenTelemetry Operator with in-memory storage.
 
 ### Prerequisites
 
 - [Install Dapr on Kubernetes]({{% ref kubernetes %}})
-- [Set up Jaeger](https://www.jaegertracing.io/docs/1.49/operator/) using the Jaeger Kubernetes Operator
 
-### Set up OpenTelemetry Collector to push to Jaeger
+### Set up Jaeger V2 with the OpenTelemetry Operator
 
-To push traces to your Jaeger instance, install the OpenTelemetry Collector on your Kubernetes cluster.
+Jaeger V2 can be deployed using the OpenTelemetry Operator for simplified management and native OTLP support. The following example configures Jaeger V2 with in-memory storage.
 
-1. Download and inspect the [`open-telemetry-collector-jaeger.yaml`](/docs/open-telemetry-collector/open-telemetry-collector-jaeger.yaml) file.
+#### Installation
 
-1. In the data section of the `otel-collector-conf` ConfigMap, update the `otlp/jaeger.endpoint` value to reflect the endpoint of your Jaeger collector Kubernetes service object.
+1. **Install cert-manager** to manage certificates:
+   ```bash
+   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml -n cert-manager
+   ```
+   Verify that all resources in the `cert-manager` namespace are ready.
 
-1. Deploy the OpenTelemetry Collector into the same namespace where your Dapr-enabled applications are running:
+1. **Install the OpenTelemetry Operator**:
+   ```bash
+   kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
+   ```
+   Confirm that all resources in the `opentelemetry-operator-system` namespace are ready.
 
-   ```sh
-   kubectl apply -f open-telemetry-collector-jaeger.yaml
+1. **Deploy a Jaeger V2 instance with in-memory storage**:
+   Apply the following configuration to create a Jaeger V2 instance:
+   ```yaml
+   apiVersion: opentelemetry.io/v1beta1
+   kind: OpenTelemetryCollector
+   metadata:
+     name: jaeger-inmemory-instance
+     namespace: observability
+   spec:
+     image: jaegertracing/jaeger:latest
+     ports:
+     - name: jaeger
+       port: 16686
+     config:
+       service:
+         extensions: [jaeger_storage, jaeger_query]
+         pipelines:
+           traces:
+             receivers: [otlp]
+             exporters: [jaeger_storage_exporter]
+       extensions:
+         jaeger_query:
+           storage:
+             traces: memstore
+         jaeger_storage:
+           backends:
+             memstore:
+               memory:
+                 max_traces: 100000
+       receivers:
+         otlp:
+           protocols:
+             grpc:
+               endpoint: 0.0.0.0:4317
+             http:
+               endpoint: 0.0.0.0:4318
+       exporters:
+         jaeger_storage_exporter:
+           trace_storage: memstore
+   ```
+   Apply it with:
+   ```bash
+   kubectl apply -f jaeger-inmemory.yaml -n observability
    ```
 
-### Set up Dapr to send traces to OpenTelemetryCollector
+#### Accessing the Jaeger V2 UI
 
-Create a Dapr configuration file to enable tracing and export the sidecar traces to the OpenTelemetry Collector.
+Expose the Jaeger V2 service or deployment to access the UI:
+```bash
+kubectl port-forward service/jaeger-inmemory-instance-collector 8080:16686 -n observability
+```
+Open `http://localhost:8080` in your browser to view the Jaeger V2 UI. Note: Direct UI interaction via the OpenTelemetry Operator is under development.
 
-1. Use the [`collector-config-otel.yaml`](/docs/open-telemetry-collector/collector-config-otel.yaml) file to create your own Dapr configuration.
+### Set up Dapr to send traces to Jaeger V2
 
-1. Update the `namespace` and `otel.endpointAddress` values to align with the namespace where your Dapr-enabled applications and OpenTelemetry Collector are deployed.
+Create a Dapr configuration file to enable tracing and export the sidecar traces directly to the Jaeger V2 instance.
 
-1. Apply the configuration with:
+1. Create a configuration file (e.g., `tracing.yaml`) with the following content, updating the `namespace` and `otel.endpointAddress` to match your Jaeger V2 instance:
+   ```yaml
+   apiVersion: dapr.io/v1alpha1
+   kind: Configuration
+   metadata:
+     name: tracing
+     namespace: order-system
+   spec:
+     tracing:
+       samplingRate: "1"
+       otel:
+         endpointAddress: "jaeger-inmemory-instance-collector.observability.svc.cluster.local:4317"
+         isSecure: false
+         protocol: grpc
+   ```
 
-   ```sh
-   kubectl apply -f collector-config.yaml
+2. Apply the configuration:
+   ```bash
+   kubectl apply -f tracing.yaml -n order-system
    ```
 
 ### Deploy your app with tracing enabled
@@ -122,10 +192,10 @@ That’s it! There’s no need to include the OpenTelemetry SDK or instrument yo
 
 ### View traces
 
-To view Dapr sidecar traces, port-forward the Jaeger Service and open the UI:
+To view Dapr sidecar traces, port-forward the Jaeger V2 service and open the UI:
 
 ```bash
-kubectl port-forward svc/jaeger-query 16686 -n observability
+kubectl port-forward svc/jaeger-inmemory-instance-collector 16686 -n observability
 ```
 
 In your browser, go to `http://localhost:16686` and you will see the Jaeger UI.
@@ -134,8 +204,9 @@ In your browser, go to `http://localhost:16686` and you will see the Jaeger UI.
 {{% /tab %}}
 
 {{< /tabpane >}}
+
 ## References
 
-- [Jaeger Getting Started](https://www.jaegertracing.io/docs/1.49/getting-started/)
-- [Jaeger Kubernetes Operator](https://www.jaegertracing.io/docs/1.49/operator/)
-- [OpenTelemetry Collector Exporters](https://opentelemetry.io/docs/collector/configuration/#exporters)
+- [Jaeger Getting Started](https://www.jaegertracing.io/docs/2.11/getting-started/)
+- [Jaeger Kubernetes Operator](https://www.jaegertracing.io/docs/2.11/deployment/kubernetes/#kubernetes-operator)
+


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within tabpane
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated the Jaeger tracing documentation to focus on Jaeger V2 with native OTLP support, using the OpenTelemetry Operator and in-memory storage, with a note on persistent storage backends. The changes replace outdated Jaeger V1 content

## Issue reference

https://github.com/dapr/docs/issues/4920