### PR TITLE
docs(redis): document Valkey 8.x/9.x support for Redis state store and pub/sub

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/redis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/redis.md
@@ -166,7 +166,7 @@ An HTTP 204 (No Content) and empty body is returned if successful.
 
 ## Supported servers and versions
 
-The Redis binding component works against any RESP-compatible server. Confirmed supported versions:
+Dapr's Redis binding component is tested against the following Redis and Valkey versions:
 
 | Server | Versions |
 |--------|----------|

--- a/daprdocs/content/en/reference/components-reference/supported-bindings/redis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/redis.md
@@ -164,11 +164,18 @@ You can delete a record in Redis using the `delete` operation. Returns success w
 An HTTP 204 (No Content) and empty body is returned if successful.
 
 
+## Supported servers and versions
+
+The Redis binding component works against any RESP-compatible server. Confirmed supported versions:
+
+| Server | Versions |
+|--------|----------|
+| Redis | 6.x, 7.x |
+| [Valkey](https://valkey.io) | 8.x, 9.x |
+
 ## Create a Redis instance
 
-Dapr can use any Redis instance - containerized, running on your local dev machine, or a managed cloud service, provided the version of Redis is 5.0.0 or later.
-
-*Note: Dapr does not support Redis >= 7. It is recommended to use Redis 6*
+Dapr can use any Redis instance - containerized, running on your local dev machine, or a managed cloud service.
 
 {{< tabpane text=true >}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-locks/redis-lock.md
+++ b/daprdocs/content/en/reference/components-reference/supported-locks/redis-lock.md
@@ -109,7 +109,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 ## Supported servers and versions
 
-The Redis lock component works against any RESP-compatible server. Confirmed supported versions:
+Dapr's Redis lock component is tested against the following Redis and Valkey versions:
 
 | Server | Versions |
 |--------|----------|

--- a/daprdocs/content/en/reference/components-reference/supported-locks/redis-lock.md
+++ b/daprdocs/content/en/reference/components-reference/supported-locks/redis-lock.md
@@ -107,6 +107,15 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | idleCheckFrequency    |    N     | Frequency of idle checks made by idle connections reaper. Default is `"1m"`. `"-1"` disables idle connections reaper.                                                                                                                                                                                             | `"-1"`                                                          |
 | idleTimeout           |    N     | Amount of time after which the client closes idle connections. Should be less than server's timeout. Default is `"5m"`. `"-1"` disables idle timeout check.                                                                                                                                                       | `"10m"`                                                         |
 
+## Supported servers and versions
+
+The Redis lock component works against any RESP-compatible server. Confirmed supported versions:
+
+| Server | Versions |
+|--------|----------|
+| Redis | 6.x, 7.x |
+| [Valkey](https://valkey.io) | 8.x, 9.x |
+
 ## Setup Redis
 
 Dapr can use any Redis instance: containerized, running on your local dev machine, or a managed cloud service.

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
@@ -87,7 +87,7 @@ The Redis pub/sub component works against any RESP-compatible server. Confirmed 
 
 ## Create a Redis instance
 
-Dapr can use any Redis instance - containerized, running on your local dev machine, or a managed cloud service, provided the version of Redis is 5.x, 6.x, or 7.x. [Valkey](https://valkey.io) 8.x and 9.x are also supported as a drop-in replacement.
+Dapr can use any Redis instance - containerized, running on your local dev machine, or a managed cloud service. Confirmed supported versions are Redis 6.x and 7.x, and [Valkey](https://valkey.io) 8.x and 9.x as a drop-in replacement.
 
 {{< tabpane text=true >}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
@@ -78,7 +78,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 
 ## Supported servers and versions
 
-The Redis pub/sub component works against any RESP-compatible server. Confirmed supported versions:
+Dapr's Redis pub/sub component is tested against the following Redis and Valkey versions:
 
 | Server | Versions |
 |--------|----------|

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
@@ -87,7 +87,7 @@ Dapr's Redis pub/sub component is tested against the following Redis and Valkey 
 
 ## Create a Redis instance
 
-Dapr can use any Redis instance - containerized, running on your local dev machine, or a managed cloud service. Confirmed supported versions are Redis 6.x and 7.x, and [Valkey](https://valkey.io) 8.x and 9.x as a drop-in replacement.
+Dapr can use any Redis instance - containerized, running on your local dev machine, or a managed cloud service. The component has been tested against Redis 6.x and 7.x, and [Valkey](https://valkey.io) 8.x and 9.x.
 
 {{< tabpane text=true >}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-redis-pubsub.md
@@ -76,9 +76,18 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | maxLenApprox        | N        | Maximum number of items inside a stream.The old entries are automatically evicted when the specified length is reached, so that the stream is left at a constant size. Defaults to unlimited. Cannot be used together with streamTTL; only one stream trimming strategy can be active at a time. | `"10000"`
 | streamTTL        | N        | TTL duration for stream entries. Entries older than this duration will be evicted. This is an approximate value, as it's implemented using Redis stream's `MINID` trimming with the '~' modifier. The actual retention may include slightly more entries than strictly defined by the TTL, as Redis optimizes the trimming operation for efficiency by potentially keeping some additional entries. Cannot be used together with maxLenApprox; only one stream trimming strategy can be active at a time. | `"30d"`
 
+## Supported servers and versions
+
+The Redis pub/sub component works against any RESP-compatible server. Confirmed supported versions:
+
+| Server | Versions |
+|--------|----------|
+| Redis | 6.x, 7.x |
+| [Valkey](https://valkey.io) | 8.x, 9.x |
+
 ## Create a Redis instance
 
-Dapr can use any Redis instance - containerized, running on your local dev machine, or a managed cloud service, provided the version of Redis is 5.x or 6.x.
+Dapr can use any Redis instance - containerized, running on your local dev machine, or a managed cloud service, provided the version of Redis is 5.x, 6.x, or 7.x. [Valkey](https://valkey.io) 8.x and 9.x are also supported as a drop-in replacement.
 
 {{< tabpane text=true >}}
 

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
@@ -141,6 +141,19 @@ If you wish to use Redis as an actor store, append the following to the yaml.
 | queryIndexes       | N         | Indexing schemas for querying JSON objects | see [Querying JSON objects](#querying-json-objects)
 | actorStateStore    | N        | Consider this state store for actors. Defaults to `"false"` | `"true"`, `"false"`
 
+## Supported servers and versions
+
+The Redis state store component works against any RESP-compatible server. Confirmed supported versions:
+
+| Server | Versions | Notes |
+|--------|----------|-------|
+| Redis | 6.x, 7.x | v6 supports the Query API with the RediSearch module |
+| [Valkey](https://valkey.io) | 8.x, 9.x | Stock `valkey/valkey` images do not ship RediSearch; the Query API is not available |
+
+{{% alert title="Valkey and the Query API" color="warning" %}}
+Stock Valkey images (`valkey/valkey:8.x`, `valkey/valkey:9.x`) do not bundle the RediSearch module. The [Query API]({{% ref "state_api.md#query-state" %}}) and the `queryIndexes` metadata field require RediSearch and will not work against a plain Valkey instance. All other state-store operations (CRUD, TTL, transactions, actor state) work normally.
+{{% /alert %}}
+
 ## Setup Redis
 
 Dapr can use any Redis instance: containerized, running on your local dev machine, or a managed cloud service.

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
@@ -143,15 +143,15 @@ If you wish to use Redis as an actor store, append the following to the yaml.
 
 ## Supported servers and versions
 
-The Redis state store component works against any RESP-compatible server. Confirmed supported versions:
+Dapr's Redis state store component is tested against the following Redis and Valkey versions:
 
 | Server | Versions | Notes |
 |--------|----------|-------|
-| Redis | 6.x, 7.x | v6 supports the Query API with the RediSearch module |
-| [Valkey](https://valkey.io) | 8.x, 9.x | Stock `valkey/valkey` images do not ship RediSearch; the Query API is not available |
+| Redis | 6.x, 7.x | The Query API requires the RediSearch **and** RedisJSON modules |
+| [Valkey](https://valkey.io) | 8.x, 9.x | Stock `valkey/valkey` images do not ship RediSearch or RedisJSON; the Query API is not available |
 
 {{% alert title="Valkey and the Query API" color="warning" %}}
-Stock Valkey images (`valkey/valkey:8.x`, `valkey/valkey:9.x`) do not bundle the RediSearch module. The [Query API]({{% ref "state_api.md#query-state" %}}) and the `queryIndexes` metadata field require RediSearch and will not work against a plain Valkey instance. All other state-store operations (CRUD, TTL, transactions, actor state) work normally.
+Stock Valkey images (`valkey/valkey:8.x`, `valkey/valkey:9.x`) do not bundle the RediSearch or RedisJSON modules. The [Query API]({{% ref "state_api.md#query-state" %}}) and the `queryIndexes` metadata field require both RediSearch and RedisJSON and will not work against a plain Valkey instance. All other state-store operations (CRUD, TTL, transactions, actor state) work normally.
 {{% /alert %}}
 
 ## Setup Redis

--- a/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
+++ b/daprdocs/content/en/reference/components-reference/supported-state-stores/setup-redis.md
@@ -148,7 +148,7 @@ Dapr's Redis state store component is tested against the following Redis and Val
 | Server | Versions | Notes |
 |--------|----------|-------|
 | Redis | 6.x, 7.x | The Query API requires the RediSearch **and** RedisJSON modules |
-| [Valkey](https://valkey.io) | 8.x, 9.x | Stock `valkey/valkey` images do not ship RediSearch or RedisJSON; the Query API is not available |
+| [Valkey](https://valkey.io) | 8.x, 9.x | The Query API is not available by default; it requires the RediSearch and RedisJSON modules to be installed |
 
 {{% alert title="Valkey and the Query API" color="warning" %}}
 Stock Valkey images (`valkey/valkey:8.x`, `valkey/valkey:9.x`) do not bundle the RediSearch or RedisJSON modules. The [Query API]({{% ref "state_api.md#query-state" %}}) and the `queryIndexes` metadata field require both RediSearch and RedisJSON and will not work against a plain Valkey instance. All other state-store operations (CRUD, TTL, transactions, actor state) work normally.


### PR DESCRIPTION
## Summary

Documents that the Dapr Redis-backed components work against [Valkey](https://valkey.io) 8.x and 9.x.

Closes Linear OSS-863.

### What this PR changes

- **`supported-state-stores/setup-redis.md`** — adds a "Supported servers and versions" section with a table listing Redis 6.x/7.x and Valkey 8.x/9.x, plus a warning callout explaining that stock Valkey images do not ship the RediSearch/RedisJSON modules and therefore the Query API is not available against plain Valkey.
- **`supported-pubsub/setup-redis-pubsub.md`** — adds a "Supported servers and versions" section with the same table, and updates the "Create a Redis instance" paragraph from "5.x or 6.x" to include 7.x and Valkey 8.x/9.x.
- **`supported-locks/redis-lock.md`** — adds a "Supported servers and versions" table for the Redis lock component.
- **`supported-bindings/redis.md`** — adds a "Supported servers and versions" table for the Redis binding component and removes the outdated Redis >= 7 note.

### RediSearch / Query API limitation

Stock `valkey/valkey` images do not include the RediSearch and RedisJSON modules. The state store Query API (`queryIndexes`, `query` operation) requires both modules and will not work against a plain Valkey instance. This is documented explicitly via a warning callout. All other operations — CRUD, TTL, transactions, pub/sub, bindings, lock, configuration — work normally.

## Testing

Conformance tests for all Redis-backed components (state, pubsub, bindings, lock, configuration) pass against both `valkey/valkey:8.0.2` and `valkey/valkey:9.0.0` locally. See the companion components-contrib PR for full test output.

Pending CI:
- ☐ Hugo build / link checks

## Related

Components-contrib PR: dapr/components-contrib#4414 — adds the Valkey entries to the conformance test matrix.
