### PR TITLE
Improve ASP.NET Core docs and reference NuGet library

### DIFF
--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-client/dotnet-daprclient-usage.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-client/dotnet-daprclient-usage.md
@@ -12,6 +12,12 @@ A `DaprClient` holds access to networking resources in the form of TCP sockets u
 
 ### Dependency Injection
 
+To get started with ASP.NET Core dependency injection, install the [Dapr.AspNetCore](https://www.nuget.org/packages/Dapr.AspNetCore) package from NuGet:
+
+```bash
+dotnet add package Dapr.AspNetCore
+```
+
 The `AddDaprClient()` method will register the Dapr client with ASP.NET Core dependency injection. This method accepts an optional
 options delegate for configuring the `DaprClient` and an `ServiceLifetime` argument, allowing you to specify a different lifetime
 for the registered resources instead of the default `Singleton` value.
@@ -27,7 +33,7 @@ as in the following example:
 
 ```csharp
 services.AddDaprClient(daprBuilder => {
-    daprBuilder.UseJsonSerializerOptions(new JsonSerializerOptions {
+    daprBuilder.UseJsonSerializationOptions(new JsonSerializerOptions {
             WriteIndented = true,
             MaxDepth = 8
         });
@@ -54,7 +60,7 @@ Rather than using dependency injection, a `DaprClient` can also be built using t
 
 For best performance, create a single long-lived instance of `DaprClient` and provide access to that shared instance throughout your application. `DaprClient` instances are thread-safe and intended to be shared.
 
-Avoid creating a `DaprClient` per-operation and disposing it when the operation is complete. 
+Avoid creating a `DaprClient` per-operation and disposing it when the operation is complete.
 
 ## Configuring DaprClient
 
@@ -135,7 +141,7 @@ var daprClient = new DaprClientBuilder()
 
 The APIs on DaprClient that perform asynchronous operations accept an optional `CancellationToken` parameter. This follows a standard .NET idiom for cancellable operations. Note that when cancellation occurs, there is no guarantee that the remote endpoint stops processing the request, only that the client has stopped waiting for completion.
 
-When an operation is cancelled, it will throw an `OperationCancelledException`. 
+When an operation is cancelled, it will throw an `OperationCancelledException`.
 
 ## Understanding DaprClient JSON serialization
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within tabpane
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This PR:

- Fixes the `UseJsonSerializationOptions` reference to use the right value. `UseJsonSerializerOptions` doesn't exist (anymore).
- Makes it clear what is library is required for dependency injection on ASP.NET Core.
- Small doc formatting