### PR TITLE
Change resources path from 'resources' to 'components'

### DIFF
--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-getting-started.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-getting-started.md
@@ -260,7 +260,7 @@ Together, these features make the agent **durable**, **reliable**, and **provide
 From the `01-dapr-agents-fundamentals` folder, with your virtual environment activated:
 
 ```bash
-dapr run --app-id durable-agent --resources-path resources -- python 06_durable_agent_http.py
+dapr run --app-id durable-agent --resources-path components -- python 06_durable_agent_http.py
 ```
 
 This:
@@ -320,7 +320,7 @@ To see durable execution in action:
    Start it again with the same command:
 
 ```bash
-   dapr run --app-id durable-agent --resources-path resources -- python 06_durable_agent_http.py
+   dapr run --app-id durable-agent --resources-path components -- python 06_durable_agent_http.py
 ```
 
 4. **Query the same workflow**


### PR DESCRIPTION
Updated the resources path in the Dapr run command for the durable agent.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ x] Commands include options for Linux, MacOS, and Windows within tabpane
- [ x] New file and folder names are globally unique
- [ x] Page references use shortcodes instead of markdown or URL links
- [ x] Images use HTML style and have alternative text
- [ x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This pull request updates the Dapr agent getting started documentation to fix the path used for Dapr resources in the example commands. The main change is to use the correct `components` directory instead of the outdated `resources` directory.

**Documentation corrections:**

* Updated example Dapr run commands to use `--resources-path components` instead of `--resources-path resources` in `daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-getting-started.md`. [[1]](diffhunk://#diff-655687d5b34e8ff644095896fea1d2ecc15744c007728ffb445239765a7ccd84L263-R263) [[2]](diffhunk://#diff-655687d5b34e8ff644095896fea1d2ecc15744c007728ffb445239765a7ccd84L323-R323)

## Issue reference

This pull request updates the documentation for running the durable agent example to ensure consistency with the correct folder naming. The `--resources-path` argument is changed from `resources` to `components` in the example commands to match the expected directory structure.

- Documentation improvements:
  * Updated the `dapr run` commands in `dapr-agents-getting-started.md` to use `--resources-path components` instead of `--resources-path resources` for accuracy and consistency. [[1]](diffhunk://#diff-655687d5b34e8ff644095896fea1d2ecc15744c007728ffb445239765a7ccd84L263-R263) [[2]](diffhunk://#diff-655687d5b34e8ff644095896fea1d2ecc15744c007728ffb445239765a7ccd84L323-R323)
