### PR TITLE
fix: repair broken click targets on docs.dapr.io

### DIFF
--- a/daprdocs/content/en/getting-started/quickstarts/resiliency/resiliency-serviceinvo-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/resiliency/resiliency-serviceinvo-quickstart.md
@@ -1176,6 +1176,6 @@ We're continuously working to improve our Quickstart examples and value your fee
 Join the discussion in our [discord channel](https://discord.com/channels/778680217417809931/953427615916638238).
 
 ## Next steps
-Visit [this](https://docs.dapr.io/operations/resiliency/resiliency-overview//) link for more information about Dapr resiliency.
+Visit [this](https://docs.dapr.io/operations/resiliency/resiliency-overview/) link for more information about Dapr resiliency.
 
 {{< button text="Explore Dapr tutorials  >>" page="getting-started/tutorials/_index.md" >}}

--- a/daprdocs/content/en/getting-started/quickstarts/secrets-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/secrets-quickstart.md
@@ -141,7 +141,7 @@ For this example, you will need:
 
 ### Step 1: Set up the environment
 
-Clone the [sample provided in the Quickstarts repo](hhttps://github.com/dapr/quickstarts/tree/master/secrets_management/javascript/sdk).
+Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/secrets_management/javascript/sdk).
 
 ```bash
 git clone https://github.com/dapr/quickstarts.git

--- a/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
+++ b/daprdocs/content/en/getting-started/quickstarts/statemanagement-quickstart.md
@@ -565,7 +565,7 @@ For this example, you will need:
 
 ### Step 1: Set up the environment
 
-Clone the [sample provided in the Quickstarts repo](hhttps://github.com/dapr/quickstarts/tree/master/state_management/go/sdk).
+Clone the [sample provided in the Quickstarts repo](https://github.com/dapr/quickstarts/tree/master/state_management/go/sdk).
 
 ```bash
 git clone https://github.com/dapr/quickstarts.git

--- a/daprdocs/content/en/operations/observability/metrics/metrics-overview.md
+++ b/daprdocs/content/en/operations/observability/metrics/metrics-overview.md
@@ -72,7 +72,7 @@ spec:
 
 ## Configuring metrics for error codes
 
-You can enable additional metrics for [Dapr API error codes](https://docs.dapr.io/reference/api/error_codes/) by setting `spec.metrics.recordErrorCodes` to `true`. Dapr APIs which communicate back to their caller may return standardized error codes. [A new metric called `error_code_total` is recorded]({{% ref errors-overview.md %}}), which allows monitoring of error codes triggered by application, code, and category. See [the `errorcodes` package](https://github.com/dapr/dapr/blob/master/pkg/messages/errorcodes/errorcodes.go) for specific codes and categories.
+You can enable additional metrics for [Dapr API error codes](https://docs.dapr.io/developing-applications/error-codes/) by setting `spec.metrics.recordErrorCodes` to `true`. Dapr APIs which communicate back to their caller may return standardized error codes. [A new metric called `error_code_total` is recorded]({{% ref errors-overview.md %}}), which allows monitoring of error codes triggered by application, code, and category. See [the `errorcodes` package](https://github.com/dapr/dapr/blob/master/pkg/messages/errorcodes/errorcodes.go) for specific codes and categories.
 
 Example configuration:
 ```yaml

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -260,7 +260,7 @@ params:
     # End user relevant links. These will show up on left side of footer and in the community page if you have one.
     user:
       - name: YouTube
-        url: https://www.youtube.com/@darpdev
+        url: https://www.youtube.com/@daprdev
         icon: fab fa-youtube
         desc: Subscribe to our YouTube channel
       - name: LinkedIn


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within tabpane
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixes broken click targets on docs.dapr.io (v1.18):

- Metrics overview **Dapr API error codes** → `/developing-applications/error-codes/` (was `/reference/api/error_codes/` 404)
- Footer YouTube `@darpdev` → `@daprdev`
- Secrets (JS) and state-management (Go) sample links `hhttps://` → `https://` (Hugo was emitting `#ZgotmplZ`)
- Resiliency quickstart **this** link: drop trailing `//`

## Issue reference

fixes #5281 5281