### PR TITLE
Clarify retry status-code matching doesn't apply to bulk subscribe RETRY

### DIFF
--- a/daprdocs/content/en/operations/resiliency/policies/retries/retries-overview.md
+++ b/daprdocs/content/en/operations/resiliency/policies/retries/retries-overview.md
@@ -132,12 +132,10 @@ spec:
           gRPCStatusCodes: "4,8-11,13,14" # retry gRPC status codes in these ranges and separate single codes.
 ```
 
-{{% alert title="Note" color="primary" %}}
-Field values for status codes must follow the format specified above. An incorrectly formatted value produces an error log ("Could not read resiliency policy") and the `daprd` startup sequence will proceed.
-{{% /alert %}}
+Retry filtering on status codes only filters on the transport-level status code of the call to your application. It does not apply to [bulk subscribe]({{% ref pubsub-bulk.md %}}), since that status isn't carried as an HTTP or gRPC status code. For instance, a bulk subscribe handler returning `RETRY` for an entry is always retried according to the policy's settings, regardless of what codes are configured.
 
 {{% alert title="Note" color="primary" %}}
-`matching.httpStatusCodes` and `matching.gRPCStatusCodes` only filter on the transport-level status code of the call to your application. They don't apply to the `RETRY` status returned in a [bulk subscribe]({{% ref pubsub-bulk.md %}}) response body, since that status isn't carried as an HTTP or gRPC status code. A bulk subscribe handler returning `RETRY` for an entry is always retried according to the policy's `duration`/`maxRetries`/backoff settings, regardless of what codes are configured in `matching`.
+Field values for status codes must follow the format specified above. An incorrectly formatted value produces an error log ("Could not read resiliency policy") and the `daprd` startup sequence will proceed.
 {{% /alert %}}
 
 ## Demo 

--- a/daprdocs/content/en/operations/resiliency/policies/retries/retries-overview.md
+++ b/daprdocs/content/en/operations/resiliency/policies/retries/retries-overview.md
@@ -136,6 +136,10 @@ spec:
 Field values for status codes must follow the format specified above. An incorrectly formatted value produces an error log ("Could not read resiliency policy") and the `daprd` startup sequence will proceed.
 {{% /alert %}}
 
+{{% alert title="Note" color="primary" %}}
+`matching.httpStatusCodes` and `matching.gRPCStatusCodes` only filter on the transport-level status code of the call to your application. They don't apply to the `RETRY` status returned in a [bulk subscribe]({{% ref pubsub-bulk.md %}}) response body, since that status isn't carried as an HTTP or gRPC status code. A bulk subscribe handler returning `RETRY` for an entry is always retried according to the policy's `duration`/`maxRetries`/backoff settings, regardless of what codes are configured in `matching`.
+{{% /alert %}}
+
 ## Demo 
 
 Watch a demo presented during [Diagrid's Dapr v1.15 celebration](https://www.diagrid.io/videos/dapr-1-15-deep-dive) to see how to set retry status code filters using Diagrid Conductor


### PR DESCRIPTION
## Summary
- `matching.httpStatusCodes`/`matching.gRPCStatusCodes` only filter on the transport-level status code of the call to the application.
- A bulk subscribe handler's per-entry `RETRY` status is returned in the response body, not as an HTTP/gRPC status code, so it is not affected by `matching` and is always retried per the policy's `duration`/`maxRetries`/backoff.
- Added a note to the "Retry filter based on status codes" section of the retries overview page to call this out, with a link to the bulk subscribe docs.

## Test plan
- [x] Verified against the dapr/dapr runtime source (`pkg/resiliency/policy.go`, `pkg/runtime/subscription/bulkresiliency.go`, `pkg/runtime/subscription/postman/http/http.go`, `pkg/runtime/subscription/postman/grpc/grpc.go`): the `matching` filter only fires when the error is a `resiliency.CodeError`, and bulk subscribe's per-entry `RETRY` never produces one.
- [ ] Docs site preview build (Hugo) once CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)