### PR TITLE
Refreshing .NET SDK index pages for each building block

### DIFF
--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-actors/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-actors/_index.md
@@ -3,15 +3,26 @@ type: docs
 title: "Dapr actors .NET SDK"
 linkTitle: "Actors"
 weight: 60000
-description: Get up and running with the Dapr actors .NET SDK
+description: "Overview of the Dapr virtual actors building block for .NET"
 ---
 
-With the Dapr actor package, you can interact with Dapr virtual actors from a .NET application.
-
-To get started, walk through the [Dapr actors]({{% ref dotnet-actors-howto.md %}}) how-to guide.
+The `Dapr.Actors` package enables you to interact with Dapr virtual actors from a .NET application. Actors are virtual, addressed by type and id, with support for state management, reminders, timers, and both strongly-typed and weakly-typed proxy clients. The actor pattern is suited to scenarios where you need single-threaded, instance-based concurrency for stateful objects.
 
 {{% alert title="Status of Dapr.Actors" color="warning" %}}
 Active development on `Dapr.Actors` has stopped; this package now receives security fixes only, and all new actor development happens in [`Dapr.Actors.Next`]({{% ref dotnet-actors-next %}}). There is no deprecation date for `Dapr.Actors` but it's considered to be in a maintenance-only mode.
 
 `Dapr.Actors.Next` is expected to be released as a stable package alongside the v1.19 Dapr runtime and SDK release.
 {{% /alert %}}
