### PR TITLE
docs: document UriUtils.encodePath for Java client service invocation

### DIFF
--- a/sdkdocs/java/content/en/java-sdk-docs/java-client/_index.md
+++ b/sdkdocs/java/content/en/java-sdk-docs/java-client/_index.md
@@ -86,11 +86,26 @@ try (DaprClient client = new DaprClientBuilder().build()) {
 
 `DaprBodyPublishers.json(...)` serializes the payload using the SDK's default Jackson serializer, matching the JSON encoding the deprecated `invokeMethod` APIs applied internally. For raw payloads use any `HttpRequest.BodyPublisher` (for example `HttpRequest.BodyPublishers.ofString(...)`).
 
+{{% alert title="Encode path segments with special characters" color="primary" %}}
+`newRequestBuilder(relativePath)` resolves the path as-is — it does **not** encode it for you. If a path segment may contain characters that are illegal in a URI (for example spaces), encode it first with `io.dapr.utils.UriUtils.encodePath(...)`; passing such characters directly throws `IllegalArgumentException`. `encodePath` percent-encodes each `/`-delimited segment (preserving the separators and any leading slash) and appends the query string unchanged, mirroring the per-segment encoding the deprecated `invokeMethod` APIs applied internally.
+
+```java
+import io.dapr.utils.UriUtils;
+
+// "Name With Spaces" -> "Name%20With%20Spaces"
+HttpRequest request = invoker.newRequestBuilder(
+        UriUtils.encodePath("orders/Name With Spaces"))
+    .GET()
+    .build();
+```
+{{% /alert %}}
+
 The table below summarizes which concerns `DaprInvokeHttpClient` handles for you (when configured with `DaprClientBuilder`) and which belong to the user:
 
 | Concern | Handled by the SDK | User's responsibility |
 |---|---|---|
 | Invoke URL (`/v1.0/invoke/{appId}/method/...`) | ✓ — resolved against the sidecar endpoint, which defaults to `http://localhost:3500` (override via `DAPR_HTTP_ENDPOINT`, or `DAPR_SIDECAR_IP` + `DAPR_HTTP_PORT`) | |
+| URL path encoding | | Encode segments that may contain characters illegal in a URI (e.g. spaces) with `UriUtils.encodePath(...)`. `newRequestBuilder` resolves the path unchanged and throws `IllegalArgumentException` on illegal characters. |
 | `dapr-api-token` header | ✓ — attached only when configured via the `dapr.api.token` system property or `DAPR_API_TOKEN` environment variable | |
 | HTTP read timeout | ✓ — defaults to **60 seconds**; override via the `dapr.http.client.readTimeoutSeconds` system property or `DAPR_HTTP_CLIENT_READ_TIMEOUT_SECONDS` environment variable | |
 | `User-Agent: dapr-sdk-java/<version>` header | ✓ — value tracks the SDK version automatically | |

--- a/sdkdocs/java/content/en/java-sdk-docs/java-client/_index.md
+++ b/sdkdocs/java/content/en/java-sdk-docs/java-client/_index.md
@@ -86,8 +86,7 @@ try (DaprClient client = new DaprClientBuilder().build()) {
 
 `DaprBodyPublishers.json(...)` serializes the payload using the SDK's default Jackson serializer, matching the JSON encoding the deprecated `invokeMethod` APIs applied internally. For raw payloads use any `HttpRequest.BodyPublisher` (for example `HttpRequest.BodyPublishers.ofString(...)`).
 
-{{% alert title="Encode path segments with special characters" color="primary" %}}
-`newRequestBuilder(relativePath)` resolves the path as-is — it does **not** encode it for you. If a path segment may contain characters that are illegal in a URI (for example spaces), encode it first with `io.dapr.utils.UriUtils.encodePath(...)`; passing such characters directly throws `IllegalArgumentException`. `encodePath` percent-encodes each `/`-delimited segment (preserving the separators and any leading slash) and appends the query string unchanged, mirroring the per-segment encoding the deprecated `invokeMethod` APIs applied internally.
+`newRequestBuilder(relativePath)` resolves the path as-is without encoding it for you. If a path segment may contain characters that are illegal in a URI (for example spaces), encode it first with `io.dapr.utils.UriUtils.encodePath(...)` method. Without this encoding, passing such characters directly throws an `IllegalArgumentException`. The `encodePath` method percent-encodes each forward-slash delimited segment (`/`), preserving the separators and any leading slashes, and appends the query string unchanged. This behavior mirrors the per-segment encoding that the deprecated `invokeMethod` APIs applied automatically:
 
 ```java
 import io.dapr.utils.UriUtils;
@@ -98,17 +97,16 @@ HttpRequest request = invoker.newRequestBuilder(
     .GET()
     .build();
 ```
-{{% /alert %}}
 
 The table below summarizes which concerns `DaprInvokeHttpClient` handles for you (when configured with `DaprClientBuilder`) and which belong to the user:
 
 | Concern | Handled by the SDK | User's responsibility |
 |---|---|---|
 | Invoke URL (`/v1.0/invoke/{appId}/method/...`) | ✓ — resolved against the sidecar endpoint, which defaults to `http://localhost:3500` (override via `DAPR_HTTP_ENDPOINT`, or `DAPR_SIDECAR_IP` + `DAPR_HTTP_PORT`) | |
-| URL path encoding | | Encode segments that may contain characters illegal in a URI (e.g. spaces) with `UriUtils.encodePath(...)`. `newRequestBuilder` resolves the path unchanged and throws `IllegalArgumentException` on illegal characters. |
 | `dapr-api-token` header | ✓ — attached only when configured via the `dapr.api.token` system property or `DAPR_API_TOKEN` environment variable | |
 | HTTP read timeout | ✓ — defaults to **60 seconds**; override via the `dapr.http.client.readTimeoutSeconds` system property or `DAPR_HTTP_CLIENT_READ_TIMEOUT_SECONDS` environment variable | |
 | `User-Agent: dapr-sdk-java/<version>` header | ✓ — value tracks the SDK version automatically | |
+| URL path encoding | | Encode path segments that may contain characters illegal in a URI (e.g. spaces) with `UriUtils.encodePath(...)`. The `newRequestBuilder` method resolves the path unchanged and throws `IllegalArgumentException` on illegal characters. |
 | `Content-Type` header | | Set via `.header("Content-Type", "...")` |
 | Request body serialization | | Use `DaprBodyPublishers.json(...)` for default JSON, or any `HttpRequest.BodyPublisher` |
 | Response body deserialization | | Pick an `HttpResponse.BodyHandler` (`ofString`, `ofByteArray`, custom) |


### PR DESCRIPTION
newRequestBuilder no longer encodes the path; document that callers must encode segments containing URI-illegal characters (e.g. spaces) with UriUtils.encodePath, and that passing them raw throws IllegalArgumentException. Reflects dapr/java-sdk#1774.

Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
