### PR TITLE
chore: update Azure Static Web App base hostname to new account

### DIFF
--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      SWA_BASE: 'proud-bay-0e9e0e81e'
+      SWA_BASE: 'delightful-moss-0b438320f'
       HUGO_ENV: production
     steps:
       - name: Checkout docs repo


### PR DESCRIPTION
Updates `SWA_BASE` in `website-root.yml` to point to the new Azure Static Web Apps instance (`delightful-moss-0b438320f`) as part of migrating to a new Azure account.