+
+## Core concepts
+
+- [How to: Run and use virtual actors in the .NET SDK]({{< ref dotnet-actors-howto.md >}}): a complete tutorial building a three-project solution — actor interfaces, an actor service with state, reminders, and timers, and a proxy client.
+- [Author & run actors]({{< ref dotnet-actors-usage.md >}}): authoring actors with `ActorHost`, dependency injection, disposal, logging, and custom type names; hosting actors in ASP.NET Core with `AddActors`, JSON options, endpoint routing via `MapActorsHandlers`, and middleware pitfalls.
+- [Actor serialization]({{< ref dotnet-actors-serialization.md >}}): the two serialization models — the weakly-typed client (System.Text.Json, JSON output) and the strongly-typed client (Data Contract Serializer, XML output) — and the rules for configuring types in each.
+- [The IActorProxyFactory interface]({{< ref dotnet-actors-client.md >}}): creating actor clients with the strongly-typed (`CreateActorProxy<>`) and weakly-typed (`Create`) proxy styles, and reading exception details from method invocations.
+
+## Next steps
+
+- [How to: Run and use virtual actors in the .NET SDK]({{< ref dotnet-actors-howto.md >}})
+- [Author & run actors]({{< ref dotnet-actors-usage.md >}})
+- [Actor serialization]({{< ref dotnet-actors-serialization.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-ai/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-ai/_index.md
@@ -3,10 +3,26 @@ type: docs
 title: "Dapr AI .NET SDK"
 linkTitle: "AI"
 weight: 100000
-description: Get up and running with the Dapr AI .NET SDK
+description: "Overview of the Dapr AI building block for .NET"
 ---
 
-With the Dapr AI package, you can interact with the Dapr AI workloads from a .NET application. 
+`Dapr.AI` provides a dedicated client for interacting with Dapr's AI workloads from a .NET application. Today, Dapr provides the Conversational API to engage with large language models, and the `DaprConversationClient` is the entry point for sending prompts, configuring response formats, managing prompt cache retention, and reading token usage statistics.
 
-Today, Dapr provides the Conversational API to engage with large language models. To get started with this workload, 
-walk through the [Dapr Conversational AI]({{% ref dotnet-ai-conversation-howto.md %}}) how-to guide.
+For developers already working with the `Microsoft.Extensions.AI` ecosystem, the `Dapr.AI.Microsoft.Extensions` package implements `IChatClient` on top of the Dapr Conversation building block, so you can use Dapr as a backend for any `IChatClient`-compatible code, including tool and function calling.
+
+{{% alert title="Runtime requirements" color="primary" %}}
+The Dapr Conversation building block requires Dapr runtime v1.16.0 or later. Response format, prompt cache retention,
+and token usage statistics require Dapr runtime v1.17.0 or later.
+{{% /alert %}}
+
+## Core concepts
+
+- [How to: Create and use Dapr AI Conversations in the .NET SDK]({{< ref dotnet-ai-conversation-howto.md >}}): install the package, register the `DaprConversationClient` with dependency injection or build it manually, and try the samples.
+- [DaprConversationClient usage]({{< ref dotnet-ai-conversation-usage.md >}}): lifetime management, builder configuration, environment variables, gRPC channel options, dependency injection overloads, sending conversation requests, JSON-schema response format, prompt cache retention, and token usage statistics.
+- [How to: Using Microsoft's AI extensions with Dapr's .NET Conversation SDK]({{< ref dotnet-ai-extensions-howto.md >}}): register `DaprChatClient` as an `IChatClient`, send chat messages, use tool and function calling, and handle errors.
+
+## Next steps
+
+- [How to: Create and use Dapr AI Conversations in the .NET SDK]({{< ref dotnet-ai-conversation-howto.md >}})
+- [DaprConversationClient usage]({{< ref dotnet-ai-conversation-usage.md >}})
+- [Using Microsoft's AI extensions with Dapr's .NET Conversation SDK]({{< ref dotnet-ai-extensions-howto.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-cryptography/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-cryptography/_index.md
@@ -3,10 +3,19 @@ type: docs
 title: "Dapr Cryptography .NET SDK"
 linkTitle: "Cryptography"
 weight: 140000
-description: Get up and running with the Dapr Cryptography .NET SDK
+description: "Overview of the Dapr Cryptography building block for .NET"
 ---
 
-With the Dapr Cryptography package, you can perform high-performance encryption and decryption operations with Dapr. 
+`Dapr.Cryptography` provides a dedicated client for performing high-performance encryption and decryption operations with Dapr. The `DaprEncryptionClient` supports streaming operations that can handle data of any size, offloading the cryptographic work to the Dapr runtime and its configured cryptography components.
 
-To get started with this functionality, walk through the [Dapr Cryptography({{< ref dotnet-cryptography-howto.md >}}) 
-how-to guide.
+The client is registered with dependency injection via `AddDaprEncryptionClient()` and can be configured from `IConfiguration`, environment variables, or a `DaprEncryptionClientBuilder` for advanced scenarios.
+
+## Core concepts
+
+- [How to: Create and use Dapr Cryptography in the .NET SDK]({{< ref dotnet-cryptography-howto.md >}}): install the package, register the client with dependency injection or build it manually, and try the samples.
+- [DaprEncryptionClient usage]({{< ref dotnet-cryptography-usage.md >}}): lifetime management, builder configuration, environment variables, gRPC channel options, cancellation, and the three dependency injection overloads.
+
+## Next steps
+
+- [How to: Create and use Dapr Cryptography in the .NET SDK]({{< ref dotnet-cryptography-howto.md >}})
+- [DaprEncryptionClient usage]({{< ref dotnet-cryptography-usage.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-distributed-lock/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-distributed-lock/_index.md
@@ -3,141 +3,26 @@ type: docs
 title: "Dapr Distributed Lock .NET SDK"
 linkTitle: "Distributed Lock"
 weight: 240000
-description: Get up and running with the Dapr Distributed .NET SDK
+description: "Overview of the Dapr Distributed Lock building block for .NET"
 ---
 
 With the Dapr Distributed Lock package, you can create and remove locks on resources to manage exclusivity across
-your distributed applications.
+your distributed applications. The `DaprDistributedLockClient` provides a dedicated client for interacting with Dapr's
+distributed lock API, supporting lock acquisition with automatic release on disposal, configurable timeouts, and
+cancellation.
 
+{{% alert title="Package guidance" color="primary" %}}
 While this capability is implemented in both the `Dapr.Client` and `Dapr.DistributedLock` packages, the approach differs
 slightly between them and a future release will see the `Dapr.Client` package be deprecated. It's recommended that new
-implementations use the `Dapr.DistributedLock` package. This document will reflect the implementation in the 
-`Dapr.DistributedLock` package.
+implementations use the `Dapr.DistributedLock` package.
+{{% /alert %}}
 
-## Lifetime management
-A `DaprDistributedLockClient` is a version of the Dapr client that is dedicated to interacting with Dapr's distributed
-lock API. It can be registered alongside a `DaprClient` and other Dapr clients without issue.
+## Core concepts
 
-It maintains access to networking resources in the form of TCP sockets used to communicate with the Dapr sidecar runtime.
+- [How to: Use the Distributed Lock client]({{< ref dotnet-distributedlock-howto.md >}}): install the package, register the client with dependency injection or build it manually, and try the samples.
+- [DaprDistributedLockClient usage]({{< ref dotnet-distributedlock-usage.md >}}): lifetime management, builder configuration, environment variables, gRPC channel options, cancellation, and the three dependency injection overloads.
 
-For best performance, it is recommended that you utilize the dependency injection container mechanisms provided with the 
-`Dapr.DistributedLock` package to provide easy access to an injected instance throughout your application. These injected
-instances are thread-safe and intended to be used across different types within your application. Registration via
-dependency injection can utilize values from an `IConfiguration` or other injected services in a way that's impractical
-when creating the client from scratch in each of your classes.
+## Next steps
 
-If you do opt to manually create a `DaprDistributedLockClient` instance, it is recommended that you use the `DaprClientBuilder`
-to create the client. This will ensure that the client is properly configured to communicate with the Dapr sidecar runtime.`
-
-Avoid creawting a `DaprDistributedLockClient` for each operation.
-
-## Configuring a `DaprDistributedLockClient` via `DaprDistributedLockBuilder`
-
-A `DaprDistributedLockClient` can be configured by invoking methods on the `DaprDistributedLockBuilder` class before calling
-`.Build()` to create the client itself. The settings for each `DaprDistributedLockClient` are separate and cannot be changed
-after calling `.Build()`.
-
-```csharp
-var daprDistributedLockClient = new DaprDistributedLockBuilder()
-    .UseDaprApiToken("abc123") // Optionally specify the API token used to authenticate to other Dapr sidecars
-    .Build();
-```
-
-The `DaprDistributedLockBuilder` contains settings for:
-
-- The HTTP endpoint of the Dapr sidecar
-- The gRPC endpoint of the Dapr sidecar
-- The `JsonSerializerOptions` object used to configure JSON serialization
-- The `GrpcChannelOptions` object used to configure gRPC
-- The API token used to authenticate requests to the sidecar
-- The factory method used to create the `HttpClient` instance used by the SDK
-- The timeout used for the `HttpClient` instance when making requests to the sidecar
-
-The SDK will read the following environment variables to configure the default values:
-
-- `DAPR_HTTP_ENDPOINT`: used to find the HTTP endpoint of the Dapr sidecar, example: `https://dapr-api.mycompany.com`
-- `DAPR_GRPC_ENDPOINT`: used to find the gRPC endpoint of the Dapr sidecar, example: `https://dapr-grpc-api.mycompany.com`
-- `DAPR_HTTP_PORT`: if `DAPR_HTTP_ENDPOINT` is not set, this is used to find the HTTP local endpoint of the Dapr sidecar
-- `DAPR_GRPC_PORT`: if `DAPR_GRPC_ENDPOINT` is not set, this is used to find the gRPC local endpoint of the Dapr sidecar
-- `DAPR_API_TOKEN`: used to set the API token
-
-### Configuring gRPC channel options
-
-Dapr's use of `CancellationToken` for cancellation relies on the configuration of the gRPC channel options. If you need
-to configure these options yourself, make sure to enable the [ThrowOperationCanceledOnCancellation setting](https://grpc.github.io/grpc/csharp-dotnet/api/Grpc.Net.Client.GrpcChannelOptions.html#Grpc_Net_Client_GrpcChannelOptions_ThrowOperationCanceledOnCancellation).
-
-```cs
-var daprDistributedLockClient = new DaprDistributedLockBuilder()
-    .UseGrpcChannelOptions(new GrpcChannelOptions { ... ThrowOperationCanceledOnCancellation = true })
-    .Build();
-```
-
-## Using cancellation with `DaprDistributedLockClient`
-
-The APIs on `DaprDistributedLockClient` perform asynchronous operations and accept an optional `CancellationToken` parameter. This
-follows a standard .NET practice for cancellable operations. Note that when cancellation occurs, there is no guarantee that
-the remote endpoint stops processing the request, only that the client has stopped waiting for completion.
-
-When an operation is cancelled, it will throw an `OperationCancelledException`.
-
-## Configuring `DaprDistributedLockClient` via dependency injection
-
-Using the built-in extension methods for registering the `DaprDistributedLockClient` in a dependency injection container can
-provide the benefit of registering the long-lived service a single time, centralize complex configuration and improve
-performance by ensuring similarly long-lived resources are re-purposed when possible (e.g. `HttpClient` instances).
-
-There are three overloads available to give the developer the greatest flexibility in configuring the client for their
-scenario. Each of these will register the `IHttpClientFactory` on your behalf if not already registered, and configure
-the `DaprDistributedLockBuilder` to use it when creating the `HttpClient` instance in order to re-use the same instance as
-much as possible and avoid socket exhaustion and other issues.
-
-In the first approach, there's no configuration done by the developer and the `DaprDistributedLockClient` is configured with the
-default settings.
-
-```cs
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddDaprDistributedLock(); //Registers the `DaprDistributedLockClient` to be injected as needed
-var app = builder.Build();
-```
-
-Sometimes the developer will need to configure the created client using the various configuration options detailed
-above. This is done through an overload that passes in the `DaprDistributedLockBuilder` and exposes methods for configuring
-the necessary options.
-
-```cs
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddDaprDistributedLock((_, daprDistributedLockBuilder) => {
-   //Set the API token
-   daprDistributedLockBuilder.UseDaprApiToken("abc123");
-   //Specify a non-standard HTTP endpoint
-   daprDistributedLockBuilder.UseHttpEndpoint("http://dapr.my-company.com");
-});
-
-var app = builder.Build();
-```
-
-Finally, it's possible that the developer may need to retrieve information from another service in order to populate
-these configuration values. That value may be provided from a `DaprClient` instance, a vendor-specific SDK or some
-local service, but as long as it's also registered in DI, it can be injected into this configuration operation via the
-last overload:
-
-```cs
-var builder = WebApplication.CreateBuilder(args);
-
-//Register a fictional service that retrieves secrets from somewhere
-builder.Services.AddSingleton<SecretService>();
-
-builder.Services.AddDaprDistributedLock((serviceProvider, daprDistributedLockBuilder) => {
-    //Retrieve an instance of the `SecretService` from the service provider
-    var secretService = serviceProvider.GetRequiredService<SecretService>();
-    var daprApiToken = secretService.GetSecret("DaprApiToken").Value;
-
-    //Configure the `DaprDistributedLockBuilder`
-    daprDistributedLockBuilder.UseDaprApiToken(daprApiToken);
-});
-
-var app = builder.Build();
-```
-
+- [How to: Use the Distributed Lock client]({{< ref dotnet-distributedlock-howto.md >}})
+- [DaprDistributedLockClient usage]({{< ref dotnet-distributedlock-usage.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-distributed-lock/dotnet-distributedlock-usage.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-distributed-lock/dotnet-distributedlock-usage.md
@@ -1,0 +1,135 @@
+---
+type: docs
+title: "DaprDistributedLockClient usage"
+linkTitle: "DaprDistributedLockClient usage"
+weight: 69050
+description: Essential tips and advice for using DaprDistributedLockClient
+---
+
+## Lifetime management
+
+A `DaprDistributedLockClient` is a version of the Dapr client that is dedicated to interacting with Dapr's distributed
+lock API. It can be registered alongside a `DaprClient` and other Dapr clients without issue.
+
+It maintains access to networking resources in the form of TCP sockets used to communicate with the Dapr sidecar runtime.
+
+For best performance, it is recommended that you utilize the dependency injection container mechanisms provided with the 
+`Dapr.DistributedLock` package to provide easy access to an injected instance throughout your application. These injected
+instances are thread-safe and intended to be used across different types within your application. Registration via
+dependency injection can utilize values from an `IConfiguration` or other injected services in a way that's impractical
+when creating the client from scratch in each of your classes.
+
+If you do opt to manually create a `DaprDistributedLockClient` instance, it is recommended that you use the `DaprDistributedLockBuilder`
+to create the client. This will ensure that the client is properly configured to communicate with the Dapr sidecar runtime.
+
+Avoid creating a `DaprDistributedLockClient` for each operation.
+
+## Configuring a `DaprDistributedLockClient` via `DaprDistributedLockBuilder`
+
+A `DaprDistributedLockClient` can be configured by invoking methods on the `DaprDistributedLockBuilder` class before calling
+`.Build()` to create the client itself. The settings for each `DaprDistributedLockClient` are separate and cannot be changed
+after calling `.Build()`.
+
+```csharp
+var daprDistributedLockClient = new DaprDistributedLockBuilder()
+    .UseDaprApiToken("abc123") // Optionally specify the API token used to authenticate to other Dapr sidecars
+    .Build();
+```
+
+The `DaprDistributedLockBuilder` contains settings for:
+
+- The HTTP endpoint of the Dapr sidecar
+- The gRPC endpoint of the Dapr sidecar
+- The `JsonSerializerOptions` object used to configure JSON serialization
+- The `GrpcChannelOptions` object used to configure gRPC
+- The API token used to authenticate requests to the sidecar
+- The factory method used to create the `HttpClient` instance used by the SDK
+- The timeout used for the `HttpClient` instance when making requests to the sidecar
+
+The SDK will read the following environment variables to configure the default values:
+
+- `DAPR_HTTP_ENDPOINT`: used to find the HTTP endpoint of the Dapr sidecar, example: `https://dapr-api.mycompany.com`
+- `DAPR_GRPC_ENDPOINT`: used to find the gRPC endpoint of the Dapr sidecar, example: `https://dapr-grpc-api.mycompany.com`
+- `DAPR_HTTP_PORT`: if `DAPR_HTTP_ENDPOINT` is not set, this is used to find the HTTP local endpoint of the Dapr sidecar
+- `DAPR_GRPC_PORT`: if `DAPR_GRPC_ENDPOINT` is not set, this is used to find the gRPC local endpoint of the Dapr sidecar
+- `DAPR_API_TOKEN`: used to set the API token
+
+### Configuring gRPC channel options
+
+Dapr's use of `CancellationToken` for cancellation relies on the configuration of the gRPC channel options. If you need
+to configure these options yourself, make sure to enable the [ThrowOperationCanceledOnCancellation setting](https://grpc.github.io/grpc/csharp-dotnet/api/Grpc.Net.Client.GrpcChannelOptions.html#Grpc_Net_Client_GrpcChannelOptions_ThrowOperationCanceledOnCancellation).
+
+```cs
+var daprDistributedLockClient = new DaprDistributedLockBuilder()
+    .UseGrpcChannelOptions(new GrpcChannelOptions { ... ThrowOperationCanceledOnCancellation = true })
+    .Build();
+```
+
+## Using cancellation with `DaprDistributedLockClient`
+
+The APIs on `DaprDistributedLockClient` perform asynchronous operations and accept an optional `CancellationToken` parameter. This
+follows a standard .NET practice for cancellable operations. Note that when cancellation occurs, there is no guarantee that
+the remote endpoint stops processing the request, only that the client has stopped waiting for completion.
+
+When an operation is cancelled, it will throw an `OperationCancelledException`.
+
+## Configuring `DaprDistributedLockClient` via dependency injection
+
+Using the built-in extension methods for registering the `DaprDistributedLockClient` in a dependency injection container can
+provide the benefit of registering the long-lived service a single time, centralize complex configuration and improve
+performance by ensuring similarly long-lived resources are re-purposed when possible (e.g. `HttpClient` instances).
+
+There are three overloads available to give the developer the greatest flexibility in configuring the client for their
+scenario. Each of these will register the `IHttpClientFactory` on your behalf if not already registered, and configure
+the `DaprDistributedLockBuilder` to use it when creating the `HttpClient` instance in order to re-use the same instance as
+much as possible and avoid socket exhaustion and other issues.
+
+In the first approach, there's no configuration done by the developer and the `DaprDistributedLockClient` is configured with the
+default settings.
+
+```cs
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDaprDistributedLock(); //Registers the `DaprDistributedLockClient` to be injected as needed
+var app = builder.Build();
+```
+
+Sometimes the developer will need to configure the created client using the various configuration options detailed
+above. This is done through an overload that passes in the `DaprDistributedLockBuilder` and exposes methods for configuring
+the necessary options.
+
+```cs
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDaprDistributedLock((_, daprDistributedLockBuilder) => {
+   //Set the API token
+   daprDistributedLockBuilder.UseDaprApiToken("abc123");
+   //Specify a non-standard HTTP endpoint
+   daprDistributedLockBuilder.UseHttpEndpoint("http://dapr.my-company.com");
+});
+
+var app = builder.Build();
+```
+
+Finally, it's possible that the developer may need to retrieve information from another service in order to populate
+these configuration values. That value may be provided from a `DaprClient` instance, a vendor-specific SDK or some
+local service, but as long as it's also registered in DI, it can be injected into this configuration operation via the
+last overload:
+
+```cs
+var builder = WebApplication.CreateBuilder(args);
+
+//Register a fictional service that retrieves secrets from somewhere
+builder.Services.AddSingleton<SecretService>();
+
+builder.Services.AddDaprDistributedLock((serviceProvider, daprDistributedLockBuilder) => {
+    //Retrieve an instance of the `SecretService` from the service provider
+    var secretService = serviceProvider.GetRequiredService<SecretService>();
+    var daprApiToken = secretService.GetSecret("DaprApiToken").Value;
+
+    //Configure the `DaprDistributedLockBuilder`
+    daprDistributedLockBuilder.UseDaprApiToken(daprApiToken);
+});
+
+var app = builder.Build();
+```

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-integrations/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-integrations/_index.md
@@ -38,5 +38,15 @@ application source code to store these files.
 
 ## Development options
 
-Choose one of these links to learn about tools you can use in local development scenarios. It's suggested that 
+Choose one of these approaches to learn about tools you can use in local development scenarios. It's suggested that 
 you familiarize yourself with each of them to get a sense of the options provided by the .NET SDK.
+
+- [Developing with the Dapr CLI]({{< ref dotnet-development-dapr-cli.md >}}): run each service and its sidecar with `dapr run`, the lightest-weight approach for getting started.
+- [Developing with .NET Aspire]({{< ref dotnet-development-dapr-aspire.md >}}): integrate Dapr sidecars into an Aspire AppHost using the `CommunityToolkit.Aspire.Hosting.Dapr` package and `WithDaprSidecar()`.
+- [Developing with Docker Compose]({{< ref dotnet-development-docker-compose.md >}}): orchestrate services, sidecars, and dependencies together using `docker-compose`.
+
+## Next steps
+
+- [Developing with the Dapr CLI]({{< ref dotnet-development-dapr-cli.md >}})
+- [Developing with .NET Aspire]({{< ref dotnet-development-dapr-aspire.md >}})
+- [Developing with Docker Compose]({{< ref dotnet-development-docker-compose.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-jobs/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-jobs/_index.md
@@ -3,11 +3,19 @@ type: docs
 title: "Dapr Jobs .NET SDK"
 linkTitle: "Jobs"
 weight: 120000
-description: Get up and running with Dapr Jobs and the Dapr .NET SDK
+description: "Overview of the Dapr Jobs building block for .NET"
 ---
 
-With the Dapr Job package, you can interact with the Dapr Job APIs from a .NET application to trigger future operations
-to run according to a predefined schedule with an optional payload.
+`Dapr.Jobs` provides a dedicated client for interacting with the Dapr Job APIs from a .NET application. With `DaprJobsClient` you can schedule future operations to run according to a predefined schedule with an optional payload. Three scheduling modes are supported: one-time jobs that fire at a specific point in time, interval-based jobs that recur on a fixed `TimeSpan`, and Cron-based jobs that use a Cron expression for calendar-aware scheduling. The SDK also provides minimal-API endpoint mapping so your application receives trigger invocations when a job fires.
 
-To get started, walk through the [Dapr Jobs]({{% ref dotnet-jobs-howto.md %}}) how-to guide and refer to
-[best practices documentation]({{% ref dotnet-jobsclient-usage.md %}}) for additional guidance.
+The client is registered with dependency injection via `AddDaprJobsClient()` and can be configured from `IConfiguration`, environment variables, or a `DaprJobsClientBuilder` for advanced scenarios.
+
+## Core concepts
+
+- [How to: Author and manage Dapr Jobs in the .NET SDK]({{< ref dotnet-jobs-howto.md >}}): client registration with dependency injection, `IConfiguration`, and manual instantiation; mapping job trigger endpoints in minimal APIs; scheduling one-time, interval-based, and Cron-based jobs; retrieving and deleting jobs.
+- [DaprJobsClient usage]({{< ref dotnet-jobsclient-usage.md >}}): lifetime management, builder configuration, environment variables, gRPC channel options, cancellation, the three dependency injection overloads, payload serialization with JSON helper extensions, and error handling.
+
+## Next steps
+
+- [How to: Author and manage Dapr Jobs in the .NET SDK]({{< ref dotnet-jobs-howto.md >}})
+- [DaprJobsClient usage]({{< ref dotnet-jobsclient-usage.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-messaging/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-messaging/_index.md
@@ -3,15 +3,23 @@ type: docs
 title: "Dapr Messaging .NET SDK"
 linkTitle: "Messaging"
 weight: 220000
-description: Get up and running with the Dapr Messaging .NET SDK
+description: "Overview of the Dapr Messaging building block for .NET"
 ---
 
-With the Dapr Messaging package, you can interact with the Dapr messaging APIs from a .NET application. In the
-v1.15 release, this package only contains the functionality corresponding to the 
-[streaming PubSub capability]({{% ref "dotnet-messaging-pubsub-howto.md#subscribe-to-topics" %}})
+`Dapr.Messaging` provides a dedicated client for interacting with the Dapr messaging APIs from a .NET application. The `DaprPublishSubscribeClient` supports streaming pub/sub subscriptions that give you greater control over backpressure: messages remain in the Dapr runtime until your application is ready to process them, and a local high-performance queue caches them in your application while processing is pending. Your message handler returns a `TopicResponseAction` — `Retry`, `Drop`, or `Success` — to tell the runtime what to do with each message, and messages persist in the runtime until a response action is taken or a per-event timeout occurs.
 
-Future Dapr .NET SDK releases will migrate existing messaging capabilities out from Dapr.Client to this 
-Dapr.Messaging package. This will be documented in the release notes, documentation and obsolete attributes in advance.
+The client is registered with dependency injection via `AddDaprPubSubClient()` and can be configured from `IConfiguration`, environment variables, or a `DaprPublishSubscribeClientBuilder` for advanced scenarios.
 
-To get started, walk through the [Dapr Messaging]({{% ref dotnet-messaging-pubsub-howto.md %}}) how-to guide and
-refer to [best practices documentation]({{% ref dotnet-messaging-pubsub-usage.md %}}) for additional guidance.
+{{% alert title="Future migration" color="primary" %}}
+In the v1.15 release, this package only contains the functionality corresponding to the streaming PubSub capability. Future Dapr .NET SDK releases will migrate existing messaging capabilities out from `Dapr.Client` into this `Dapr.Messaging` package. This will be documented in the release notes, documentation, and obsolete attributes in advance.
+{{% /alert %}}
+
+## Core concepts
+
+- [How to: Author and manage Dapr streaming subscriptions in the .NET SDK]({{< ref dotnet-messaging-pubsub-howto.md >}}): client registration with dependency injection, `IConfiguration`, and manual instantiation; defining message handlers that return `TopicResponseAction`; configuring subscriptions with `DaprSubscriptionOptions`; and subscription cleanup.
+- [DaprPublishSubscribeClient usage]({{< ref dotnet-messaging-pubsub-usage.md >}}): lifetime management, builder configuration, environment variables, gRPC channel options, cancellation, and the three dependency injection overloads.
+
+## Next steps
+
+- [How to: Author and manage Dapr streaming subscriptions in the .NET SDK]({{< ref dotnet-messaging-pubsub-howto.md >}})
+- [DaprPublishSubscribeClient usage]({{< ref dotnet-messaging-pubsub-usage.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-metadata/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-metadata/_index.md
@@ -3,11 +3,17 @@ type: docs
 title: "Dapr Metadata .NET SDK"
 linkTitle: "Metadata"
 weight: 200000
-description: Get up and running with the Dapr Metadata .NET SDK
+description: "Overview of the Dapr Metadata building block for .NET"
 ---
 
-With the Dapr Metadata package, you can retrieve typed metadata from the Dapr runtime in a .NET application. The package
-integrates with the .NET options pattern so metadata can be injected through `IOptions<DaprMetadata>`,
-`IOptionsSnapshot<DaprMetadata>`, or `IOptionsMonitor<DaprMetadata>`.
+`Dapr.Metadata` provides typed access to Dapr runtime metadata from a .NET application. The package registers a hosted service that fetches sidecar metadata at startup and exposes it through the .NET options pattern as `DaprMetadata`. You can inject it via `IOptions<DaprMetadata>`, `IOptionsSnapshot<DaprMetadata>`, or `IOptionsMonitor<DaprMetadata>`, giving you access to the components, subscriptions, app connection properties, and other metadata the runtime reports about itself.
 
-To get started, walk through the [Dapr Metadata]({{% ref dotnet-metadata-howto.md %}}) how-to guide.
+The client is registered with dependency injection via `AddDaprMetadata()` and can be configured from `IConfiguration` or environment variables.
+
+## Core concepts
+
+- [How to: Retrieve Dapr runtime metadata with the .NET SDK]({{< ref dotnet-metadata-howto.md >}}): install the package, register with dependency injection, inject metadata through the options pattern, read metadata values, and configure the Dapr endpoint.
+
+## Next steps
+
+- [How to: Retrieve Dapr runtime metadata with the .NET SDK]({{< ref dotnet-metadata-howto.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-secrets/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-secrets/_index.md
@@ -3,9 +3,19 @@ type: docs
 title: "Dapr Secrets Management .NET SDK"
 linkTitle: "Secrets Management"
 weight: 160000
-description: Get up and running with Dapr Secrets Management .NET SDK
+description: "Overview of the Dapr Secrets Management building block for .NET"
 ---
 
-With the Dapr Secrets Management package, you can interact with the Dapr Secrets API from a .NET application to retrieve individual or bulk secrets from configured secret store components. The package also includes a source generator that provides strongly-typed access to your secrets via dependency injection.
+`Dapr.SecretsManagement` provides a dedicated client for retrieving secrets from the Dapr Secrets API in a .NET application. With `DaprSecretsManagementClient` you can retrieve individual or bulk secrets from configured secret store components, pass metadata to requests, and take advantage of a source generator that provides strongly-typed access to your secrets through dependency injection using `[SecretStore]` and `[Secret]` attributes.
 
-To get started, walk through the [Dapr Secrets Management]({{% ref dotnet-secrets-howto.md %}}) how-to guide and refer to [best practices documentation]({{% ref dotnet-secretsclient-usage.md %}}) for additional guidance.
+The client is registered with dependency injection via `AddDaprSecretsManagement()` and can be configured from `IConfiguration`, environment variables, or a `DaprSecretsManagementClientBuilder` for advanced scenarios.
+
+## Core concepts
+
+- [How to: Manage secrets with the Dapr Secrets Management .NET SDK]({{< ref dotnet-secrets-howto.md >}}): client registration, retrieving single and bulk secrets with metadata, the source generator for strongly-typed secrets, and testing approaches.
+- [DaprSecretsManagementClient usage]({{< ref dotnet-secretsclient-usage.md >}}): lifetime management, builder configuration, environment variables, gRPC channel options, cancellation, the three dependency injection overloads, chaining source-generator registrations, API response shapes, and error handling.
+
+## Next steps
+
+- [How to: Manage secrets with the Dapr Secrets Management .NET SDK]({{< ref dotnet-secrets-howto.md >}})
+- [DaprSecretsManagementClient usage]({{< ref dotnet-secretsclient-usage.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-state-management/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-state-management/_index.md
@@ -3,9 +3,19 @@ type: docs
 title: "Dapr State Management .NET SDK"
 linkTitle: "State Management"
 weight: 180000
-description: Get up and running with Dapr State Management .NET SDK
+description: "Overview of the Dapr State Management building block for .NET"
 ---
 
-With the Dapr State Management package, you can interact with the Dapr State Management API from a .NET application to save, retrieve, delete, and query key/value state entries in configured state store components. The package supports single-key and bulk operations, optimistic concurrency control via ETags, state transactions, and state queries. It also includes a source generator that provides strongly-typed, store-scoped access via dependency injection.
+`Dapr.StateManagement` provides a dedicated client for interacting with the Dapr State Management API from a .NET application. With `DaprStateManagementClient` you can save, retrieve, delete, and query key/value state entries in configured state store components. The package supports single-key and bulk operations, optimistic concurrency control via ETags, state transactions, and state queries. It also includes a source generator that provides strongly-typed, store-scoped access through dependency injection using `[StateStore]` and `[State]` attributes.
 
-To get started, walk through the [Dapr State Management]({{% ref dotnet-statemanagement-howto.md %}}) how-to guide and refer to [best practices documentation]({{% ref dotnet-statemanagementclient-usage.md %}}) for additional guidance.
+The client is registered with dependency injection via `AddDaprStateManagement()` and can be configured from `IConfiguration`, environment variables, or a `DaprStateManagementClientBuilder` for advanced scenarios.
+
+## Core concepts
+
+- [How to: Manage state with the Dapr State Management .NET SDK]({{< ref dotnet-statemanagement-howto.md >}}): end-to-end walkthrough covering save, retrieve, delete, and query operations, ETags, bulk operations, state transactions, the source generator for typed state store access, and testing.
+- [DaprStateManagementClient usage]({{< ref dotnet-statemanagementclient-usage.md >}}): lifetime management, builder configuration, environment variables, gRPC channel options, dependency injection overloads, JSON serialization defaults, API response shapes, `StateOptions` for consistency and concurrency, error handling, and migration from `DaprClient`.
+
+## Next steps
+
+- [How to: Manage state with the Dapr State Management .NET SDK]({{< ref dotnet-statemanagement-howto.md >}})
+- [DaprStateManagementClient usage]({{< ref dotnet-statemanagementclient-usage.md >}})

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-workflow/_index.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-workflow/_index.md
@@ -3,6 +3,25 @@ type: docs
 title: "Dapr Workflow .NET SDK"
 linkTitle: "Workflow"
 weight: 40000
-description: Get up and running with Dapr Workflow and the Dapr .NET SDK
+description: "Overview of the Dapr Workflow building block for .NET"
 ---
 
+`Dapr.Workflow` brings durable, long-running orchestration to .NET applications. Workflows are expressed as C# classes that orchestrate sequences of activities — each activity is a discrete unit of work that can call other Dapr building blocks, and the workflow runtime handles persistence, replay, and recovery automatically. If a process restarts mid-workflow, the runtime replays the event log to reconstruct state and resume execution.
+
+Workflows and activities are registered with dependency injection via `AddDaprWorkflow()`. Starting with the v1.18 SDK, a build-time source generator discovers and registers all workflow and activity types automatically, so you no longer need to call `RegisterWorkflow<T>` or `RegisterActivity<T>` by hand, though doing so is still fully supported. The `DaprWorkflowClient` is then injected to schedule, manage, and inspect running workflow instances.
+
+## Core concepts
+
+- [DaprWorkflowClient registration and lifetime]({{< ref dotnet-workflowclient-usage.md >}}): dependency injection with singleton, scoped, or transient lifetimes, injecting services into activities, and using the replay-safe logger.
+- [Workflow versioning]({{< ref dotnet-workflow-versioning.md >}}): patch-based and name-based versioning strategies, cross-assembly workflow discovery, and override attributes.
+- [Workflow serialization]({{< ref dotnet-workflow-serialization.md >}}): overriding the default System.Text.Json settings and registering custom serializers (e.g. MessagePack).
+- [Multi-application workflows]({{< ref dotnet-workflow-multi-app.md >}}): calling activities and child workflows hosted in a different Dapr application.
+- [Workflow management operations]({{< ref dotnet-workflow-management-methods.md >}}): schedule, retrieve status, raise events, suspend, resume, terminate, and purge workflow instances with `DaprWorkflowClient`.
+- [Workflow history propagation]({{< ref dotnet-workflow-history-propagation.md >}}): opt-in per-call propagation of workflow history to child workflows and activities, querying propagated history, and security considerations.
+- [Workflow examples]({{< ref dotnet-workflow-examples.md >}}): links to runnable tutorials in the Dapr Quickstarts repository and example projects in the .NET SDK repository.
+
+## Next steps
+
+- [DaprWorkflowClient registration and lifetime]({{< ref dotnet-workflowclient-usage.md >}})
+- [Workflow management operations]({{< ref dotnet-workflow-management-methods.md >}})
+- [Workflow examples]({{< ref dotnet-workflow-examples.md >}})


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Making .NET docs consistent to add an introduction page that then directs users towards additional information.

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
