### PR TITLE
Moved workflow versioning guidance to separate workflows document

### DIFF
--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-features-concepts.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-features-concepts.md
@@ -523,32 +523,6 @@ task.Await(nil)
 
 {{< /tabpane >}}
 
-### Versioning Process Guidance
-
-Because named workflows are fully compatible with patches, the approach is that changes to your workflow are initially
-made by applying patches to your existing workflow logic. Eventually you'll hit one of the following problems after
-applying several patches:
-- You're concerned about the overhead to your workflow state history because of the number of applied patches;
-- The golden path through your workflow logic is hard to follow;
-- You need to make another workflow tweak, but can't figure out how to apply a patch that doesn't break the
-  determinism guarantee.
-
-At this point, the recommendation is that you introduce a named version of your workflow. Copy your existing
-workflow, change its name to reflect whatever versioning strategy you're using in your SDK and refactor to remove all
-your patches and retain only your intended "latest" logic. Apply your new changes (no need for a patch here – it's a
-new workflow) and deploy it.
-
-Here, apply patches again as needed to address future changes and when necessary, introduce another named workflow
-version and continue. Repeat this process indefinitely.
-
-It is recommended that you retain old workflow versions until you're completely confident that nothing is in-flight
-(including deferred with a long-running timer) that uses any of your old workflow versions.
-
-Workflow versioning doesn't address changing the types of inputs and outputs of the workflows themselves. As general
-guidance, it is recommended to either return serialized values like strings (making the consumer of the output
-responsible for being able to deserialize different outputs over time) or adopt complex types that incorporate
-optional properties to include new expected output values.
-
 ### Updating workflow code
 Make sure updates you make to the workflow code maintain its determinism. Here are a few example of code updates
 that can break workflow determinism:
@@ -575,8 +549,3 @@ patch and introduce new named workflow versions to incorporate changes to your w
    - [.NET](https://github.com/dapr/dotnet-sdk/tree/master/examples/Workflow)
    - [Java](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples/workflows)
    - [Go](https://github.com/dapr/go-sdk/tree/main/examples/workflow/README.md)
-
-
-
-
-

--- a/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-versioning.md
+++ b/daprdocs/content/en/developing-applications/building-blocks/workflow/workflow-versioning.md
@@ -320,3 +320,29 @@ def workflow_v2(ctx: DaprWorkflowContext, wf_input: str):
 {{% /tab %}}
 
 {{< /tabpane >}}
+
+### Versioning Process Guidance
+
+Because named workflows are fully compatible with patches, the approach is that changes to your workflow are initially
+made by applying patches to your existing workflow logic. Eventually you'll hit one of the following problems after
+applying several patches:
+- You're concerned about the overhead to your workflow state history because of the number of applied patches;
+- The golden path through your workflow logic is hard to follow;
+- You need to make another workflow tweak, but can't figure out how to apply a patch that doesn't break the
+  determinism guarantee.
+
+At this point, the recommendation is that you introduce a named version of your workflow. Copy your existing
+workflow, change its name to reflect whatever versioning strategy you're using in your SDK and refactor to remove all
+your patches and retain only your intended "latest" logic. Apply your new changes (no need for a patch here – it's a
+new workflow) and deploy it.
+
+Here, apply patches again as needed to address future changes and when necessary, introduce another named workflow
+version and continue. Repeat this process indefinitely.
+
+It is recommended that you retain old workflow versions until you're completely confident that nothing is in-flight
+(including deferred with a long-running timer) that uses any of your old workflow versions.
+
+Workflow versioning doesn't address changing the types of inputs and outputs of the workflows themselves. As general
+guidance, it is recommended to either return serialized values like strings (making the consumer of the output
+responsible for being able to deserialize different outputs over time) or adopt complex types that incorporate
+optional properties to include new expected output values.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Moving workflow versioning guidance to versioning doc from features-and-concepts [per request](https://github.com/dapr/docs/pull/5003#discussion_r2847840637)

@msfussell 

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
