### PR TITLE
Add aliases to redirect old Dapr Agent pages to new location

### DIFF
--- a/daprdocs/content/en/developing-ai/_index.md
+++ b/daprdocs/content/en/developing-ai/_index.md
@@ -4,6 +4,4 @@ title: "Developing AI with Dapr"
 linkTitle: "Developing AI"
 description: "Information on how to build reliable and secure agentic AI systems with Dapr"
 weight: 31
-aliases:
-  - /developing-applications/dapr-agents
 ---

--- a/daprdocs/content/en/developing-ai/_index.md
+++ b/daprdocs/content/en/developing-ai/_index.md
@@ -4,4 +4,6 @@ title: "Developing AI with Dapr"
 linkTitle: "Developing AI"
 description: "Information on how to build reliable and secure agentic AI systems with Dapr"
 weight: 31
+aliases:
+  - /developing-applications/dapr-agents
 ---

--- a/daprdocs/content/en/developing-ai/dapr-agents/_index.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/_index.md
@@ -4,6 +4,8 @@ title: "Dapr Agents"
 linkTitle: "Dapr Agents"
 weight: 25
 description: "A framework for building durable and resilient AI agent systems at scale"
+aliases:
+  - /developing-applications/dapr-agents
 ---
 
 ###  What is Dapr Agents?

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-core-concepts.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-core-concepts.md
@@ -4,6 +4,8 @@ title: "Core Concepts"
 linkTitle: "Core Concepts"
 weight: 40
 description: "Learn about the core concepts of Dapr Agents"
+aliases:
+  - /developing-applications/dapr-agents/dapr-agents-core-concepts
 ---
 
 Dapr Agents provides a structured way to build and orchestrate applications that use LLMs without getting bogged down in infrastructure details. The primary goal is to enable AI development by abstracting away the complexities of working with LLMs, tools, memory management, and distributed systems, allowing developers to focus on the business logic of their AI applications. Agents in this framework are the fundamental building blocks.

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-getting-started.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-getting-started.md
@@ -4,6 +4,8 @@ title: "Getting Started"
 linkTitle: "Getting Started"
 weight: 20
 description: "How to install Dapr Agents and run your first agent"
+aliases:
+  - /developing-applications/dapr-agents/dapr-agents-getting-started
 ---
 
 {{% alert title="Dapr Agents Concepts" color="primary" %}}

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-integrations.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-integrations.md
@@ -4,6 +4,8 @@ title: "Integrations"
 linkTitle: "Integrations"
 weight: 60
 description: "Various integrations and tools available in Dapr Agents"
+aliases:
+  - /developing-applications/dapr-agents/dapr-agents-integrations
 ---
 
 # Out-of-the-box Tools

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-introduction.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-introduction.md
@@ -4,6 +4,8 @@ title: "Introduction"
 linkTitle: "Introduction"
 weight: 10
 description: "Overview of Dapr Agents and its key features"
+aliases:
+  - /developing-applications/dapr-agents/dapr-agents-introduction
 ---
 
 ![Agent Overview](/images/dapr-agents/concepts-agents-overview.png)

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-patterns.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-patterns.md
@@ -4,6 +4,8 @@ title: "Agentic Patterns"
 linkTitle: "Agentic Patterns"
 weight: 50
 description: "Common design patterns and use cases for building agentic systems"
+aliases:
+  - /developing-applications/dapr-agents/dapr-agents-patterns
 ---
 
 Dapr Agents simplify the implementation of agentic systems, from simple augmented LLMs to fully autonomous agents in enterprise environments. The following sections describe several application patterns that can benefit from Dapr Agents.

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-quickstarts.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-quickstarts.md
@@ -4,6 +4,8 @@ title: "Quickstarts"
 linkTitle: "Quickstarts"
 weight: 70
 description: "Get started with Dapr Agents through practical step-by-step examples"
+aliases:
+  - /developing-applications/dapr-agents/dapr-agents-quickstarts
 ---
 
 [Dapr Agents Quickstarts](https://github.com/dapr/dapr-agents/tree/main/quickstarts) demonstrate how to use Dapr Agents to build applications with LLM-powered autonomous agents and event-driven workflows. Each quickstart builds upon the previous one, introducing new concepts incrementally.

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-why.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-why.md
@@ -4,6 +4,8 @@ title: "Why Dapr Agents"
 linkTitle: "Why Dapr Agents"
 weight: 30
 description: "Understanding the benefits and use cases for Dapr Agents"
+aliases:
+  - /developing-applications/dapr-agents/dapr-agents-why
 ---
 
 Dapr Agents is an open-source framework for building and orchestrating LLM-based autonomous agents that leverages Dapr's proven distributed systems foundation. Unlike other agentic frameworks that require developers to build infrastructure from scratch, Dapr Agents enables teams to focus on agent intelligence by providing enterprise-grade scalability, state management, and messaging capabilities out of the box. This approach eliminates the complexity of recreating distributed system fundamentals while delivering agentic workflows powered by Dapr.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Add Hugo aliases to Dapr Agent content to prevent broken links/indexing due to https://github.com/dapr/docs/pull/4969/

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
