### PR TITLE
Adds Request Metadata field for fifoMessageGroupId

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-aws-snssqs.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-aws-snssqs.md
@@ -101,6 +101,14 @@ The above example uses secrets as plain strings. It is recommended to use [a sec
 | concurrencyMode | N  | When messages are received in bulk from SQS, call the subscriber sequentially (“single” message at a time), or concurrently (in “parallel”). Default: `"parallel"` | `"single"`, `"parallel"`
 | concurrencyLimit | N | Defines the maximum number of concurrent workers handling messages. This value is ignored when concurrencyMode is set to `"single"`. To avoid limiting the number of concurrent workers, set this to `0`. Default: `0` | `100`
 
+
+## Request metadata fields
+
+| Field              | Required | Details | Example |
+|--------------------|:--------:|---------|---------|
+| fifoMessageGroupId | N | If `fifo` is enabled, instructs Dapr to use a custom [Message Group ID](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html) per request for the pubsub deployment | `"customer-123"`
+
+
 ### Additional info
 
 #### Conforming with AWS specifications


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Adds the documentation for https://github.com/dapr/components-contrib/issues/3415 to allow for the messageGroupId to be overridden in the request metadata

## Issue reference

https://github.com/dapr/components-contrib/issues/3415