### PR TITLE
Add Elastic how-tos for tracing, metrics and logging

### DIFF
--- a/daprdocs/content/en/operations/observability/logging/elastic-logs.md
+++ b/daprdocs/content/en/operations/observability/logging/elastic-logs.md
@@ -1,0 +1,165 @@
+---
+type: docs
+title: "How-To: Set up Elastic to search Dapr logs"
+linkTitle: "Elastic"
+weight: 4000
+description: "Collect Dapr's JSON logs into Elastic with the Elastic Distribution of OpenTelemetry Collector"
+---
+
+Dapr writes [structured logs]({{% ref "logs.md" %}}) to stdout, so on Kubernetes they are ordinary container logs. The [Elastic Distribution of OpenTelemetry (EDOT) Collector](https://www.elastic.co/docs/reference/opentelemetry/edot-collector) collects them with its `filelog` receiver. EDOT is the Elastic Agent running in `otel` mode, reading a standard OpenTelemetry Collector configuration.
+
+## Prerequisites
+
+- [Dapr installed on Kubernetes]({{% ref "kubernetes-deploy.md" %}})
+- An Elasticsearch endpoint and API key, from either Elastic Cloud or a self-managed deployment
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+
+## Enable JSON-formatted logs
+
+Dapr logs in plain text by default. Turn on JSON output so the fields survive collection.
+
+For the control plane, set `global.logAsJson` when installing:
+
+```bash
+helm upgrade --install dapr dapr/dapr \
+  --namespace dapr-system --create-namespace \
+  --set global.logAsJson=true
+```
+
+For each application, add the `dapr.io/log-as-json` annotation to the pod template:
+
+```yaml
+annotations:
+  dapr.io/enabled: "true"
+  dapr.io/app-id: "myapp"
+  dapr.io/log-as-json: "true"
+```
+
+## Deploy the collector
+
+The `filelog` receiver reads log files from the node, so the collector runs as a DaemonSet with the host log paths mounted. Save the following as `edot-logs.yaml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edot-logs-config
+  namespace: dapr-monitoring
+data:
+  collector.yaml: |
+    receivers:
+      filelog:
+        include:
+          - /var/log/pods/*/*/*.log
+        exclude:
+          - /var/log/pods/*edot-logs*/*/*.log
+        start_at: end
+        include_file_path: true
+        retry_on_failure:
+          enabled: true
+        operators:
+          - id: container-parser
+            type: container
+          - id: json-parser
+            type: json_parser
+            on_error: send_quiet
+            parse_from: body
+            parse_to: body
+    processors:
+      batch: {}
+      k8s_attributes:
+        passthrough: false
+        filter:
+          node_from_env_var: OTEL_K8S_NODE_NAME
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            - k8s.deployment.name
+            - k8s.node.name
+    exporters:
+      elasticsearch/otel:
+        endpoints:
+          - "${env:ELASTIC_ENDPOINT}"
+        api_key: "${env:ELASTIC_API_KEY}"
+        mapping:
+          mode: otel
+    service:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: [k8s_attributes, batch]
+          exporters: [elasticsearch/otel]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: edot-logs
+  namespace: dapr-monitoring
+spec:
+  selector:
+    matchLabels:
+      app: edot-logs
+  template:
+    metadata:
+      labels:
+        app: edot-logs
+    spec:
+      serviceAccountName: edot-logs
+      containers:
+        - name: agent
+          image: docker.elastic.co/elastic-agent/elastic-agent:9.5.3
+          args: ["--config=/conf/collector.yaml"]
+          securityContext:
+            runAsUser: 0
+          env:
+            - name: ELASTIC_AGENT_OTEL
+              value: "true"
+            - name: OTEL_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: ELASTIC_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: elastic-secret
+                  key: elastic_endpoint
+            - name: ELASTIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: elastic-secret
+                  key: elastic_api_key
+          volumeMounts:
+            - name: conf
+              mountPath: /conf
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+      volumes:
+        - name: conf
+          configMap:
+            name: edot-logs-config
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+```
+
+This reuses the `elastic-secret` created in the [metrics how-to]({{% ref "elastic-metrics.md" %}}). Create it first if you have not already, and add a `ServiceAccount` named `edot-logs` with a `ClusterRole` granting `get`, `list` and `watch` on pods, nodes and namespaces so `k8s_attributes` can enrich the records.
+
+Apply it:
+
+```bash
+kubectl apply -f edot-logs.yaml
+```
+
+{{% alert title="Note" color="warning" %}}
+The `json_parser` operator is required, and must come after the container parser.
+{{% /alert %}}
+
+## Related links
+
+- [Logs]({{% ref "logs.md" %}})
+- [Dapr metrics with Elastic]({{% ref "elastic-metrics.md" %}})
+- [Dapr traces with Elastic]({{% ref "open-telemetry-collector-elastic.md" %}})
+- [EDOT Collector: configure logs collection](https://www.elastic.co/docs/reference/edot-collector/config/configure-logs-collection)

--- a/daprdocs/content/en/operations/observability/metrics/elastic-metrics.md
+++ b/daprdocs/content/en/operations/observability/metrics/elastic-metrics.md
@@ -1,0 +1,175 @@
+---
+type: docs
+title: "How-To: Set up Elastic to collect Dapr metrics"
+linkTitle: "Elastic"
+weight: 8000
+description: "Scrape Dapr's Prometheus metrics endpoint into Elastic with the Elastic Distribution of OpenTelemetry Collector"
+---
+
+The [Elastic Distribution of OpenTelemetry (EDOT) Collector](https://www.elastic.co/docs/reference/opentelemetry/edot-collector) scrapes Dapr's [Prometheus metrics endpoint]({{% ref "metrics-overview.md" %}}) with its `prometheus` receiver and writes to Elasticsearch. EDOT is the Elastic Agent running in `otel` mode, reading a standard OpenTelemetry Collector configuration.
+
+## Prerequisites
+
+- [Dapr installed on Kubernetes]({{% ref "kubernetes-deploy.md" %}})
+- An Elasticsearch endpoint and API key, from either Elastic Cloud or a self-managed deployment
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+
+## Create the credentials secret
+
+```bash
+kubectl create namespace dapr-monitoring
+
+kubectl create secret generic elastic-secret -n dapr-monitoring \
+  --from-literal=elastic_endpoint="https://YOUR_DEPLOYMENT.es.YOUR_REGION.cloud.es.io:443" \
+  --from-literal=elastic_api_key="YOUR_API_KEY"
+```
+
+## Annotate your applications
+
+The `dapr-sidecars` scrape job keeps pods carrying both of these annotations, so set them on each pod template:
+
+```yaml
+annotations:
+  dapr.io/enabled: "true"
+  dapr.io/enable-metrics: "true"
+```
+
+## Deploy the collector
+
+Copy the `dapr-sidecars` and `dapr` scrape jobs from the `values.yaml` file in [How-To: Observe metrics with Prometheus]({{% ref "prometheus.md" %}}) into the `scrape_configs` block below, doubling `$` to `$$` so the collector's environment expansion leaves the relabel capture groups intact.
+
+Save as `edot-metrics.yaml`:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edot-metrics
+  namespace: dapr-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edot-metrics
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "namespaces", "endpoints", "services"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edot-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edot-metrics
+subjects:
+  - kind: ServiceAccount
+    name: edot-metrics
+    namespace: dapr-monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edot-metrics-config
+  namespace: dapr-monitoring
+data:
+  collector.yaml: |
+    receivers:
+      prometheus/dapr:
+        config:
+          scrape_configs:
+            # Paste the `dapr-sidecars` and `dapr` jobs here, from
+            # https://docs.dapr.io/operations/observability/metrics/prometheus/
+            # Replace each `${1}` with `$${1}`.
+    processors:
+      batch: {}
+      cumulativetodelta: {}
+    exporters:
+      elasticsearch/otel:
+        endpoints:
+          - "${env:ELASTIC_ENDPOINT}"
+        api_key: "${env:ELASTIC_API_KEY}"
+        mapping:
+          mode: otel
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus/dapr]
+          processors: [cumulativetodelta, batch]
+          exporters: [elasticsearch/otel]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edot-metrics
+  namespace: dapr-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: edot-metrics
+  template:
+    metadata:
+      labels:
+        app: edot-metrics
+    spec:
+      serviceAccountName: edot-metrics
+      containers:
+        - name: agent
+          image: docker.elastic.co/elastic-agent/elastic-agent:9.5.3
+          args: ["--config=/conf/collector.yaml"]
+          env:
+            - name: ELASTIC_AGENT_OTEL
+              value: "true"
+            - name: ELASTIC_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: elastic-secret
+                  key: elastic_endpoint
+            - name: ELASTIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: elastic-secret
+                  key: elastic_api_key
+          volumeMounts:
+            - name: conf
+              mountPath: /conf
+      volumes:
+        - name: conf
+          configMap:
+            name: edot-metrics-config
+```
+
+```bash
+kubectl apply -f edot-metrics.yaml
+```
+
+{{% alert title="Note" color="warning" %}}
+`cumulativetodelta` is required: Dapr's histograms are cumulative, and the Elasticsearch exporter accepts only delta temporality.
+{{% /alert %}}
+
+## Verify
+
+Confirm the scrape job started:
+
+```bash
+kubectl logs -n dapr-monitoring -l app=edot-metrics | grep "Scrape job added"
+```
+
+Query Elasticsearch for a Dapr metric:
+
+```bash
+curl -H "Authorization: ApiKey YOUR_API_KEY" \
+  "https://YOUR_DEPLOYMENT.es.YOUR_REGION.cloud.es.io/.ds-metrics-*/_count" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"exists":{"field":"metrics.dapr_http_server_latency"}}}'
+```
+
+## Related links
+
+- [Configure metrics]({{% ref "metrics-overview.md" %}})
+- [How-To: Observe metrics with Prometheus]({{% ref "prometheus.md" %}})
+- [Dapr traces with Elastic]({{% ref "open-telemetry-collector-elastic.md" %}})
+- [EDOT Collector: configure metrics collection](https://www.elastic.co/docs/reference/edot-collector/config/configure-metrics-collection)

--- a/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-elastic.md
+++ b/daprdocs/content/en/operations/observability/tracing/otel-collector/open-telemetry-collector-elastic.md
@@ -1,0 +1,171 @@
+---
+type: docs
+title: "Using the Elastic Distribution of OpenTelemetry Collector to collect traces to send to Elastic"
+linkTitle: "Using the Elastic OpenTelemetry Collector"
+weight: 1100
+description: "How to push trace events to Elastic, using the Elastic Distribution of OpenTelemetry Collector"
+---
+
+The [Elastic Distribution of OpenTelemetry (EDOT) Collector](https://www.elastic.co/docs/reference/opentelemetry/edot-collector) is the Elastic Agent running in `otel` mode, reading a standard OpenTelemetry Collector configuration. This guide walks through pushing Dapr traces to Elasticsearch through it.
+
+## Prerequisites
+
+- [Install Dapr on Kubernetes]({{% ref kubernetes %}})
+- An Elasticsearch endpoint and API key, from either Elastic Cloud or a self-managed deployment
+
+## Create the credentials secret
+
+```bash
+kubectl create namespace dapr-monitoring
+
+kubectl create secret generic elastic-secret -n dapr-monitoring \
+  --from-literal=elastic_endpoint="https://YOUR_DEPLOYMENT.es.YOUR_REGION.cloud.es.io:443" \
+  --from-literal=elastic_api_key="YOUR_API_KEY"
+```
+
+## Deploy the collector
+
+Save the following as `edot-collector.yaml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edot-config
+  namespace: dapr-monitoring
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch: {}
+    exporters:
+      elasticsearch/otel:
+        endpoints:
+          - "${env:ELASTIC_ENDPOINT}"
+        api_key: "${env:ELASTIC_API_KEY}"
+        mapping:
+          mode: otel
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [elasticsearch/otel]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edot-collector
+  namespace: dapr-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: edot-collector
+  template:
+    metadata:
+      labels:
+        app: edot-collector
+    spec:
+      containers:
+        - name: agent
+          image: docker.elastic.co/elastic-agent/elastic-agent:9.5.3
+          args: ["--config=/conf/collector.yaml"]
+          env:
+            - name: ELASTIC_AGENT_OTEL
+              value: "true"
+            - name: ELASTIC_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: elastic-secret
+                  key: elastic_endpoint
+            - name: ELASTIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: elastic-secret
+                  key: elastic_api_key
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+          volumeMounts:
+            - name: conf
+              mountPath: /conf
+      volumes:
+        - name: conf
+          configMap:
+            name: edot-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: edot-collector
+  namespace: dapr-monitoring
+spec:
+  selector:
+    app: edot-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+```
+
+```bash
+kubectl apply -f edot-collector.yaml
+```
+
+{{% alert title="Note" color="primary" %}}
+`ELASTIC_AGENT_OTEL: "true"` puts the Elastic Agent into `otel` mode. Without it the container starts as a conventional Elastic Agent and does not open an OTLP port.
+{{% /alert %}}
+
+## Set up Dapr to send traces to the collector
+
+```yaml
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: appconfig
+spec:
+  tracing:
+    samplingRate: "1"
+    otel:
+      endpointAddress: "edot-collector.dapr-monitoring.svc:4317"
+      protocol: grpc
+      isSecure: false
+```
+
+```bash
+kubectl apply -f appconfig.yaml
+```
+
+`isSecure` refers to the in-cluster connection between the sidecar and the collector. The collector's own connection to Elasticsearch uses HTTPS and the API key.
+
+Reference the configuration from each deployment, then restart it so the sidecar picks up the change:
+
+```yaml
+annotations:
+  dapr.io/enabled: "true"
+  dapr.io/app-id: "myapp"
+  dapr.io/config: "appconfig"
+```
+
+## View traces
+
+Open your Elastic deployment and go to **Observability > APM > Traces**. Each Dapr application appears as a service named after its `dapr.io/app-id`.
+
+## Related links
+
+- [Dapr metrics with Elastic]({{% ref "elastic-metrics.md" %}})
+- [Dapr logs with Elastic]({{% ref "elastic-logs.md" %}})
+- [Elastic Distribution of OpenTelemetry Collector](https://www.elastic.co/docs/reference/opentelemetry/edot-collector)
+- [Elastic Agent in `otel` mode](https://www.elastic.co/docs/reference/fleet/otel-agent)


### PR DESCRIPTION
Thank you for helping make the Dapr documentation better!

**Please follow this checklist before submitting:**
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://docs.dapr.io/contributing/contributing-overview/#developer-certificate-of-origin-signing-your-work))
- [x] [Read the contribution guide](https://docs.dapr.io/contributing/docs-contrib/contributing-docs/)
- [x] Commands include options for Linux, MacOS, and Windows within tabpane
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have tabpane

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Adds Elastic how-tos to the three observability sections. Elastic currently appears only in the FluentD logging page, with nothing under `tracing/` or `metrics/`.

All three use the Elastic Distribution of OpenTelemetry Collector (EDOT), which is the Elastic Agent running in `otel` mode reading a standard collector configuration. One collector can carry all three signals, so the pages share a deployment shape and a single credentials secret, and cross-link to each other.



## Issue reference

Closes #5307
