### PR TITLE
Correcting .NET typo in WF documentation

### DIFF
--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-workflow/dotnet-workflowclient-usage.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-workflow/dotnet-workflowclient-usage.md
@@ -150,7 +150,7 @@ if you were able to inject a standard `ILogger` into a workflow and it needed to
 subsequent replay from the event source log would result in the log recording additional operations that didn't actually
 take place a second or third time because their results were sourced from the log. This has the potential to introduce 
 a significant amount of confusion. Rather, a replay-safe logger is made available for use within workflows. It will only 
-log events the first time the workflow runs and will not log anything whenever the workflow is being replaced.
+log events the first time the workflow runs and will not log anything whenever the workflow is being replayed.
 
 This logger can be retrieved from a method present on the `WorkflowContext` available on your workflow instance and
 otherwise used precisely as you might otherwise use an `ILogger` instance.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Correcting typo in the .NET WF documentation.

This is not dependent on any changes in 1.17 and can be safely merged at any time.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
