### PR TITLE
docs: add dapr-agents operations page with docs on Agent Metadata Schema

### DIFF
--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
@@ -1,0 +1,42 @@
+---
+type: docs
+title: "Operations"
+linkTitle: "Operations"
+weight: 80
+description: "Get started with secure and reliable operations of Dapr Agents"
+aliases:
+  - /developing-ai/dapr-agents/dapr-agents-operations
+---
+
+## Operations
+
+### Agent Registry 
+
+#### Agent Metadata Schema
+
+Dapr Agents utilizes an Agent Registry (often referenced as `agent-registry` statestore) to communicate Agent capabilities. The Agent Registry contains Agent metadata, including the agent's name, description, version and much more. 
+  
+In order to facilitate easier handling of version changes to the agent metadata, Dapr Agents supplies versioned JSON schemas. Within the [dapr agents repository] you'll find 3 types of JSON schema files:
+
+- [index.json](https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/index.json)
+- [latest.json](https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/latest.json)
+- `v{version}.json`
+
+The `index.json` can be used as a lookup table and looks like:
+
+```
+{
+  "current_version": "0.10.7",
+  "schema_url": "https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/v0.10.7.json",
+  "available_versions": [
+    "v0.10.7",
+    "v0.10.6"
+  ]
+}
+```
+
+When the agent starts up it will insert its own metadata into the supplied Agent Registry. The Agent Metadata object contains the key `schema_version` which can be used as a reference to fetch the valid schema for that agent version:
+
+```sh
+curl -s -v "https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/v$(jq -r '.schema_version' agent-metadata.json).json"
+```

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
@@ -26,11 +26,11 @@ The `index.json` can be used as a lookup table and looks like:
 
 ```
 {
-  "current_version": "0.10.7",
-  "schema_url": "https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/v0.10.7.json",
+  "current_version": "X.Y.Z",
+  "schema_url": "https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/vX.Y.Z.json",
   "available_versions": [
-    "v0.10.7",
-    "v0.10.6"
+    "vX.Y.Z",
+    "vA.B.C"
   ]
 }
 ```

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
@@ -14,7 +14,7 @@ aliases:
 
 #### Agent Metadata Schema
 
-Dapr Agents utilizes an Agent Registry (often referenced as `agent-registry` statestore) to communicate Agent capabilities. The Agent Registry contains Agent metadata, including the agent's name, description, version and much more. 
+Dapr Agents utilizes an agent registry (often referenced as `agent-registry` statestore) to communicate agent capabilities. The agent registry contains agent metadata, including the agent's name, description, version and more. 
   
 In order to facilitate easier handling of version changes to the agent metadata, Dapr Agents supplies versioned JSON schemas. Within the [dapr agents repository] you'll find 3 types of JSON schema files:
 

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
@@ -16,7 +16,7 @@ aliases:
 
 Dapr Agents utilizes an agent registry (often referenced as `agent-registry` statestore) to communicate agent capabilities. The agent registry contains agent metadata, including the agent's name, description, version and more. 
   
-In order to facilitate easier handling of version changes to the agent metadata, Dapr Agents supplies versioned JSON schemas. Within the [dapr agents repository] you'll find 3 types of JSON schema files:
+In order to facilitate easier handling of version changes to the agent metadata, Dapr Agents supplies versioned JSON schemas. Within the agents repository you'll find 3 types of JSON schema files:
 
 - [index.json](https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/index.json)
 - [latest.json](https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/latest.json)

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-operations.md
@@ -35,7 +35,7 @@ The `index.json` can be used as a lookup table and looks like:
 }
 ```
 
-When the agent starts up it will insert its own metadata into the supplied Agent Registry. The Agent Metadata object contains the key `schema_version` which can be used as a reference to fetch the valid schema for that agent version:
+When the agent starts up it will insert its own metadata into the supplied agent registry. The agent metadata object contains the key `schema_version` which can be used as a reference to fetch the valid schema for that agent version:
 
 ```sh
 curl -s -v "https://raw.githubusercontent.com/dapr/dapr-agents/main/schemas/agent-metadata/v$(jq -r '.schema_version' agent-metadata.json).json"


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within tabpane
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Going out of https://github.com/dapr/dapr-agents/pull/373 Dapr Agents now supplies its Metadata schema in the repo. This PR extends the docs with references to this so Operators can find and handle the differences in the versioned schemas when presenting agents etc.

## Issue reference

<!--Please reference the issue this PR will close: N/A
