### PR TITLE
chore: fix Azure Static Web App staging URL region suffix

### DIFF
--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git config --global --add safe.directory /github/workspace
           if [ $GITHUB_EVENT_NAME == 'pull_request' ]; then
-            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.westus2.azurestaticapps.net/"
+            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.1.azurestaticapps.net/"
           fi
           hugo ${STAGING_URL+-b "$STAGING_URL"} --minify
       - name: Deploy docs site


### PR DESCRIPTION
Updates the staging PR URL in `website-root.yml` from `.westus2.azurestaticapps.net` to `.1.azurestaticapps.net` to match the new Azure Static Web App instance region (East US 2).