### PR TITLE
revert: restore original Azure Static Web App configuration

### DIFF
--- a/.github/workflows/website-root.yml
+++ b/.github/workflows/website-root.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      SWA_BASE: 'mango-sky-0f64b320f'
+      SWA_BASE: 'proud-bay-0e9e0e81e'
       HUGO_ENV: production
     steps:
       - name: Checkout docs repo
@@ -48,7 +48,7 @@ jobs:
         run: |
           git config --global --add safe.directory /github/workspace
           if [ $GITHUB_EVENT_NAME == 'pull_request' ]; then
-            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.2.azurestaticapps.net/"
+            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.westus2.azurestaticapps.net/"
           fi
           hugo ${STAGING_URL+-b "$STAGING_URL"} --minify
       - name: Deploy docs site


### PR DESCRIPTION
Reverts changes from #5095, #5096, and #5097 — restoring `website-root.yml` to the original Azure Static Web App configuration:

- `SWA_BASE`: `mango-sky-0f64b320f` → `proud-bay-0e9e0e81e`
- Staging URL suffix: `.2.azurestaticapps.net` → `.westus2.azurestaticapps.net`

Also requires reverting the `AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_BAY_0E9E0E81E` and `AZURE_STATIC_WEB_APPS_V1_17` secrets back to the original token from the old Azure account.