### PR TITLE
chore: update Azure Static Web App to new instance

### DIFF
--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      SWA_BASE: 'delightful-moss-0b438320f'
+      SWA_BASE: 'mango-sky-0f64b320f'
       HUGO_ENV: production
     steps:
       - name: Checkout docs repo
@@ -48,7 +48,7 @@ jobs:
         run: |
           git config --global --add safe.directory /github/workspace
           if [ $GITHUB_EVENT_NAME == 'pull_request' ]; then
-            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.1.azurestaticapps.net/"
+            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.2.azurestaticapps.net/"
           fi
           hugo ${STAGING_URL+-b "$STAGING_URL"} --minify
       - name: Deploy docs site


### PR DESCRIPTION
Updates `website-root.yml` to point to the new Azure Static Web Apps instance:

- `SWA_BASE`: `delightful-moss-0b438320f` → `mango-sky-0f64b320f`
- Staging URL suffix: `.1.azurestaticapps.net` → `.2.azurestaticapps.net`

Also requires updating the `AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E` secret with the new deployment token.