### PR TITLE
fix: allow workflow_dispatch for v1.18 SWA deployment

### DIFF
--- a/.github/workflows/website-v1-18.yml
+++ b/.github/workflows/website-v1-18.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:


### PR DESCRIPTION
## Problem
The build job condition only allows `push` and `pull_request` events:
```
if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
```
`workflow_dispatch` is excluded, so manual triggers skip the build.

## Fix
Use the same condition as `website-root.yml`:
```
if: github.event.action != 'closed'
```
This works for all event types (push, pull_request, workflow_dispatch) and only skips the closed PR action.

## Context
Needed after migrating SWAs to the new Azure subscription. When merged, the push event will trigger deployment to the new SWA.