### PR TITLE
[1.19] Hot reloading of the actor state store

### DIFF
--- a/daprdocs/content/en/operations/components/component-secrets.md
+++ b/daprdocs/content/en/operations/components/component-secrets.md
@@ -138,7 +138,7 @@ Keep in mind the following when relying on this behavior:
 - Changes to secret values are picked up by the periodic reconciler, so it can take up to 60 seconds for the new value to be applied.
 - The component is unavailable for a short period of time while it is closed and re-initialized.
 - This requires [hot reloading]({{% ref "component-updates.md#hot-reloading" %}}) to be enabled, which is the default. If the `HotReload` feature is disabled, secret changes are only picked up when the Dapr sidecar is restarted.
-- Component types that are [excluded from hot reloading]({{% ref "component-updates.md#components-and-subscriptions" %}}) include Actor state stores and Workflow backends, do not pick up secret changes and require a Dapr sidecar restart.
+- In Dapr 1.18.2 and earlier, the actor state store is [excluded from hot reloading]({{% ref "component-updates.md#components-and-subscriptions" %}}), does not pick up secret changes, and requires a Dapr sidecar restart. Since Dapr 1.18.3, the actor state store is reloaded like any other component, and a secret rotation swaps the store instance without interrupting actor hosting.
 {{% /alert %}}
 
 ### Other secret stores

--- a/daprdocs/content/en/operations/components/component-updates.md
+++ b/daprdocs/content/en/operations/components/component-updates.md
@@ -42,10 +42,22 @@ That is, the behaviour is the same as when the sidecar loads components on boot.
 - `spec.ignoreErrors=true`: the sidecar continues to run with neither the old or new component configuration registered.
 {{% /alert %}}
 
-All components are supported for hot reloading except for the following types.
-Any create, update, or deletion of these component types is ignored by the sidecar with a restart required to pick up changes.
-- [Actor State Stores]({{% ref "state_api.md#configuring-state-store-for-actors" %}})
-- [Workflow Backends]({{% ref "workflow-architecture.md#workflow-backend" %}})
+All component types are supported for hot reloading.
+
+{{% alert title="Actor State Stores in Dapr 1.18.2 and earlier" color="warning" %}}
+In Dapr 1.18.2 and earlier, the [actor state store]({{% ref "state_api.md#configuring-state-store-for-actors" %}}) is excluded from hot reloading.
+Any create, update, or deletion of the actor state store component is ignored by the sidecar, with a restart required to pick up changes.
+{{% /alert %}}
+
+#### Actor State Stores
+
+Since Dapr 1.18.3, the [actor state store]({{% ref "state_api.md#configuring-state-store-for-actors" %}}) is also hot reloaded, and the actors runtime reconciles actor hosting with the configured store at runtime:
+
+- **Adding** an actor state store enables actor hosting and the workflow APIs, including for workflow workers that connected before the store existed.
+- **Removing** the actor state store drains and deactivates hosted actors, and de-advertises actor types from the placement and scheduler services. Actor state and workflow APIs return errors until a store is configured again. The Dapr sidecar keeps running, and actor hosting resumes automatically when a store is re-added.
+- **Updating** the actor state store in place, for example a reload picking up a rotated secret, swaps the store instance without interrupting actor hosting. Actors are only drained when the store is removed, unmarked as the actor state store, or replaced by a component with a different name.
+
+Only a single actor state store may be configured. Hot loading a second component marked as the actor state store is skipped with an error logged, and that component is applied if the current actor state store is later removed.
 
 #### Referenced Kubernetes secrets
 


### PR DESCRIPTION
Since Dapr 1.18.3, the actor state store is no longer excluded from hot reloading. The actors runtime now reconciles actor hosting with the configured store at runtime: adding a store enables actor hosting and the workflow APIs, removing it drains hosted actors until a store returns, and in-place updates (such as a rotated secret) swap the store instance without interrupting actor hosting.

Added in dapr/dapr#10309, backported to release-1.18 (v1.18.3) in dapr/dapr#10325.