### PR TITLE
Limit the deployment of the version specific website to only preview and archive state

### DIFF
--- a/.github/workflows/website-v1-17.yml
+++ b/.github/workflows/website-v1-17.yml
@@ -11,8 +11,38 @@ on:
       - v1.17
 
 jobs:
+  check_state:
+    name: Check branch state
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.read_state.outputs.is_latest }}
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+      - name: Read version_menu from hugo.yaml
+        id: read_state
+        run: |
+          # Gate signal: this workflow only deploys when hugo.yaml's
+          # params.version_menu does NOT contain "(latest)" — i.e., the
+          # branch is currently preview or archived. While the branch is
+          # the live "latest", website-root.yml owns the deploy.
+          VERSION_MENU=$(yq '.params.version_menu' hugo.yaml)
+          echo "version_menu read from hugo.yaml: '$VERSION_MENU'"
+          if [[ -z "$VERSION_MENU" || "$VERSION_MENU" == "null" ]]; then
+            echo "::error::params.version_menu is missing from hugo.yaml — cannot determine branch state."
+            exit 1
+          fi
+          if [[ "$VERSION_MENU" == *"(latest)"* ]]; then
+            echo "Branch is the live 'latest' — deploy job will be skipped."
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch is preview or archived — deploy job will run."
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    needs: check_state
+    if: needs.check_state.outputs.is_latest != 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed'))
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -58,7 +88,8 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    needs: check_state
+    if: needs.check_state.outputs.is_latest != 'true' && github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:

--- a/daprdocs/content/en/contributing/docs-contrib/maintainer-guide.md
+++ b/daprdocs/content/en/contributing/docs-contrib/maintainer-guide.md
@@ -73,6 +73,23 @@ The release process for docs requires the following:
 - A new DNS entry for the next version's website
 - A new git branch for the next version
 
+### How deploys are gated by branch state
+
+The Dapr docs repo deploys via two GitHub Actions workflows per branch:
+
+- `.github/workflows/website-root.yml` — deploys to the root domain `docs.dapr.io`. Present **only** on the branch that is currently the live "latest."
+- `.github/workflows/website-v1-X.yml` — deploys to the per-version subdomain `v1-X.docs.dapr.io`. Present on every released branch (preview, latest, and archived).
+
+To avoid both workflows firing simultaneously while a branch is the live "latest" (which would produce a redundant deploy to `v1-X.docs.dapr.io`), `website-v1-X.yml` contains a `check_state` job that reads `params.version_menu` from `hugo.yaml`:
+
+| Branch state | `params.version_menu` value | `website-root.yml`        | `website-v1-X.yml`             |
+| ------------ | --------------------------- | ------------------------- | ------------------------------ |
+| Preview      | `v1.X (preview)`            | not present               | deploys to `v1-X.docs.dapr.io` |
+| Latest       | `v1.X (latest)`             | deploys to `docs.dapr.io` | **skipped by `check_state`**   |
+| Archived     | `v1.X`                      | deleted on archival       | deploys to `v1-X.docs.dapr.io` |
+
+The gate signal is the literal substring `(latest)` inside `version_menu`. The release-process steps below already toggle this string at the correct points — no extra action is required beyond following them.
+
 ### Upmerge
 
 First, perform a [docs upmerge](#upmerge-from-current-release-branch-to-the-pre-release-branch) from the latest release to the upcoming release branch. 
@@ -107,6 +124,10 @@ These steps will prepare the latest release branch for archival.
 1. Add the following configuration to the `# Versioning` section (around line 121 and onwards):
 
    ```yaml
+   # NOTE: dropping the "(latest)" suffix below is what activates
+   # .github/workflows/website-v1-0.yml on this branch — the workflow's
+   # check_state job reads params.version_menu and skips deploys while
+   # the value contains "(latest)".
    version_menu: "v1.0"
    version: "v1.0"
    archived_version: true
@@ -120,6 +141,8 @@ These steps will prepare the latest release branch for archival.
     - version: v1.0
       url: https://v1-0.docs.dapr.io
    ```
+
+   Removing the `(latest)` parenthetical from `version_menu` flips the version-specific workflow (`.github/workflows/website-v1-0.yml`) from dormant to active. While the parenthetical was present, that workflow's `check_state` job marked the branch as the live "latest" and skipped its deploy job — leaving `docs.dapr.io` (driven by `website-root.yml`) as the sole deploy target. Once you commit this change, future pushes to `v1.0` will deploy to `v1-0.docs.dapr.io` via `website-v1-0.yml`.
 
 1. Delete `.github/workflows/website-root.yml`.
 1. Commit the staged changes and push to your branch (`release_v1.0`).
@@ -150,6 +173,12 @@ These steps will prepare the upcoming release branch for promotion to latest rel
 
    ```yaml
    # Versioning
+   # NOTE: adding the "(latest)" suffix below silences the version-specific
+   # workflow (.github/workflows/website-v1-1.yml). Its check_state job
+   # detects "(latest)" in params.version_menu and skips its deploy job,
+   # leaving website-root.yml as the sole deploy target while v1.1 is latest.
+   # Do not delete website-v1-1.yml — it must remain so that it can take
+   # over deploying v1-1.docs.dapr.io once v1.1 is later archived.
    version_menu: "v1.1 (latest)"
    version: "v1.1"
    archived_version: false

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -100,7 +100,7 @@ markup:
 
 # Comment out if you don't want the "print entire section" link enabled.
 outputs:
-  section: [HTML, print, RSS]
+  section: [HTML, RSS]
 
 params:
   taxonomy:


### PR DESCRIPTION
Since the latest version of Docs is deployed via website-root.yaml, the deployment of the website-<version>.yaml is limited to either the preview or archived state, so the current Docs version is never deployed to two Static Web Apps.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
