### PR TITLE
docs(kafka): document numPartitions and replicationFactor metadata

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/kafka.md
@@ -45,6 +45,10 @@ spec:
     value: "newest"
   - name: maxMessageBytes # Optional.
     value: "1024"
+  - name: numPartitions # Optional.
+    value: 3
+  - name: replicationFactor # Optional.
+    value: 3
   - name: heartbeatInterval # Optional.
     value: 5s
   - name: sessionTimeout # Optional.
@@ -84,6 +88,8 @@ spec:
 | `saslMechanism` | N | Input/Output | The SASL authentication mechanism you'd like to use. Only required if `authtype` is set to `"password"`. If not provided, defaults to `PLAINTEXT`, which could cause a break for some services, like Amazon Managed Service for Kafka. | `"SHA-512", "SHA-256", "PLAINTEXT"` |
 | `initialOffset`   | N | Input | The initial offset to use if no offset was previously committed. Should be "newest" or "oldest". Defaults to "newest". | `"oldest"` |
 | `maxMessageBytes` | N | Input/Output | The maximum size in bytes allowed for a single Kafka message. Defaults to 1024. | `"2048"` |
+| `numPartitions` | N | Input/Output | If set to a value greater than 0, Dapr creates the topic with this many partitions if it doesn't already exist. Defaults to `0`, meaning Dapr does not create topics and leaves this to the broker's auto-create behavior or external provisioning. Not supported when `authType` is `awsiam`. | `"3"` |
+| `replicationFactor` | N | Input/Output | The replication factor used when Dapr creates the topic. Only applies when `numPartitions` is set. Defaults to `1`. | `"3"` |
 | `oidcTokenEndpoint` | N | Input/Output | Full URL to an OAuth2 identity provider access token endpoint. Required when `authType` is set to `oidc` or `oidc_private_key_jwt` | "https://identity.example.com/v1/token" |
 | `oidcClientID` | N | Input/Output | The OAuth2 client ID that has been provisioned in the identity provider. Required when `authType` is set to `oidc` or `oidc_private_key_jwt` | `"dapr-kafka"` |
 | `oidcClientSecret` | N | Input/Output | The OAuth2 client secret that has been provisioned in the identity provider: Required when `authType` is set to `oidc` | `"KeFg23!"` |

--- a/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
+++ b/daprdocs/content/en/reference/components-reference/supported-pubsub/setup-apache-kafka.md
@@ -43,6 +43,10 @@ spec:
     value: "SHA-512"
   - name: maxMessageBytes # Optional.
     value: 1024
+  - name: numPartitions # Optional.
+    value: 3
+  - name: replicationFactor # Optional.
+    value: 3
   - name: consumeRetryInterval # Optional.
     value: 200ms
   - name: heartbeatInterval # Optional.
@@ -95,6 +99,8 @@ spec:
 | saslMechanism      | N | The SASL Authentication Mechanism you wish to use. Only required if `authType` is set to `"password"`. Defaults to `PLAINTEXT` | `"SHA-512", "SHA-256", "PLAINTEXT"`
 | initialOffset       | N | The initial offset to use if no offset was previously committed. Should be "newest" or "oldest". Defaults to "newest". | `"oldest"`
 | maxMessageBytes     | N | The maximum size in bytes allowed for a single Kafka message. Defaults to 1024. | `2048`
+| numPartitions | N | If set to a value greater than 0, Dapr creates the topic with this many partitions if it doesn't already exist. Defaults to `0`, meaning Dapr does not create topics and leaves this to the broker's auto-create behavior or external provisioning. Not supported when `authType` is `awsiam`. | `3` |
+| replicationFactor | N | The replication factor used when Dapr creates the topic. Only applies when `numPartitions` is set. Defaults to `1`. | `3` |
 | consumeRetryInterval | N | The interval between retries when attempting to consume topics. Treats numbers without suffix as milliseconds. Defaults to 100ms. | `200ms` |
 | consumeRetryEnabled | N | Disable consume retry by setting `"false"` | `"true"`, `"false"` |
 | version               | N | Kafka cluster version. Defaults to 2.0.0. Note that this must be set to `1.0.0` if you are using Azure EventHubs with Kafka. | `0.10.2.0` |


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Documents the new `numPartitions` and `replicationFactor` metadata fields for the Kafka pubsub and Kafka binding components, added in the corresponding `dapr/components-contrib` PR. Updates the component YAML examples and spec metadata tables in both `setup-apache-kafka.md` and `bindings/kafka.md`, including the `awsiam` auth restriction.


## Issue reference

Companion docs for dapr/components-contrib#3110