### PR TITLE
docs(influxdb): add example for create operation

### DIFF
--- a/daprdocs/content/en/reference/components-reference/supported-bindings/influxdb.md
+++ b/daprdocs/content/en/reference/components-reference/supported-bindings/influxdb.md
@@ -51,6 +51,23 @@ This component supports **output binding** with the following operations:
 - `create`
 - `query`
 
+### Create
+
+In order to write a point to InfluxDB, use a `create` operation with `measurement`, `tags`, and `values` keys in the call's data. `tags` and `values` are [InfluxDB line protocol](https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/) tag and field sets, for example `host=serverA,region=us-west` and `temperature=25.3`:
+
+```shell
+curl -X POST http://localhost:3500/v1.0/bindings/myInfluxBinding \
+  -H "Content-Type: application/json" \
+  -d "{
+        \"data\": {
+          \"measurement\": \"temperature\",
+          \"tags\": \"host=serverA,region=us-west\",
+          \"values\": \"value=25.3\"
+        },
+        \"operation\": \"create\"
+      }"
+```
+
 ### Query
 
 In order to query InfluxDB, use a `query` operation along with a `raw` key in the call's metadata, with the query as the value:


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within tabpane
- [ ] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The InfluxDB binding page lists `create` and `query` as the two supported operations, but only `query` had a usage example. Added a `### Create` section with a curl example, matching the `measurement`, `tags`, and `values` fields the component actually reads off the request data (verified against `bindings/influx/influx.go` in components-contrib, which builds an InfluxDB line protocol point from those three keys).

## Issue reference

Please reference the issue this PR will close: #3279
