### PR TITLE
update docs to use dapr v1.17.1 and v1.17.0

### DIFF
--- a/daprdocs/content/en/operations/support/support-release-policy.md
+++ b/daprdocs/content/en/operations/support/support-release-policy.md
@@ -45,7 +45,8 @@ The table below shows the versions of Dapr releases that have been tested togeth
 
 | Release date | Runtime     | CLI  | SDKs  | Dashboard  | Status | Release notes |
 |--------------------|:--------:|:--------|---------|---------|---------|------------|
-| Feb 26th 2026 | 1.17.0</br> | 1.17.0 | Java 1.17.0 </br>Go 1.14.0 </br>PHP 1.2.0 </br>Python 1.17.0 </br>.NET 1.17.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported (current) | [v1.17.0 release notes](https://github.com/dapr/dapr/releases/tag/v1.17.0)   |
+| Mar 9th 2026 | 1.17.1</br> | 1.17.0 | Java 1.17.0 </br>Go 1.14.0 </br>PHP 1.2.0 </br>Python 1.17.0 </br>.NET 1.17.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported (current) | [v1.17.1 release notes](https://github.com/dapr/dapr/releases/tag/v1.17.1)   |
+| Feb 27th 2026 | 1.17.0</br> | 1.17.0 | Java 1.17.0 </br>Go 1.14.0 </br>PHP 1.2.0 </br>Python 1.17.0 </br>.NET 1.17.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported | [v1.17.0 release notes](https://github.com/dapr/dapr/releases/tag/v1.17.0)   |
 | Feb 12th 2026 | 1.16.9</br> | 1.16.5 | Java 1.16.0 </br>Go 1.13.0 </br>PHP 1.2.0 </br>Python 1.16.0 </br>.NET 1.16.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported | [v1.16.9 release notes](https://github.com/dapr/dapr/releases/tag/v1.16.9)   |
 | Jan 26th 2026 | 1.16.8</br> | 1.16.5 | Java 1.16.0 </br>Go 1.13.0 </br>PHP 1.2.0 </br>Python 1.16.0 </br>.NET 1.16.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported | [v1.16.8 release notes](https://github.com/dapr/dapr/releases/tag/v1.16.8)   |
 | Jan 20th 2026 | 1.16.7</br> | 1.16.5 | Java 1.16.0 </br>Go 1.13.0 </br>PHP 1.2.0 </br>Python 1.16.0 </br>.NET 1.16.0 </br>JS 3.6.0 </br>Rust 0.17.0 | 0.15.0 | Supported | [v1.16.7 release notes](https://github.com/dapr/dapr/releases/tag/v1.16.7)   |

--- a/daprdocs/layouts/_shortcodes/dapr-latest-version.html
+++ b/daprdocs/layouts/_shortcodes/dapr-latest-version.html
@@ -1,1 +1,1 @@
-{{- if .Get "short" }}1.16{{ else if .Get "long" }}1.16.9{{ else if .Get "cli" }}1.16.5{{ else }}1.16.9{{ end -}}
+{{- if .Get "short" }}1.17{{ else if .Get "long" }}1.17.1{{ else if .Get "cli" }}1.17.0{{ else }}1.17.1{{ end -}}


### PR DESCRIPTION
update to latest dapr versions