### PR TITLE
Update filename numbering to match quickstarts/ on dapr-agents

### DIFF
--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-getting-started.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-getting-started.md
@@ -145,7 +145,7 @@ Dapr also supports Anthropic, Mistral, and other providers through the [Conversa
 
 ## Prepare your environment
 
-In this getting started guide, you'll work directly from the [Dapr Agents quickstarts](https://github.com/dapr/dapr-agents/tree/main/quickstarts). You'll focus on `02_durable_agent_http.py`—a reliable durable agent backed by Dapr's workflow engine and exposed over HTTP.
+In this getting started guide, you'll work directly from the [Dapr Agents quickstarts](https://github.com/dapr/dapr-agents/tree/main/quickstarts). You'll focus on `03_durable_agent_http.py`—a reliable durable agent backed by Dapr's workflow engine and exposed over HTTP.
 
 ### 1. Clone the repository
 
@@ -179,14 +179,14 @@ This example creates an agent that assists with weather information and uses Dap
 
 For this quickstart you'll primarily work with:
 
-* `02_durable_agent_http.py` – the main durable weather agent application exposed over HTTP
+* `03_durable_agent_http.py` – the main durable weather agent application exposed over HTTP
 * `function_tools.py` – contains `slow_weather_func`, the tool used by the agent
 * `resources/llm-provider.yaml` – Conversation API and LLM configuration
 * `resources/agent-memory.yaml` – conversation memory state store
 * `resources/agent-workflow.yaml` – workflow and durable execution state store
 
 
-Open `02_durable_agent_http.py`:
+Open `03_durable_agent_http.py`:
 
 ```python
 from dapr_agents.llm import DaprChatClient
@@ -347,13 +347,13 @@ Together, these features make the agent **durable**, **reliable**, and **provide
 From the `quickstarts` folder, with your virtual environment activated:
 
 ```bash
-uv run dapr run --app-id durable-agent --resources-path resources -- python 02_durable_agent_http.py
+uv run dapr run --app-id durable-agent --resources-path resources -- python 03_durable_agent_http.py
 ```
 
 This:
 
 * Starts a Dapr sidecar using the components in `resources/`.
-* Runs `02_durable_agent_http.py` with the durable `WeatherAgent`.
+* Runs `03_durable_agent_http.py` with the durable `WeatherAgent`.
 * Exposes the agent's HTTP API on port `8001`.
 
 ### Trigger the agent with a prompt
@@ -407,7 +407,7 @@ To see durable execution in action:
    Start it again with the same command:
 
 ```bash
-   uv run dapr run --app-id durable-agent --resources-path resources -- python 02_durable_agent_http.py
+   uv run dapr run --app-id durable-agent --resources-path resources -- python 03_durable_agent_http.py
 ```
 
 4. **Query the same workflow**

--- a/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-quickstarts.md
+++ b/daprdocs/content/en/developing-ai/dapr-agents/dapr-agents-quickstarts.md
@@ -24,12 +24,13 @@ The [Dapr Agents Fundamentals quickstart](https://github.com/dapr/dapr-agents/tr
 | Step | File | What You'll Learn |
 |------|------|-------------------|
 | 1 | [`01_llm_client.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/01_llm_client.py) | Call an LLM via the Dapr Conversation API using `DaprChatClient` |
-| 2 | [`02_durable_agent_http.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/02_durable_agent_http.py) | Run a durable agent backed by Dapr Workflows, exposed over HTTP |
-| 3 | [`03_durable_agent_pubsub.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/03_durable_agent_pubsub.py) | Trigger a durable agent via pub/sub instead of HTTP |
-| 4 | [`04_workflow_llm.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/04_workflow_llm.py) | Build a deterministic Dapr Workflow that calls LLMs as activities |
-| 5 | [`05_workflow_agents.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/05_workflow_agents.py) | Orchestrate multiple specialized agents as child workflows |
-| 6 | [`06_durable_agent_tracing.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/06_durable_agent_tracing.py) | Enable distributed tracing for agents and workflows with Zipkin |
-| 7 | [`07_durable_agent_hot_reload.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/07_durable_agent_hot_reload.py) | Hot-reload agent configuration at runtime via Dapr Configuration Store |
+| 2 | [`02_durable_agent_workflow.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/02_durable_agent_workflow.py) | Run a durable agent triggered programmatically via the Dapr Workflow API, using `trigger_agent` from client code or `call_agent` from within another orchestrator |
+| 3 | [`03_durable_agent_http.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/03_durable_agent_http.py) | Run a durable agent backed by Dapr Workflows, exposed over HTTP |
+| 4 | [`04_durable_agent_pubsub.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/04_durable_agent_pubsub.py) | Trigger a durable agent via pub/sub instead of HTTP |
+| 5 | [`05_workflow_llm.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/05_workflow_llm.py) | Build a deterministic Dapr Workflow that calls LLMs as activities |
+| 6 | [`06_workflow_agents.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/06_workflow_agents.py) | Orchestrate multiple specialized agents as child workflows |
+| 7 | [`07_durable_agent_tracing.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/07_durable_agent_tracing.py) | Enable distributed tracing for agents and workflows with Zipkin |
+| 8 | [`08_durable_agent_hot_reload.py`](https://github.com/dapr/dapr-agents/blob/main/quickstarts/08_durable_agent_hot_reload.py) | Hot-reload agent configuration at runtime via Dapr Configuration Store |
 
 See the [quickstarts README](https://github.com/dapr/dapr-agents/tree/main/quickstarts#readme) for full setup instructions including LLM configuration and prerequisites.
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within tabpane
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Changes the command snippets in the Dapr Agents quickstarts to match the actual numbering of the files in the repo.
Also adds the missing link to the second quickstart (used `02_durable_agent_workflow.py`) to the Fundamentals table. 

## Issue reference

Closes [dapr-agents #573](https://github.com/dapr/dapr-agents/issues/573).
