### PR TITLE
.NET SDK: Reflect updated PubSub message handler for streaming subscriptions

### DIFF
--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-messaging/dotnet-messaging-pubsub-howto.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-messaging/dotnet-messaging-pubsub-howto.md
@@ -6,13 +6,14 @@ weight: 61000
 description: Learn how to author and manage Dapr streaming subscriptions using the .NET SDK
 ---
 
-Let's create a subscription to a pub/sub topic or queue at using the streaming capability. We'll use the 
-[simple example provided here](https://github.com/dapr/dotnet-sdk/tree/master/examples/Client/PublishSubscribe/StreamingSubscriptionExample), 
-for the following demonstration and walk through it as an explainer of how you can configure message handlers at 
+Let's create a subscription to a pub/sub topic or queue at runtime using the streaming capability. We'll use the
+[simple example provided here](https://github.com/dapr/dotnet-sdk/tree/master/examples/Messaging/StreamingSubscriptionExample),
+for the following demonstration and walk through it as an explainer of how you can configure message handlers at
 runtime and which do not require an endpoint to be pre-configured. In this guide, you will:
 
-- Deploy a .NET Web API application ([StreamingSubscriptionExample](https://github.com/dapr/dotnet-sdk/tree/master/examples/Client/PublishSubscribe/StreamingSubscriptionExample))
+- Deploy a .NET Web API application ([StreamingSubscriptionExample](https://github.com/dapr/dotnet-sdk/tree/master/examples/Messaging/StreamingSubscriptionExample))
 - Utilize the Dapr .NET Messaging SDK to subscribe dynamically to a pub/sub topic.
+- Automatically reconnect the subscription after a stream termination and observe subscription errors.
 
 ## Prerequisites
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
@@ -32,7 +33,7 @@ git clone https://github.com/dapr/dotnet-sdk.git
 From the .NET SDK root directory, navigate to the Dapr streaming PubSub example.
 
 ```sh
-cd examples/Client/PublishSubscribe
+cd examples/Messaging
 ```
 
 ## Run the application locally
@@ -51,7 +52,7 @@ dapr run --app-id pubsubapp --dapr-grpc-port 4001 --dapr-http-port 3500 -- dotne
 > Dapr listens for HTTP requests at `http://localhost:3500` and internal Jobs gRPC requests at `http://localhost:4001`.
 
 ## Register the Dapr PubSub client with dependency injection
-The Dapr Messaging SDK provides an extension method to simplify the registration of the Dapr PubSub client. Before 
+The Dapr Messaging SDK provides an extension method to simplify the registration of the Dapr PubSub client. Before
 completing the dependency injection registration in `Program.cs`, add the following line:
 
 ```csharp
@@ -171,8 +172,8 @@ requests with the API token header `abc123`.
 
 ## Use the Dapr PubSub client without relying on dependency injection
 While the use of dependency injection simplifies the use of complex types in .NET and makes it easier to
-deal with complicated configurations, you're not required to register the `DaprPublishSubscribeClient` in this way. 
-Rather, you can also elect to create an instance of it from a `DaprPublishSubscribeClientBuilder` instance as 
+deal with complicated configurations, you're not required to register the `DaprPublishSubscribeClient` in this way.
+Rather, you can also elect to create an instance of it from a `DaprPublishSubscribeClientBuilder` instance as
 demonstrated below:
 
 ```cs
@@ -191,9 +192,9 @@ public class MySampleClass
 
 ## Set up message handler
 The streaming subscription implementation in Dapr gives you greater control over handling backpressure from events by
-leaving the messages in the Dapr runtime until your application is ready to accept them. The .NET SDK supports a 
+leaving the messages in the Dapr runtime until your application is ready to accept them. The .NET SDK supports a
 high-performance queue for maintaining a local cache of these messages in your application while processing is pending.
-These messages will persist in the queue until processing either times out for each one or a response action is taken 
+These messages will persist in the queue until processing either times out for each one or a response action is taken
 for each (typically after processing succeeds or fails). Until this response action is received by the Dapr runtime,
 the messages will be persisted by Dapr and made available in case of a service failure.
 
@@ -211,54 +212,165 @@ The handler must be configured to return a `Task<TopicResponseAction>` indicatin
 a try/catch block. If an exception is not caught by your handler, the subscription will use the response action configured
 in the options during subscription registration.
 
-The following demonstrates the sample message handler provided in the example:
+A best practice is to catch *specific* exception types rather than swallowing every exception with a bare `catch`. The
+response you return for a given failure should match the nature of that failure: a malformed payload that will never
+parse should be **dropped** so Dapr does not redeliver it endlessly (a "poison-message" loop), while a transient
+failure — such as a downstream dependency being momentarily unavailable — should be **retried** so Dapr redelivers the
+message for another attempt. The handler below, taken from the example, follows this pattern: it catches
+`JsonException` to drop unparseable messages and falls back to a general `catch` that retries on any other failure.
 
 ```csharp
-Task<TopicResponseAction> HandleMessageAsync(TopicMessage message, CancellationToken cancellationToken = default)
+// The message handler processes each topic message and returns the action the sidecar should take.
+// Returning Retry asks Dapr to redeliver the message; Success acknowledges it; Drop discards it.
+// Catch specific exceptions rather than swallowing everything — an unparseable message, for
+// example, should be dropped (not retried) to avoid a poison-message loop.
+Task<TopicResponseAction> HandleMessageAsync(TopicMessage message, CancellationToken cancellationToken)
 {
     try
     {
-        //Do something with the message
-        Console.WriteLine(Encoding.UTF8.GetString(message.Data.Span));
+        var body = Encoding.UTF8.GetString(message.Data.Span);
+        Console.WriteLine($"Received: {body}");
         return Task.FromResult(TopicResponseAction.Success);
     }
-    catch
+    catch (JsonException)
     {
+        // Malformed payload — don't retry, drop it.
+        return Task.FromResult(TopicResponseAction.Drop);
+    }
+    catch (Exception ex)
+    {
+        // Transient failure — let Dapr redeliver.
+        Console.WriteLine($"Message handler error: {ex.Message}");
         return Task.FromResult(TopicResponseAction.Retry);
     }
 }
 ```
 
+Note that the handler receives the `CancellationToken` passed to the subscription (without a default value), so it can
+cooperatively respond to cancellation alongside the rest of the subscription lifecycle.
+
 ## Configure and subscribe to the PubSub topic
 Configuration of the streaming subscription requires the name of the PubSub component registered with Dapr, the name
 of the topic or queue being subscribed to, the `DaprSubscriptionOptions` providing the configuration for the subscription,
-the message handler and an optional cancellation token. The only required argument to the `DaprSubscriptionOptions` is 
+the message handler and an optional cancellation token. The only required argument to the `DaprSubscriptionOptions` is
 the default `MessageHandlingPolicy` which consists of a per-event timeout and the `TopicResponseAction` to take when
 that timeout occurs.
 
 Other options are as follows:
 
-| Property Name                                                                                 | Description                                                                                    |
-|-----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
-| Metadata                                                                                      | Additional subscription metadata                                                               |
-| DeadLetterTopic                                                                               | The optional name of the dead-letter topic to send dropped messages to.                        |
-| MaximumQueuedMessages                                                                         | By default, there is no maximum boundary enforced for the internal queue, but setting this     |
-| property would impose an upper limit.                                                         |                                                                                                |
-| MaximumCleanupTimeout                                                                         | When the subscription is disposed of or the token flags a cancellation request, this specifies |
-| the maximum amount of time available to process the remaining messages in the internal queue. |                                                                                                |
+| Property Name         | Description                                                                                                                                                                                                    |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Metadata              | Additional subscription metadata.                                                                                                                                                                              |
+| DeadLetterTopic       | The optional name of the dead-letter topic to send dropped messages to.                                                                                                                                       |
+| MaximumQueuedMessages | By default, there is no maximum boundary enforced for the internal queue, but setting this property would impose an upper limit.                                                                              |
+| MaximumCleanupTimeout | When the subscription is disposed of or the token flags a cancellation request, this specifies the maximum amount of time available to process the remaining messages in the internal queue.                   |
+| ErrorHandler          | An optional callback invoked when background tasks (sidecar streaming, acknowledgement processing, message processing) fault after a successful initial subscription. If not set, the fault propagates to `IDaprSubscription.Completion` as a `DaprException`. If the handler itself throws, both the original fault and the handler failure are surfaced as an `AggregateException` on `Completion`. |
 
-Subscription is then configured as in the following example:
+Subscription is then configured as in the following example. Rather than subscribing once and assuming the gRPC stream
+will live forever, the example wraps the subscription in a **reconnection loop**: after the stream terminates for any
+reason (sidecar restart, network blip, background-task fault), the loop re-establishes the subscription by calling
+`SubscribeAsync` again. The supervisor inside `PublishSubscribeReceiver` resets its state on every termination, so
+re-calling `SubscribeAsync` always works — even after a fault.
+
+Each iteration:
+
+1. Builds a `DaprSubscriptionOptions`, including an optional `ErrorHandler` that receives background faults (for example,
+   the gRPC stream dropping). When an `ErrorHandler` is configured it is invoked once per fault and `Completion`
+   **completes normally**, so the loop simply continues and re-subscribes. If the handler itself throws, `Completion`
+   faults with an `AggregateException` (caught below).
+2. Calls `SubscribeAsync`, which returns an `IAsyncDisposable` that also implements `IDaprSubscription`.
+3. Casts the returned subscription to `IDaprSubscription` to access the `Completion` task and awaits it, blocking the
+   loop until the subscription terminates.
+4. Handles the three ways `Completion` can finish: `OperationCanceledException` (the caller cancelled — exit the loop),
+   `AggregateException` (the `ErrorHandler` itself threw), and `DaprException` (no `ErrorHandler` was configured, or
+   the fault could not be handled).
+5. Disposes the subscription (`await using`) and waits briefly before reconnecting, to avoid a tight loop if the sidecar
+   is down.
+
 ```csharp
 var messagingClient = app.Services.GetRequiredService<DaprPublishSubscribeClient>();
 
-var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(60)); //Override the default of 30 seconds
-var options = new DaprSubscriptionOptions(new MessageHandlingPolicy(TimeSpan.FromSeconds(10), TopicResponseAction.Retry));
-var subscription = await messagingClient.SubscribeAsync("pubsub", "mytopic", options, HandleMessageAsync, cancellationTokenSource.Token);
+using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+
+// Reconnection loop: re-establishes the subscription after any stream termination
+// (sidecar restart, network blip, background-task fault, etc.). The supervisor
+// resets its state on every termination, so re-calling SubscribeAsync always works.
+while (!cts.Token.IsCancellationRequested)
+{
+    var options = new DaprSubscriptionOptions(
+        new MessageHandlingPolicy(TimeSpan.FromSeconds(10), TopicResponseAction.Retry))
+    {
+        // The ErrorHandler receives background faults (e.g. the gRPC stream drops).
+        // If configured, it is invoked once per fault and Completion completes
+        // normally — the loop continues and re-subscribes. If the handler itself
+        // throws, Completion faults with an AggregateException (caught below).
+        ErrorHandler = ex =>
+        {
+            Console.WriteLine($"Subscription error: {ex.InnerException?.Message ?? ex.Message}");
+            return Task.CompletedTask;
+        }
+    };
+
+    await using var subscription = await messagingClient.SubscribeAsync(
+        "pubsub", "myTopic", options, HandleMessageAsync, cts.Token);
+
+    // The returned IAsyncDisposable also implements IDaprSubscription.
+    // Await Completion to block until the subscription terminates.
+    var completion = ((IDaprSubscription)subscription).Completion;
+
+    try
+    {
+        await completion.WaitAsync(cts.Token);
+    }
+    catch (OperationCanceledException)
+    {
+        // Caller cancelled — exit the loop.
+        break;
+    }
+    catch (AggregateException ex)
+    {
+        // The ErrorHandler itself threw — its exception is combined with the original DaprException.
+        Console.WriteLine($"Subscription faulted (handler error): {ex.Flatten().InnerException?.Message}");
+    }
+    catch (DaprException ex)
+    {
+        // No ErrorHandler was configured, or the fault could not be handled.
+        Console.WriteLine($"Subscription faulted: {ex.InnerException?.Message ?? ex.Message}");
+    }
+
+    // Brief delay before reconnecting to avoid a tight loop if the sidecar is down.
+    try { await Task.Delay(TimeSpan.FromSeconds(3), cts.Token); }
+    catch (OperationCanceledException) { break; }
+}
 ```
 
+## Observe subscription lifetime and handle errors
+The object returned by `SubscribeAsync` is an `IAsyncDisposable` that also implements the `IDaprSubscription`
+interface. `IDaprSubscription` exposes a single property, `Completion`, which is a `Task` that completes when the
+subscription's background processing finishes. This gives you a way to observe the subscription's lifetime — and any
+faults — independently of disposing it.
+
+| Outcome | Behavior of `Completion` |
+|---|---|
+| The stream ends cleanly or the subscription is cancelled | Completes normally (or with `OperationCanceledException` if you awaited with a token). |
+| A background task faults and **no** `ErrorHandler` is configured | Faults with a `DaprException` wrapping the original error. |
+| A background task faults and an `ErrorHandler` **is** configured | The handler is invoked; `Completion` completes normally. |
+| The `ErrorHandler` itself throws | `Completion` faults with an `AggregateException` combining the original fault and the handler failure. |
+
+Because the receiver resets its internal state on every termination, you can always observe a fault via `Completion`
+and then re-establish the subscription by calling `SubscribeAsync` again — even after a fault. Callers that never retry
+can still observe errors through `Completion`, which replaces the previous cache-and-rethrow-on-next-subscribe model.
+This is what makes the reconnection loop shown above reliable.
+
 ## Terminate and clean up subscription
-When you've finished with your subscription and wish to stop receiving new events, simply await a call to 
-`DisposeAsync()` on your subscription instance. This will cause the client to unregister from additional events and 
+When you've finished with your subscription and wish to stop receiving new events, simply await a call to
+`DisposeAsync()` on your subscription instance. This will cause the client to unregister from additional events and
 proceed to finish processing all the events still leftover in the backpressure queue, if any, before disposing of any
 internal resources. This cleanup will be limited to the timeout interval provided in the `DaprSubscriptionOptions` when
 the subscription was registered and by default, this is set to 30 seconds.
+
+In the reconnection loop above, each subscription is scoped to a single iteration with `await using`, so it is disposed
+automatically before the next `SubscribeAsync` call. Disposing a subscription does not throw if the underlying stream
+has already terminated — it simply releases the subscription's resources. To shut down the whole loop, cancel the
+`CancellationTokenSource`; the awaited `Completion` (or the next `Task.Delay`) will throw
+`OperationCanceledException`, which the loop catches to exit cleanly.

--- a/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-messaging/dotnet-messaging-pubsub-usage.md
+++ b/sdkdocs/dotnet/content/en/dotnet-sdk-docs/dotnet-messaging/dotnet-messaging-pubsub-usage.md
@@ -128,3 +128,37 @@ builder.Services.AddDaprPublishSubscribeClient((serviceProvider, daprPubSubClien
 
 var app = builder.Build();
 ```
+
+## Subscription lifecycle and error handling
+A streaming subscription is long-lived, but the underlying gRPC stream is not guaranteed to live forever. Sidecar
+restarts, network blips, or faults in the background processing tasks can all terminate the stream. The following
+best practices keep a subscription resilient.
+
+### Use a reconnection loop
+Wrap `SubscribeAsync` in a loop that re-establishes the subscription after `IDaprSubscription.Completion` terminates.
+The receiver resets its internal state on every termination, so re-calling `SubscribeAsync` always works — even after
+a fault. Add a short delay before reconnecting to avoid a tight loop if the sidecar is down. Cancel a single
+`CancellationTokenSource` to shut the whole loop down.
+
+### Observe faults through `IDaprSubscription.Completion`
+The `IAsyncDisposable` returned by `SubscribeAsync` also implements `IDaprSubscription`, whose `Completion` task
+completes when background processing finishes. Await it to block until termination, then handle the three ways it can
+finish: `OperationCanceledException` (caller cancelled), `DaprException` (a background task faulted and no
+`ErrorHandler` was configured), and `AggregateException` (an `ErrorHandler` was configured but itself threw).
+
+### Configure an `ErrorHandler`
+Set `DaprSubscriptionOptions.ErrorHandler` to receive background faults (such as the gRPC stream dropping). When
+configured, the handler is invoked once per fault and `Completion` completes normally, so your reconnection loop
+simply continues. If the handler itself throws, both the original fault and the handler failure surface as an
+`AggregateException` on `Completion`. Without an `ErrorHandler`, faults propagate to `Completion` as a
+`DaprException`. Note that the handler runs on a thread-pool thread, so implementations should be thread-safe.
+
+### Catch specific exceptions in the message handler
+Catch specific exception types and return a `TopicResponseAction` that matches the failure: `Drop` unparseable
+messages so Dapr does not redeliver them in a poison-message loop, and `Retry` only transient failures. A bare
+`catch` that always retries will redeliver a message that can never succeed.
+
+### Keep the client shared, the subscription scoped
+Keep a single long-lived `DaprPublishSubscribeClient` shared across your application, but scope each subscription to a
+single loop iteration with `await using` so it is disposed before the next `SubscribeAsync` call. Disposing a
+subscription that has already terminated simply releases its resources — it does not throw.


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [ ] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated to reflect better resiliency implementation in PubSub streaming message handler. This will be released as part of a patch release this week in the .NET SDK and I'll remove the do-not-merge label at that time. If you could review in advance, I'd appreciate it!

## Issue reference

<!--Please reference the issue this PR will close: #[issue number]-->
