### PR TITLE
Clarify relative paths for local file components

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-cryptography/local-storage.md
+++ b/daprdocs/content/en/reference/components-reference/supported-cryptography/local-storage.md
@@ -46,7 +46,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 | Field              | Required | Details | Example |
 |--------------------|:--------:|---------|---------|
-| `path`             | Y        | Folder containing the keys to be loaded. When loading a key, the name of the key will be used as name of the file in this folder.  | `/path/to/folder` |
+| `path`             | Y        | Folder containing the keys to be loaded. Relative paths are resolved from the directory where the application is run; in Multi-App Run, this is the app's `appDirPath`. When loading a key, the key name is used as the file name in this folder. | `/path/to/folder` |
 
 **Example**
 

--- a/daprdocs/content/en/reference/components-reference/supported-secret-stores/file-secret-store.md
+++ b/daprdocs/content/en/reference/components-reference/supported-secret-stores/file-secret-store.md
@@ -38,7 +38,7 @@ spec:
 
 | Field              | Required | Details                                                                 | Example                  |
 |--------------------|:--------:|-------------------------------------------------------------------------|--------------------------|
-| secretsFile        | Y        | The path to the file where secrets are stored   | `"path/to/file.json"` |
+| secretsFile        | Y        | The path to the file where secrets are stored. Relative paths are resolved from the directory where the application is run; in Multi-App Run, this is the app's `appDirPath`. | `"path/to/file.json"` |
 | nestedSeparator    | N        | Used by the store when flattening the JSON hierarchy to a map. Defaults to `":"` | `":"` 
 | multiValued        | N        | `"true"` sets the `multipleKeyValuesPerSecret` behavior. Allows one level of multi-valued key/value pairs before flattening JSON hierarchy. Defaults to `"false"` | `"true"` |
 


### PR DESCRIPTION
## Summary
- clarify how relative local file paths are resolved for the file secret store
- add the same guidance for the local storage cryptography component
- mention Multi-App Run `appDirPath` for multi-app setups

Fixes #3305