### PR TITLE
add dapr 1.16.5

### DIFF
--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -45,6 +45,7 @@ The table below shows the versions of Dapr releases that have been tested togeth
 
 | Release date | Runtime     | CLI  | SDKs  | Dashboard  | Status | Release notes |
 |--------------------|:--------:|:--------|---------|---------|---------|------------|
+| Dec 19th 2025 | 1.16.5</br> | 1.16.5 | Java 1.16.0 </br>Go 1.13.0 </br>PHP 1.2.0 </br>Python 1.16.0 </br>.NET 1.16.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported (current) | [v1.16.4 release notes](https://github.com/dapr/dapr/releases/tag/v1.16.4)   |
 | Dec 8th 2025 | 1.16.4</br> | 1.16.5 | Java 1.16.0 </br>Go 1.13.0 </br>PHP 1.2.0 </br>Python 1.16.0 </br>.NET 1.16.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported (current) | [v1.16.4 release notes](https://github.com/dapr/dapr/releases/tag/v1.16.4)   |
 | Nov 21st 2025| 1.16.3</br> | 1.16.4 | Java 1.16.0 </br>Go 1.13.0 </br>PHP 1.2.0 </br>Python 1.16.0 </br>.NET 1.16.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported (current) | [v1.16.3 release notes](https://github.com/dapr/dapr/releases/tag/v1.16.3)   |
 | Oct 30th 2025 | 1.16.2</br>  | 1.16.3 | Java 1.16.0 </br>Go 1.13.0 </br>PHP 1.2.0 </br>Python 1.16.0 </br>.NET 1.16.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported (current) | [v1.16.2 release notes](https://github.com/dapr/dapr/releases/tag/v1.16.2) |

--- a/daprdocs/layouts/_shortcodes/dapr-latest-version.html
+++ b/daprdocs/layouts/_shortcodes/dapr-latest-version.html
@@ -1,1 +1,1 @@
-{{- if .Get "short" }}1.16{{ else if .Get "long" }}1.16.4{{ else if .Get "cli" }}1.16.5{{ else }}1.16.4{{ end -}}
+{{- if .Get "short" }}1.16{{ else if .Get "long" }}1.16.5{{ else if .Get "cli" }}1.16.5{{ else }}1.16.5{{ end -}}


### PR DESCRIPTION
note latest dapr version [1.16.5](https://github.com/dapr/dapr/releases/tag/v1.16.5)