### PR TITLE
Add trackingSettings to Twilio SendGrid binding spec

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/sendgrid.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/sendgrid.md
@@ -39,6 +39,8 @@ spec:
     value: "d-123456789" # optional
   - name: dynamicTemplateData
     value: '{"customer":{"name":"John Smith"}}' # optional
+  - name: trackingSettings
+    value: '{"click_tracking":{"enable":true},"open_tracking":{"enable":true}}' # optional
   - name: apiKey
     value: "YOUR_API_KEY" # required, this is your SendGrid key
 ```
@@ -59,6 +61,7 @@ The above example uses secrets as plain strings. It is recommended to use a secr
 | `emailCc` | N | Output | If set this specifies the 'cc' email address of the email message. Only a single email address is allowed. Optional field, see [below](#example-request-payload) | `"me@example.com"` |
 | `emailBcc` | N | Output | If set this specifies the 'bcc' email address of the email message. Only a single email address is allowed. Optional field, see [below](#example-request-payload) | `"me@example.com"` |
 | `subject` | N | Output | If set this specifies the subject of the email message. Optional field, see [below](#example-request-payload) | `"subject of the email"` |
+| `trackingSettings` | N | Output | If set this specifies the [SendGrid tracking settings](https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send#request-body) for the email message, as a JSON object using SendGrid API field names (`click_tracking`, `open_tracking`, `subscription_tracking`, `ganalytics`). Can also be set per request; request-level settings override the component-level value. Optional field, see [below](#email-tracking-settings) | `'{"click_tracking":{"enable":true},"open_tracking":{"enable":true}}'` |
 
 ## Binding support
 
@@ -93,6 +96,22 @@ If a dynamic template is used, a `dynamicTemplateId` needs to be provided and th
     "dynamicTemplateId": "d-123456789",
     "dynamicTemplateData": "{\"customer\":{\"name\":\"John Smith\"}}"
   }
+}
+```
+
+## Email tracking settings
+
+Email tracking can be configured with the `trackingSettings` metadata field, either on the component (shown [above](#component-format)) or per request. The value is a JSON object using the field names from the [SendGrid mail send API](https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send#request-body): `click_tracking`, `open_tracking`, `subscription_tracking`, and `ganalytics`. When set on the request, it overrides the component-level value:
+
+```json
+{
+  "operation": "create",
+  "metadata": {
+    "emailTo": "changeme@example.net",
+    "subject": "An email from Dapr SendGrid binding",
+    "trackingSettings": "{\"click_tracking\":{\"enable\":true,\"enable_text\":true},\"open_tracking\":{\"enable\":true},\"subscription_tracking\":{\"enable\":false},\"ganalytics\":{\"enable\":true,\"utm_source\":\"transactional-email\",\"utm_medium\":\"email\"}}"
+  },
+  "data": "<h1>Testing Dapr Bindings</h1>This is a test.<br>Bye!"
 }
 ```
 


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within tabpane
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Documents the new optional `trackingSettings` metadata field on the Twilio SendGrid output binding spec page:

- Added `trackingSettings` to the component format example
- Added a `trackingSettings` row to the spec metadata fields table
- Added an "Email tracking settings" section with a per-request example and a note that request-level settings override the component-level value

Implementation PR: dapr/components-contrib#4456

## Issue reference

dapr/components-contrib#4455
